### PR TITLE
[All] GitHub ラベルの色とコントリビューション関連のラベルを追加

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -31,13 +31,13 @@
 
 # Difficulty Labels
 - name: "difficulty/hard"
-  color: "#1C3F75"
+  color: "#800080"
   description: "Requires significant effort or expertise"
 - name: "difficulty/medium"
-  color: "#2980B9"
+  color: "#FFA500"
   description: "Moderately challenging; some effort required"
 - name: "difficulty/easy"
-  color: "#3498DB"
+  color: "#90EE90"
   description: "Simple to complete with minimal effort"
 
 # Dependabot Labels

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,6 +1,6 @@
 # Category Labels
 - name: "category/documentation"
-  color: "#0075CA"
+  color: "#A0AEC0"
   description: "Documentation related tasks"
 - name: "category/github"
   color: "#181717"

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -63,3 +63,11 @@
 - name: "team/infra"
   color: "#0969DA"
   description: "Owned by the infra team"
+
+# Contribution Labels
+- name: "contributions welcome"
+  color: "#0075CA"
+  description: "Open for contributions"
+- name: "good first issue"
+  color: "#7058E0"
+  description: "Good for newcomers"


### PR DESCRIPTION
## Issue

Closes #11

## 概要

GitHub ラベルの視認性を向上させ、コントリビューション関連のラベルを追加しました。

## 詳細

### ラベルの色変更

1. カテゴリーラベル
   - `category/documentation`: `#0075CA` → `#A0AEC0` (グレー)
     - `category/dependencies` との区別を明確にするため

2. 難易度ラベル
   - `difficulty/hard`: `#1C3F75` → `#800080` (紫)
   - `difficulty/medium`: `#2980B9` → `#FFA500` (オレンジ)
   - `difficulty/easy`: `#3498DB` → `#90EE90` (薄緑)
   - 難易度の違いをより直感的に表現するため、異なる色を使用

### コントリビューション関連のラベル追加

新しいセクション「Contribution Labels」を追加し、以下のラベルを定義：

1. `contributions welcome`
   - 色: `#0075CA` (青)
   - 説明: コントリビューションを歓迎する Issue を示す

2. `good first issue`
   - 色: `#7058E0` (紫)
   - 説明: 新規コントリビューターに適した Issue を示す