### PR TITLE
[All] CSpell 警告対応

### DIFF
--- a/apps/dashboard/lib/main.dart
+++ b/apps/dashboard/lib/main.dart
@@ -82,7 +82,7 @@ class _MyHomePageState extends State<MyHomePage> {
         // change color while the other colors stay the same.
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
+        // the App.build method, and use it to set our AppBar title.
         title: Text(widget.title),
       ),
       body: Center(

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -6,7 +6,11 @@
         "CODEOWNERS",
         "FlutterKaigi",
         "marocchino",
-        "Supabase"
+        "Supabase",
+        "xcassets",
+        "xcconfig",
+        "xcodeproj",
+        "xcworkspace"
     ],
     "ignorePaths": [
         "node_modules",
@@ -14,7 +18,13 @@
         "*.lock",
         ".editorconfig",
         ".tool-versions",
-        ".github/CODEOWNERS"
+        ".github/CODEOWNERS",
+        "Runner.xcodeproj",
+        "Runner.xcworkspace",
+        "*.xcconfig",
+        "*.xib",
+        "*.storyboard",
+        "*.plist"
     ],
     "import": [
         "@cspell/dict-software-terms/cspell-ext.json",

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -2,10 +2,13 @@
     "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
     "version": "0.2",
     "words": [
+        "allprojects",
         "bunx",
         "CODEOWNERS",
         "FlutterKaigi",
         "marocchino",
+        "Subproject",
+        "subprojects",
         "Supabase",
         "xcassets",
         "xcconfig",
@@ -24,7 +27,8 @@
         "*.xcconfig",
         "*.xib",
         "*.storyboard",
-        "*.plist"
+        "*.plist",
+        "*.properties"
     ],
     "import": [
         "@cspell/dict-software-terms/cspell-ext.json",

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -5,6 +5,7 @@
         "allprojects",
         "bunx",
         "CODEOWNERS",
+        "cupertino",
         "FlutterKaigi",
         "marocchino",
         "Subproject",


### PR DESCRIPTION
## Issue

Closes #26

## 概要

CSpell の警告を解消するために、以下の対応を行いました：
1. Xcode 関連ファイルを ignore リストに追加
2. Gradle 関連の単語を dictionary に追加
3. Flutter 関連の単語を dictionary に追加
4. `main.dart` の AppBar 表記を統一

## 詳細

### 1. Xcode 関連ファイル
以下のファイルを ignore リストに追加：
- `Runner.xcodeproj`
- `Runner.xcworkspace`
- `*.xcconfig`
- `*.xib`
- `*.storyboard`
- `*.plist`

### 2. Gradle 関連
以下の単語を dictionary に追加：
- `allprojects`
- `Subproject`
- `subprojects`

### 3. Flutter 関連
以下の単語を dictionary に追加：
- `cupertino`

### 4. コードの改善
- `main.dart` 内のコメントで `appbar` となっていた表記を `AppBar` に統一

## その他

今後も新しい単語や無視すべきファイルが出てきた場合は、適宜 `cspell.jsonc` を更新していく必要があります。