### PR TITLE
[All] CSpell の設定改善

### DIFF
--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -1,6 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
     "version": "0.2",
+    "useGitignore": true,
     "words": [
         "allprojects",
         "bunx",

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -19,6 +19,7 @@
         "tfbackend"
     ],
     "ignorePaths": [
+        "cspell.jsonc",
         "*.lock",
         ".editorconfig",
         ".tool-versions",

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -30,7 +30,6 @@
             "name": "github-action-term",
             "description": "GitHub Actions related terms",
             "words": [
-                "marocchino",
                 "stefanbuck",
                 "ghaction"
             ]

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -30,7 +30,9 @@
             "name": "github-action-term",
             "description": "GitHub Actions related terms",
             "words": [
-                "marocchino"
+                "marocchino",
+                "stefanbuck",
+                "ghaction"
             ]
         },
         {
@@ -59,7 +61,10 @@
             "name": "terraform-term",
             "description": "Terraform related terms",
             "words": [
-                "tfbackend"
+                "tfbackend",
+                "tflint",
+                "shunsuke",
+                "tfcmt"
             ]
         }
     ],

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -80,9 +80,6 @@
     "ignorePaths": [
         "cspell.jsonc",
         "*.lock",
-        ".editorconfig",
-        ".tool-versions",
-        ".github/CODEOWNERS",
         "Runner.xcodeproj",
         "Runner.xcworkspace",
         "*.xcconfig",

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -19,8 +19,6 @@
         "tfbackend"
     ],
     "ignorePaths": [
-        "node_modules",
-        ".dart_tool",
         "*.lock",
         ".editorconfig",
         ".tool-versions",

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -5,7 +5,6 @@
     "words": [
         "allprojects",
         "bunx",
-        "CODEOWNERS",
         "cupertino",
         "FlutterKaigi",
         "marocchino",
@@ -13,8 +12,6 @@
         "subprojects",
         "Supabase",
         "xcassets",
-        "xcconfig",
-        "xcodeproj",
         "xcworkspace",
         "tfbackend"
     ],

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -2,18 +2,76 @@
     "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
     "version": "0.2",
     "useGitignore": true,
-    "words": [
-        "allprojects",
-        "bunx",
-        "cupertino",
-        "FlutterKaigi",
-        "marocchino",
-        "Subproject",
-        "subprojects",
-        "Supabase",
-        "xcassets",
-        "xcworkspace",
-        "tfbackend"
+    "dictionaryDefinitions": [
+        {
+            "name": "android-term",
+            "description": "Android related terms",
+            "words": [
+                "allprojects",
+                "Subproject",
+                "subprojects"
+            ]
+        },
+        {
+            "name": "bun-term",
+            "description": "Bun related terms",
+            "words": [
+                "bunx"
+            ]
+        },
+        {
+            "name": "flutter-term",
+            "description": "Flutter related terms",
+            "words": [
+                "cupertino"
+            ]
+        },
+        {
+            "name": "github-action-term",
+            "description": "GitHub Actions related terms",
+            "words": [
+                "marocchino"
+            ]
+        },
+        {
+            "name": "ios-term",
+            "description": "iOS related terms",
+            "words": [
+                "xcassets",
+                "xcworkspace"
+            ]
+        },
+        {
+            "name": "project-term",
+            "description": "Project specific terms",
+            "words": [
+                "FlutterKaigi"
+            ]
+        },
+        {
+            "name": "supabase-term",
+            "description": "Supabase related terms",
+            "words": [
+                "Supabase"
+            ]
+        },
+        {
+            "name": "terraform-term",
+            "description": "Terraform related terms",
+            "words": [
+                "tfbackend"
+            ]
+        }
+    ],
+    "dictionaries": [
+        "android-term",
+        "bun-term",
+        "flutter-term",
+        "github-action-term",
+        "ios-term",
+        "project-term",
+        "supabase-term",
+        "terraform-term"
     ],
     "ignorePaths": [
         "cspell.jsonc",


### PR DESCRIPTION
## Issue

Closes #40

## 概要

cspell の設定を全体的に見直し、より効率的で管理しやすい形式に改善しました。

## 詳細

### 辞書の整理と分類
- 既存の `words` をカテゴリごとに分類し、`dictionaryDefinitions` として再定義：
  - android-term
  - bun-term
  - flutter-term
  - github-action-term
  - ios-term
  - project-term
  - supabase-term
  - terraform-term

### Git 関連の設定改善
- `useGitignore: true` を追加し、.gitignore に記載されているファイルを自動的にスペルチェック対象から除外するように設定

### ignorePaths の最適化
- 不要な設定を削除：
  - `node_modules`（.gitignore でカバー）
  - `.dart_tool`（.gitignore でカバー）
  - `.editorconfig`
  - `.tool-versions`
  - `.github/CODEOWNERS`
- `cspell.jsonc` を追加（設定ファイル自体はチェック不要）

### 用語の追加と更新
- Terraform 関連の用語を追加：
  - tflint
  - shunsuke
  - tfcmt
- GitHub Actions 関連の用語を追加：
  - stefanbuck
  - ghaction

## その他

- 各辞書には description を追加し、どのような用語が含まれているかを明確にしました
- 今後新しい用語を追加する際は、適切な辞書に分類して追加することで、より管理がしやすくなります
- .gitignore との連携により、重複した除外設定を削減し、メンテナンスコストを低減しました