### PR TITLE
[infra] Supabaseのインスタンスを作成するTerraformを追加

### DIFF
--- a/.env.json
+++ b/.env.json
@@ -1,0 +1,18 @@
+{
+	"TF_VAR_SUPABASE_ACCESS_TOKEN": "ENC[AES256_GCM,data:PC/37hPpNfHYE1EAQhQJ8Q5M+tm8bDJGeuuceBizV3jhN5TynN6afkzSP9U=,iv:UAO5amhKRRF0amd7te+3Z54tNLMacKz8TiUvIeBwwx4=,tag:eSD1GOahIRNTNFPUKCPxSQ==,type:str]",
+	"TF_VAR_SUPABASE_ORGANIZATION_ID": "ENC[AES256_GCM,data:9i6Pmmd2FYhvJLSgG5ktm0hdafQ=,iv:TntHpNG++JlV/wZRsINFjc2wDlsTHNSkIGL7+sJ4zUs=,tag:uelP6MVpoZVGHrEegA9dZA==,type:str]",
+	"TF_VAR_SUPABASE_DB_PASSWORD_PRODUCTION": "ENC[AES256_GCM,data:UmYbMzng+Ymx6V+nR3QB5P5sbH2FjbwhREVcaI33SSI=,iv:TO0CpfmLQtKUPoLAtdGJ8mqSii4tNSOH+762jXWA4X8=,tag:s4xX0ZK8IwJQ/PHepFyDnw==,type:str]",
+	"TF_VAR_SUPABASE_DB_PASSWORD_STAGING": "ENC[AES256_GCM,data:XNT9h1lNIdtdSWZmg5tAXYT7Q5fEcHhESX8//zCutXU=,iv:Ul+WPXXLXK3qdDSiVAUvCaIr+Su30aiFwLhrprcmteM=,tag:aZzfOzaYcL2S7WqbEiJIaQ==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age1xjdqf6nct4pnztwtpsjdjf0n9776nc8kgqu8cymy9uww327f790qgpxwup",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSY3BaWVVXR1Nmc2VzZ1FR\nOWEvVVZkUjBLeHF4QWVlNzJ2UTZDK1NhVkFzCjFmdGFmakM4Wlp6ZUlsTUJ2RlR5\nQkpjZEZZNzlnWmVRaGhaaWJDcG1xNnMKLS0tIG5HS3hLUkpaNFliWWxxb2dGbXRs\nM3k0aGRoMDRETkhnWVNCQ0RjOXpFYzgKxfEtzq/FsXde5tuyOlErsjYy0CvmzRG/\nPqc+kFLKPD/Fgn0aJ7gmH4qnELlkxHZe8yNt9kqg3/vQR30PmCZlqA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-04-22T18:39:25Z",
+		"mac": "ENC[AES256_GCM,data:xtnT9oQahELuvGEN0aibC0j3yIoZR1M3fbRpPQwO/UKnv0aK7bHpsjnXqo6Xwx4jm+owRQfRMEFpvIV6rnhrif84FYxl3fyv+9S2LZJjTjwLTjC1H9RcMp7Nf+iUKy2u+qQKaD3HDdobT9c4PS80AzA0O/vmlzZofynJ9wyAMe8=,iv:Sz+xI/FDHYtOJxk877LGCLgggGb+OPBXqNYS5zrCZ9g=,tag:fQ7a+n79xYdHOI+sm+LAug==,type:str]",
+		"encrypted_regex": "^TF_VAR_",
+		"version": "3.10.1"
+	}
+}

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -10,13 +10,14 @@ on:
 jobs:
   apply:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     strategy:
       matrix:
-        directory:
-          - "terraform/supabase"
+        target:
+          - "supabase"
     defaults:
       run:
-        working-directory: ${{ matrix.directory }}
+        working-directory: terraform/${{ matrix.target }}
     steps:
       # https://github.com/actions/checkout
       - name: Checkout
@@ -32,11 +33,12 @@ jobs:
       - name: Extract SOPS secrets
         run: |
           mkdir -p ~/.config/mise
-          echo "${{ secrets.SOPS_FILE }}" >> ~/.config/mise/flutterkaigi.txt
+          echo "${{ secrets.SOPS_FILE }}" > ~/.config/mise/flutterkaigi.txt
 
-      - name: Terraform format
-        id: format
-        run: terraform fmt -check
+      - name: Extract backend.tfbackend
+        run: |
+          echo ${{ secrets.TERRAFORM_BACKEND_CONFIGURATION }} | base64 -d  \
+            > backend.tfbackend
 
       - name: Check directory is not empty
         run: |
@@ -44,35 +46,26 @@ jobs:
             echo "Directory is empty! Please add a Terraform file to the directory."
             exit 1
           fi
-
-      - name: Terraform Init
+      - name: Terraform init
         id: init
         run: terraform init
 
-      - name: Terraform Plan
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check
+
+      - name: Terraform validate
+        id: validate
+        run: terraform validate
+
+      - name: Terraform plan
         id: plan
-        run: terraform plan -no-color
-        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: tfcmt plan -patch -var "target:${{ matrix.target }}" -- terraform plan -input=false
 
-      - name: Comment PR
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const output = `#### Terraform Format 🖌\`${{ steps.format.outputs.stdout }}\`
-            #### Terraform Initialization ⚙️\`${{ steps.init.outputs.stdout }}\`
-            #### Terraform Plan 📖\`${{ steps.plan.outputs.stdout }}\`
-
-            <details>
-            <summary>Terraform Apply</summary>
-            \`\`\`
-            ${steps.apply.outputs.stdout}
-            \`\`\`
-            </details>
-            `;
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `## Terraform checks in directory '${{ matrix.directory }}'\n` + output
-            })
+      - name: Terraform apply
+        id: apply
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: tfcmt apply -patch -var "target:${{ matrix.target }}" -- terraform apply --auto-approve

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -22,10 +22,9 @@ jobs:
         id: define-matrix
         run: |
           # `terraform/`配下のディレクトリを取得
-          target=$(find terraform -maxdepth 1 -type d |  \
-            sed 's|^terraform/||' | \
-            jq -R -s 'split("\n")[:-1]')
-          echo "targets=$(jq -c -n '$ARGS.positional' --args "${target[@]}")" >> $GITHUB_OUTPUT
+          dirs=$(find terraform -maxdepth 1 -type d | grep -v "^terraform$" | sed 's|^terraform/||')
+          targets=$(echo "$dirs" | jq -R . | jq -s .)
+          echo "targets=$targets" >> $GITHUB_OUTPUT
 
   lint:
     name: Terraform Lint (${{ matrix.target }})

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -23,8 +23,8 @@ jobs:
         run: |
           # `terraform/`配下のディレクトリを取得
           dirs=$(find terraform -maxdepth 1 -type d | grep -v "^terraform$" | sed 's|^terraform/||')
-          targets=$(echo "$dirs" | jq -R . | jq -s .)
-          echo "targets=$targets" >> $GITHUB_OUTPUT
+          targets=$(echo "$dirs" | jq -R . | jq -sc .)
+          echo "targets=${targets}" >> $GITHUB_OUTPUT
 
   lint:
     name: Terraform Lint (${{ matrix.target }})

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -46,9 +46,10 @@ jobs:
             echo "Directory is empty! Please add a Terraform file to the directory."
             exit 1
           fi
+
       - name: Terraform init
         id: init
-        run: terraform init
+        run: terraform init -backend-config=backend.tfbackend
 
       - name: Terraform fmt
         id: fmt

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -8,13 +8,79 @@ on:
       - "terraform/**/*.tf"
 
 jobs:
-  apply:
+  define-matrix:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 1
+    outputs:
+      targets: ${{ steps.define-matrix.outputs.targets }}
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Define matrix
+        id: define-matrix
+        run: |
+          # `terraform/`配下のディレクトリを取得
+          target=$(find terraform -maxdepth 1 -type d |  \
+            sed 's|^terraform/||' | \
+            jq -R -s 'split("\n")[:-1]')
+          echo "targets=$(jq -c -n '$ARGS.positional' --args "${target[@]}")" >> $GITHUB_OUTPUT
+
+  lint:
+    name: Terraform Lint (${{ matrix.target }})
+    needs:
+      - define-matrix
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     strategy:
       matrix:
-        target:
-          - "supabase"
+        target: ${{ fromJson(needs.define-matrix.outputs.targets) }}
+    defaults:
+      run:
+        working-directory: terraform/${{ matrix.target }}
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # https://github.com/jdx/mise-action
+      - name: Install Mise dependencies
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
+        with:
+          install: true
+          install_args: "terraform tflint aqua:suzuki-shunsuke/tfcmt"
+
+      - name: Extract SOPS secrets
+        run: |
+          mkdir -p ~/.config/mise
+          echo "${{ secrets.SOPS_FILE }}" > ~/.config/mise/flutterkaigi.txt
+
+      - name: Extract backend.tfbackend
+        run: |
+          echo "${{ secrets.TERRAFORM_BACKEND_CONFIGURATION }}" | base64 -d  \
+            > backend.tfbackend
+
+      - name: Check directory is not empty
+        run: |
+          if [ -z "$(ls -A)" ]; then
+            echo "Directory is empty! Please add a Terraform file to the directory."
+            exit 1
+          fi
+
+      - name: Terraform init
+        id: init
+        run: terraform init -backend-config=backend.tfbackend
+
+  apply:
+    name: Terraform Apply (${{ matrix.target }})
+    needs:
+      - define-matrix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.define-matrix.outputs.targets) }}
     defaults:
       run:
         working-directory: terraform/${{ matrix.target }}

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -1,0 +1,78 @@
+name: Terraform Apply
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "terraform/**/*.tf"
+
+jobs:
+  apply:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        directory:
+          - "terraform/supabase"
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # https://github.com/jdx/mise-action
+      - name: Install Mise dependencies
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
+        with:
+          install: true
+          install_args: "terraform"
+
+      - name: Extract SOPS secrets
+        run: |
+          mkdir -p ~/.config/mise
+          echo "${{ secrets.SOPS_FILE }}" >> ~/.config/mise/flutterkaigi.txt
+
+      - name: Terraform format
+        id: format
+        run: terraform fmt -check
+
+      - name: Check directory is not empty
+        run: |
+          if [ -z "$(ls -A)" ]; then
+            echo "Directory is empty! Please add a Terraform file to the directory."
+            exit 1
+          fi
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color
+        continue-on-error: true
+
+      - name: Comment PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format 🖌\`${{ steps.format.outputs.stdout }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outputs.stdout }}\`
+            #### Terraform Plan 📖\`${{ steps.plan.outputs.stdout }}\`
+
+            <details>
+            <summary>Terraform Apply</summary>
+            \`\`\`
+            ${steps.apply.outputs.stdout}
+            \`\`\`
+            </details>
+            `;
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Terraform checks in directory '${{ matrix.directory }}'\n` + output
+            })

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -28,8 +28,8 @@ jobs:
         run: |
           # `terraform/`配下のディレクトリを取得
           dirs=$(find terraform -maxdepth 1 -type d | grep -v "^terraform$" | sed 's|^terraform/||')
-          targets=$(echo "$dirs" | jq -R . | jq -s .)
-          echo "targets=$targets" >> $GITHUB_OUTPUT
+          targets=$(echo "$dirs" | jq -R . | jq -sc .)
+          echo "targets=${targets}" >> $GITHUB_OUTPUT
 
   lint:
     name: Terraform Lint (${{ matrix.target }})

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -1,0 +1,82 @@
+name: Terraform Plan
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "terraform/**/*.tf"
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        directory:
+          - "terraform/supabase"
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # https://github.com/jdx/mise-action
+      - name: Install Mise dependencies
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
+        with:
+          install: true
+          install_args: "terraform"
+
+      - name: Extract SOPS secrets
+        run: |
+          mkdir -p ~/.config/mise
+          echo "${{ secrets.SOPS_FILE }}" >> ~/.config/mise/flutterkaigi.txt
+
+      - name: Terraform format
+        id: format
+        run: terraform fmt -check
+
+      - name: Check directory is not empty
+        run: |
+          if [ -z "$(ls -A)" ]; then
+            echo "Directory is empty! Please add a Terraform file to the directory."
+            exit 1
+          fi
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color
+        continue-on-error: true
+
+      - name: Comment PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format 🖌\`${{ steps.format.outputs.stdout }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outputs.stdout }}\`
+            #### Terraform Plan 📖\`${{ steps.plan.outputs.stdout }}\`
+
+            <details>
+            <summary>Terraform Plan</summary>
+            \`\`\`
+            ${steps.plan.outputs.stdout}
+            \`\`\`
+            </details>
+            `;
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Terraform checks in directory '${{ matrix.directory }}'\n` + output
+            })

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -13,13 +13,14 @@ on:
 jobs:
   plan:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     strategy:
       matrix:
-        directory:
-          - "terraform/supabase"
+        target:
+          - "supabase"
     defaults:
       run:
-        working-directory: ${{ matrix.directory }}
+        working-directory: terraform/${{ matrix.target }}
     steps:
       # https://github.com/actions/checkout
       - name: Checkout
@@ -35,7 +36,12 @@ jobs:
       - name: Extract SOPS secrets
         run: |
           mkdir -p ~/.config/mise
-          echo "${{ secrets.SOPS_FILE }}" >> ~/.config/mise/flutterkaigi.txt
+          echo "${{ secrets.SOPS_FILE }}" > ~/.config/mise/flutterkaigi.txt
+
+      - name: Extract backend.tfbackend
+        run: |
+          echo ${{ secrets.TERRAFORM_BACKEND_CONFIGURATION }} | base64 -d  \
+            > backend.tfbackend
 
       - name: Check directory is not empty
         run: |
@@ -59,4 +65,4 @@ jobs:
         id: plan
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: tfcmt plan -patch -- terraform plan -input=false
+        run: tfcmt plan -patch -var "target:${{ matrix.target }}" -- terraform plan -input=false

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -10,14 +10,84 @@ on:
       - opened
       - synchronize
 
+
+
 jobs:
-  plan:
+  define-matrix:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 1
+    outputs:
+      targets: ${{ steps.define-matrix.outputs.targets }}
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Define matrix
+        id: define-matrix
+        run: |
+          # `terraform/`配下のディレクトリを取得
+          target=$(find terraform -maxdepth 1 -type d |  \
+            sed 's|^terraform/||' | \
+            jq -R -s 'split("\n")[:-1]')
+          echo "targets=$(jq -c -n '$ARGS.positional' --args "${target[@]}")" >> $GITHUB_OUTPUT
+
+  lint:
+    name: Terraform Lint (${{ matrix.target }})
+    needs:
+      - define-matrix
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     strategy:
       matrix:
-        target:
-          - "supabase"
+        target: ${{ fromJson(needs.define-matrix.outputs.targets) }}
+    defaults:
+      run:
+        working-directory: terraform/${{ matrix.target }}
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # https://github.com/jdx/mise-action
+      - name: Install Mise dependencies
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
+        with:
+          install: true
+          install_args: "terraform tflint aqua:suzuki-shunsuke/tfcmt"
+
+      - name: Extract SOPS secrets
+        run: |
+          mkdir -p ~/.config/mise
+          echo "${{ secrets.SOPS_FILE }}" > ~/.config/mise/flutterkaigi.txt
+
+      - name: Extract backend.tfbackend
+        run: |
+          echo "${{ secrets.TERRAFORM_BACKEND_CONFIGURATION }}" | base64 -d  \
+            > backend.tfbackend
+
+      - name: Check directory is not empty
+        run: |
+          if [ -z "$(ls -A)" ]; then
+            echo "Directory is empty! Please add a Terraform file to the directory."
+            exit 1
+          fi
+
+      - name: Terraform init
+        id: init
+        run: terraform init -backend-config=backend.tfbackend
+
+
+  plan:
+    name: Terraform Plan (${{ matrix.target }})
+    needs:
+      - lint
+      - define-matrix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.define-matrix.outputs.targets) }}
     defaults:
       run:
         working-directory: terraform/${{ matrix.target }}

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Extract backend.tfbackend
         run: |
-          echo ${{ secrets.TERRAFORM_BACKEND_CONFIGURATION }} | base64 -d  \
+          echo "${{ secrets.TERRAFORM_BACKEND_CONFIGURATION }}" | base64 -d  \
             > backend.tfbackend
 
       - name: Check directory is not empty

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -49,9 +49,10 @@ jobs:
             echo "Directory is empty! Please add a Terraform file to the directory."
             exit 1
           fi
+
       - name: Terraform init
         id: init
-        run: terraform init
+        run: terraform init -backend-config=backend.tfbackend
 
       - name: Terraform fmt
         id: fmt

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -30,16 +30,12 @@ jobs:
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           install: true
-          install_args: "terraform"
+          install_args: "terraform tflint aqua:suzuki-shunsuke/tfcmt"
 
       - name: Extract SOPS secrets
         run: |
           mkdir -p ~/.config/mise
           echo "${{ secrets.SOPS_FILE }}" >> ~/.config/mise/flutterkaigi.txt
-
-      - name: Terraform format
-        id: format
-        run: terraform fmt -check
 
       - name: Check directory is not empty
         run: |
@@ -47,36 +43,20 @@ jobs:
             echo "Directory is empty! Please add a Terraform file to the directory."
             exit 1
           fi
-
-      - name: Terraform Init
+      - name: Terraform init
         id: init
         run: terraform init
 
-      - name: Terraform Plan
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check
+
+      - name: Terraform validate
+        id: validate
+        run: terraform validate
+
+      - name: Terraform plan
         id: plan
-        run: terraform plan -no-color
-        continue-on-error: true
-
-      - name: Comment PR
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const output = `#### Terraform Format 🖌\`${{ steps.format.outputs.stdout }}\`
-            #### Terraform Initialization ⚙️\`${{ steps.init.outputs.stdout }}\`
-            #### Terraform Plan 📖\`${{ steps.plan.outputs.stdout }}\`
-
-            <details>
-            <summary>Terraform Plan</summary>
-            \`\`\`
-            ${steps.plan.outputs.stdout}
-            \`\`\`
-            </details>
-            `;
-
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `## Terraform checks in directory '${{ matrix.directory }}'\n` + output
-            })
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: tfcmt plan -patch -- terraform plan -input=false

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -76,6 +76,12 @@ jobs:
         id: init
         run: terraform init -backend-config=backend.tfbackend
 
+      - name: Terraform fmt
+        run: terraform fmt -check
+
+      - name: TFLint
+        run: tflint
+
 
   plan:
     name: Terraform Plan (${{ matrix.target }})

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -27,10 +27,9 @@ jobs:
         id: define-matrix
         run: |
           # `terraform/`配下のディレクトリを取得
-          target=$(find terraform -maxdepth 1 -type d |  \
-            sed 's|^terraform/||' | \
-            jq -R -s 'split("\n")[:-1]')
-          echo "targets=$(jq -c -n '$ARGS.positional' --args "${target[@]}")" >> $GITHUB_OUTPUT
+          dirs=$(find terraform -maxdepth 1 -type d | grep -v "^terraform$" | sed 's|^terraform/||')
+          targets=$(echo "$dirs" | jq -R . | jq -s .)
+          echo "targets=$targets" >> $GITHUB_OUTPUT
 
   lint:
     name: Terraform Lint (${{ matrix.target }})

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,3 @@ node_modules/
 
 # macOS
 .DS_Store
-
-# Environment Values
-.env
-!.env.example

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ node_modules/
 
 # macOS
 .DS_Store
+
+# Environment Values
+.env
+!.env.example

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - encrypted_regex: "^TF_VAR_"
+  - age: age1xjdqf6nct4pnztwtpsjdjf0n9776nc8kgqu8cymy9uww327f790qgpxwup

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,5 @@ bun     1.2.10
 flutter 3.29.3-stable
 nodejs  22.14.0
 terraform  1.11.4
+tflint  0.56.0
+aqua:suzuki-shunsuke/tfcmt  4.14.5

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 bun     1.2.10
 flutter 3.29.3-stable
 nodejs  22.14.0
+terraform  1.11.4

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[env]
+'_'.file.path = ".env.json"
+
+[settings.sops]
+age_key_file = "~/.config/mise/flutterkaigi.txt"

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,27 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used for local dev
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore lock files
+.terraform.lock.hcl

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -25,3 +25,5 @@ terraform.rc
 
 # Ignore lock files
 .terraform.lock.hcl
+
+backend.tfbackend

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -4,15 +4,9 @@
 
 ## 環境変数と秘密情報
 
-このプロジェクトでは機密情報を安全に管理するために[SOPS](https://github.com/mozilla/sops)を使用しています。秘密情報は`.sops.yaml`の設定に従って暗号化されます。
+このプロジェクトでは機密情報を安全に管理するために[SOPS]を使用しています。秘密情報は`.sops.yaml`の設定に従って暗号化されます。
 
-```yaml
-creation_rules:
-  - encrypted_regex: "^TF_VAR_"
-  - age: age1xjdqf6nct4pnztwtpsjdjf0n9776nc8kgqu8cymy9uww327f790qgpxwup
-```
-
-また、`mise.toml`で設定されているように、秘密鍵ファイルは以下の場所に保存されています：
+また、`mise.toml`で設定されているように、秘密鍵ファイルは以下の場所に保存してください。ファイルを配置することで、miseによりSOPSの秘密鍵が自動で読み込まれ、復号された状態で環境変数に設定されます。
 
 ```yaml
 [settings.sops]

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,30 @@
+# FlutterKaigi 2025 Terraform
+
+このディレクトリには、FlutterKaigi 2025プロジェクトで使用するインフラをTerraformで管理するためのコードが含まれています。
+
+## 環境変数と秘密情報
+
+このプロジェクトでは機密情報を安全に管理するために[SOPS](https://github.com/mozilla/sops)を使用しています。秘密情報は`.sops.yaml`の設定に従って暗号化されます。
+
+```yaml
+creation_rules:
+  - encrypted_regex: "^TF_VAR_"
+  - age: age1xjdqf6nct4pnztwtpsjdjf0n9776nc8kgqu8cymy9uww327f790qgpxwup
+```
+
+また、`mise.toml`で設定されているように、秘密鍵ファイルは以下の場所に保存されています：
+
+```yaml
+[settings.sops]
+age_key_file = "~/.config/mise/flutterkaigi.txt"
+```
+
+## 使い方
+
+1. 管理者から`flutterkaigi.txt`を取得して`~/.config/mise/`に配置してください
+
+- SOPSの秘密鍵が含まれています
+
+1. `terraform init`でTerraformを初期化
+1. `terraform plan`で変更内容を確認
+1. `terraform apply`で変更を適用 (※ 通常GitHub Actionsから実行すること)

--- a/terraform/supabase/README.md
+++ b/terraform/supabase/README.md
@@ -1,0 +1,19 @@
+# FlutterKaigi 2025 Supabase Terraform
+
+このディレクトリには、FlutterKaigi 2025プロジェクトで使用するSupabase環境をTerraformで管理するためのコードが含まれています。
+
+## 概要
+
+このTerraformコードは、Supabaseプロジェクトを以下の環境で管理します：
+
+- **Production環境**: `flutterkaigi-2025-production`
+- **Staging環境**: `flutterkaigi-2025-staging`
+
+両環境とも東京リージョン（ap-northeast-1）にデプロイされます。
+
+## ファイル構成
+
+- `production.tf`: 本番環境のSupabaseプロジェクト設定
+- `staging.tf`: ステージング環境のSupabaseプロジェクト設定
+- `provider.tf`: Supabase Terraformプロバイダーの設定
+- `variables.tf`: 変数定義ファイル

--- a/terraform/supabase/backend.tf
+++ b/terraform/supabase/backend.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "s3" {
+    bucket                      = "tf-state"
+    key                         = "flutterkaigi-2025-supabase.tfstate"
+    region                      = "auto"
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints                   = { s3 = "https://cdd8f59359fe226645e7b541cdc53b57.r2.cloudflarestorage.com" }
+  }
+}

--- a/terraform/supabase/production.tf
+++ b/terraform/supabase/production.tf
@@ -1,0 +1,34 @@
+resource "supabase_project" "production" {
+  organization_id   = var.SUPABASE_ORGANIZATION_ID
+  name              = "flutterkaigi-2025-production"
+  database_password = var.SUPABASE_DB_PASSWORD_PRODUCTION
+  region            = "ap-northeast-1"
+
+  lifecycle {
+    ignore_changes = [database_password]
+  }
+}
+
+data "supabase_apikeys" "production" {
+  project_ref = supabase_project.production.id
+}
+
+output "production_anon_key" {
+  value     = data.supabase_apikeys.production.anon_key
+  sensitive = true
+}
+
+output "production_service_role_key" {
+  value     = data.supabase_apikeys.production.service_role_key
+  sensitive = true
+}
+
+resource "supabase_settings" "production" {
+  project_ref = supabase_project.production.id
+
+  api = jsonencode({
+    db_schema            = "public,storage,graphql_public"
+    db_extra_search_path = "public,extensions"
+    max_rows             = 1000
+  })
+}

--- a/terraform/supabase/provider.tf
+++ b/terraform/supabase/provider.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = "1.11.4"
   required_providers {
     # https://registry.terraform.io/providers/supabase/supabase/latest
     supabase = {

--- a/terraform/supabase/provider.tf
+++ b/terraform/supabase/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    # https://registry.terraform.io/providers/supabase/supabase/latest
+    supabase = {
+      source  = "supabase/supabase"
+      version = "1.5.1"
+    }
+  }
+}
+
+provider "supabase" {
+  access_token = var.SUPABASE_ACCESS_TOKEN
+}

--- a/terraform/supabase/staging.tf
+++ b/terraform/supabase/staging.tf
@@ -1,0 +1,34 @@
+resource "supabase_project" "staging" {
+  organization_id   = var.SUPABASE_ORGANIZATION_ID
+  name              = "flutterkaigi-2025-staging"
+  database_password = var.SUPABASE_DB_PASSWORD_STAGING
+  region            = "ap-northeast-1"
+
+  lifecycle {
+    ignore_changes = [database_password]
+  }
+}
+
+data "supabase_apikeys" "staging" {
+  project_ref = supabase_project.staging.id
+}
+
+output "staging_anon_key" {
+  value     = data.supabase_apikeys.staging.anon_key
+  sensitive = true
+}
+
+output "staging_service_role_key" {
+  value     = data.supabase_apikeys.staging.service_role_key
+  sensitive = true
+}
+
+resource "supabase_settings" "staging" {
+  project_ref = supabase_project.staging.id
+
+  api = jsonencode({
+    db_schema            = "public,storage,graphql_public"
+    db_extra_search_path = "public,extensions"
+    max_rows             = 1000
+  })
+}

--- a/terraform/supabase/variables.tf
+++ b/terraform/supabase/variables.tf
@@ -1,0 +1,22 @@
+variable "SUPABASE_ACCESS_TOKEN" {
+  type        = string
+  description = "Supabase Access Token"
+  sensitive   = true
+}
+
+variable "SUPABASE_ORGANIZATION_ID" {
+  type        = string
+  description = "Supabase Organization ID"
+}
+
+variable "SUPABASE_DB_PASSWORD_PRODUCTION" {
+  type        = string
+  description = "Production Database Password"
+  sensitive   = true
+}
+
+variable "SUPABASE_DB_PASSWORD_STAGING" {
+  type        = string
+  description = "Staging Database Password"
+  sensitive   = true
+}


### PR DESCRIPTION
## Issue

- Closes #2

## 概要

- Terraformの準備
  - miseにTerraform, TFLint, tfcmtを追加
    - TFLint, tfcmtはCIで利用
  - `.env.json`を作成し、[SOPS]で暗号化した状態でコミット 	
  - CI/CDの構築
    - PR作成時: TFLint, Terraform Plan
    - mainへpush時: Terraform Apply
- supabaseのインスタンス作成
  - `flutterkaigi-2025-production` `flutterkaigi-2025-staging`
  - 中のスキーマは追って作成していきます


## 詳細

- [SOPS](https://github.com/getsops/sops)を利用して、`.env.json`を暗号化するようにしました
  - `TF_VAR`から始まる値は、環境変数にセットされた後に TerraformのVariableとして使われます
  - SOPSを利用して、暗号化されたものをコミットすることで.envをバージョン管理することができるようになりました
- 

## その他

- ローカルで、Terraform applyが正常に動作することは確認しました
  - Terraform Destroyしておきました
- CD環境で正常に動作するかどうかは未検証です 