### PR TITLE
[All] check-spell ワークフローの bun セットアップを mise に移行

### DIFF
--- a/.github/workflows/check-spell.yaml
+++ b/.github/workflows/check-spell.yaml
@@ -7,14 +7,19 @@ jobs:
   check-spell:
     runs-on: ubuntu-24.04
     steps:
+      # https://github.com/actions/checkout
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # https://github.com/jdx/mise-action
       - name: Install Mise dependencies
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
           install: true
           install_args: "bun"
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
       - name: Run spell check
         run: bunx cspell .

--- a/.github/workflows/check-spell.yaml
+++ b/.github/workflows/check-spell.yaml
@@ -15,7 +15,6 @@ jobs:
       - name: Install Mise dependencies
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          install: true
           install_args: "bun"
 
       - name: Install dependencies

--- a/.github/workflows/check-spell.yaml
+++ b/.github/workflows/check-spell.yaml
@@ -9,13 +9,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Read .tool-versions
-        uses: marocchino/tool-versions-action@18a164fa2b0db1cc1edf7305fcb17ace36d1c306 # v1.2.0
-        id: versions
-      - name: Setup bun
-        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+      - name: Install Mise dependencies
+        uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          bun-version: ${{ steps.versions.outputs.bun }}
+          install: true
+          install_args: "bun"
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Run spell check

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -73,7 +73,6 @@ jobs:
       - name: Install Mise dependencies
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          install: true
           install_args: "terraform tflint"
 
       - name: Extract SOPS secrets
@@ -129,7 +128,6 @@ jobs:
       - name: Install Mise dependencies
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          install: true
           install_args: "terraform aqua:suzuki-shunsuke/tfcmt"
 
       - name: Extract SOPS secrets

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -76,7 +76,6 @@ jobs:
       - name: Install Mise dependencies
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          install: true
           install_args: "terraform tflint aqua:suzuki-shunsuke/tfcmt"
 
       - name: Extract SOPS secrets
@@ -131,7 +130,6 @@ jobs:
       - name: Install Mise dependencies
         uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.1.11
         with:
-          install: true
           install_args: "terraform tflint aqua:suzuki-shunsuke/tfcmt"
 
       - name: Extract SOPS secrets


### PR DESCRIPTION
## Issue

Closes #35

## 概要

check-spell ワークフローの bun セットアップを `.tool-versions` と `setup-bun` から `mise` に移行し、他のワークフローの mise-action の設定も最適化しました。

## 詳細

以下の変更を行いました：

1. `check-spell.yaml` のツール管理を `.tool-versions` から `mise` に移行
   - `tool-versions-action` の使用を廃止
   - `setup-bun` の代わりに `mise-action` を使用
   - Bunのバージョン管理を mise に統一

2. 各ワークフローファイルの `mise-action` の設定を最適化
   - 不要な `install: true` パラメータを削除
   - インストール設定をシンプル化

これらの変更により：
- ツール管理の一貫性が向上
- ワークフローの設定がよりシンプルに
- メンテナンス性の向上

## 画像・動画

<!-- 見た目の変更はないため、画像は不要です -->

## その他

- この変更は GitHub Actions のワークフローの実行に影響を与えますが、機能的な変更はありません
- すべてのワークフローで mise を使用することで、ツールのバージョン管理がより統一的になります