### PR TITLE
[Infra] Terraformワークフローを手動実行できるように変更

### DIFF
--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -6,6 +6,13 @@ on:
       - main
     paths:
       - "terraform/**/*.tf"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Terraformを実行するtarget (terraform/配下のディレクトリ名をカンマ区切りで指定)"
+        required: true
+        type: string
+        default: "supabase"
 
 jobs:
   define-matrix:
@@ -21,8 +28,25 @@ jobs:
       - name: Define matrix
         id: define-matrix
         run: |
-          # `terraform/`配下のディレクトリを取得
-          dirs=$(find terraform -maxdepth 1 -type d | grep -v "^terraform$" | sed 's|^terraform/||')
+          # workflow_dispatchのinputsを取得
+          if [ -n "${{ inputs.target }}" ]; then
+            # カンマで区切る
+            dirs=$(echo "${{ inputs.target }}" | tr ',' '\n')
+            # 存在しないディレクトリが指定された場合はエラー
+            for dir in $dirs; do
+              if [ -d "terraform/${dir}" ]; then
+                targets="${targets} ${dir}"
+              else
+                echo "terraform/${dir} is not found"
+                exit 1
+              fi
+            done
+          else
+            # `terraform/`配下のディレクトリを取得
+            dirs=$(find terraform -maxdepth 1 -type d | grep -v "^terraform$" | sed 's|^terraform/||')
+          fi
+
+          # JSONの配列に変換し、outputsに設定
           targets=$(echo "$dirs" | jq -R . | jq -sc .)
           echo "targets=${targets}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -9,8 +9,13 @@ on:
     types:
       - opened
       - synchronize
-
-
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Terraformを実行するtarget (terraform/配下のディレクトリ名をカンマ区切りで指定)"
+        required: true
+        type: string
+        default: "supabase"
 
 jobs:
   define-matrix:
@@ -26,8 +31,25 @@ jobs:
       - name: Define matrix
         id: define-matrix
         run: |
-          # `terraform/`配下のディレクトリを取得
-          dirs=$(find terraform -maxdepth 1 -type d | grep -v "^terraform$" | sed 's|^terraform/||')
+          # workflow_dispatchのinputsを取得
+          if [ -n "${{ inputs.target }}" ]; then
+            # カンマで区切る
+            dirs=$(echo "${{ inputs.target }}" | tr ',' '\n')
+            # 存在しないディレクトリが指定された場合はエラー
+            for dir in $dirs; do
+              if [ -d "terraform/${dir}" ]; then
+                targets="${targets} ${dir}"
+              else
+                echo "terraform/${dir} is not found"
+                exit 1
+              fi
+            done
+          else
+            # `terraform/`配下のディレクトリを取得
+            dirs=$(find terraform -maxdepth 1 -type d | grep -v "^terraform$" | sed 's|^terraform/||')
+          fi
+
+          # JSONの配列に変換し、outputsに設定
           targets=$(echo "$dirs" | jq -R . | jq -sc .)
           echo "targets=${targets}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## 概要

- Terraform lint, applyをGitHub Actionsから実行したい
  - しかし、`terraform/**/*.tf`に変更が無い場合は実行できなかった
  - 基本的には変更が無い場合は実行する必要がないが、エラー等で手動実行したいケースがある
	- 環境変数をいじった時も考えうる
  - 手動実行できるようにします
    - 実行するtarget(`terraform/{target}`ディレクトリ)を入力できるようにしました
    - 現状は、`supabase`しかないですが 今後`cloudflare`, `firebase`が増えると思います 	
