### PR TITLE
ci: 参画時用のスクリプトを追加

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -11,3 +11,10 @@ tflint = "0.56.0"
 description = "Initialize the workspace."
 run = './tools/bootstrap.sh'
 alias = "bs"
+
+[tasks.clean]
+description = "Clean this workspace."
+run = [
+  'bun run clean',
+  'melos clean',
+]

--- a/mise.toml
+++ b/mise.toml
@@ -6,3 +6,8 @@ flutter = "3.29.3-stable"
 node = "22.14.0"
 terraform = "1.11.4"
 tflint = "0.56.0"
+
+[tasks.bootstrap]
+description = "Initialize the workspace."
+run = './tools/bootstrap.sh'
+alias = "bs"

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# ---- Rich Output Setup ----
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+step=1
+START_TIME=$(date +%s)
+
+print_step() {
+  echo -e "${BLUE}Step $((step++)): $1${NC}"
+}
+
+print_result() {
+  local code=$1; shift
+  if [ $code -eq 0 ]; then
+    echo -e "${GREEN}[✔] $*${NC}"
+  else
+    echo -e "${RED}[✖] $* (exit ${code})${NC}"
+  fi
+}
+
+trap 'echo -e "${RED}[✖] Aborted at step ${step}${NC}"; exit 1' ERR INT
+
+# Move to project root
+cd "$(dirname "$0")/../" || { echo -e "${RED}[✖] Failed to cd to project root${NC}"; exit 1; }
+echo -e "${BLUE}[INFO] Working directory: $(pwd)${NC}"
+
+##############################################################################
+##
+##  mise
+##
+##############################################################################
+echo ""
+print_step "mise install"
+if type mise >/dev/null 2>&1; then
+  if mise install; then
+    print_result 0 "mise install"
+  else
+    print_result $? "mise install"
+  fi
+else
+  echo -e "${YELLOW}[!] mise install: Skip because it could not be found.${NC}"
+  echo -e "${YELLOW}[!] See https://mise.jdx.dev/getting-started.html for installation.${NC}"
+fi
+
+##############################################################################
+##
+##  bun
+##
+##############################################################################
+echo ""
+print_step "bun install"
+if type bun >/dev/null 2>&1; then
+  if bun install; then
+    print_result 0 "bun install"
+  else
+    print_result $? "bun install"
+  fi
+else
+  echo -e "${YELLOW}[!] bun install: Skip because it could not be found.${NC}"
+  echo -e "${YELLOW}[!] This may be due to mise installation not completed.${NC}"
+fi
+
+##############################################################################
+##
+##  melos
+##
+##############################################################################
+echo ""
+print_step "melos bootstrap"
+if type melos >/dev/null 2>&1; then
+  if melos bootstrap; then
+    print_result 0 "melos bootstrap"
+  else
+    print_result $? "melos bootstrap"
+  fi
+else
+  echo -e "${YELLOW}[!] melos bootstrap: Skip because it could not be found.${NC}"
+  echo -e "${YELLOW}[!] See https://melos.invertase.dev/getting-started for installation.${NC}"
+fi
+
+##############################################################################
+##
+##  Finish
+##
+##############################################################################
+echo ""
+ELAPSED=$(( $(date +%s) - START_TIME ))
+echo -e "${BLUE}[INFO] Total elapsed time: ${ELAPSED}s${NC}"
+echo -e "${BLUE}[END] Bootstrap finished${NC}"

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -21,7 +21,7 @@ print_step() {
 
 print_result() {
   local code=$1; shift
-  if [ $code -eq 0 ]; then
+  if [ "$code" -eq 0 ]; then
     echo -e "${GREEN}[✔] $*${NC}"
   else
     echo -e "${RED}[✖] $* (exit ${code})${NC}"

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -11,6 +11,7 @@ RED='\033[0;31m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
+bootstrap_result=0
 step=0
 START_TIME=$(date +%s)
 
@@ -24,6 +25,7 @@ print_result() {
     echo -e "${GREEN}[✔] $*${NC}"
   else
     echo -e "${RED}[✖] $* (exit ${code})${NC}"
+    bootstrap_result=1
   fi
 }
 
@@ -96,3 +98,4 @@ echo ""
 ELAPSED=$(( $(date +%s) - START_TIME ))
 echo -e "${BLUE}[INFO] Total elapsed time: ${ELAPSED}s${NC}"
 echo -e "${BLUE}[END] Bootstrap finished${NC}"
+exit $bootstrap_result

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -11,11 +11,11 @@ RED='\033[0;31m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-step=1
+step=0
 START_TIME=$(date +%s)
 
 print_step() {
-  echo -e "${BLUE}Step $((step++)): $1${NC}"
+  echo -e "${BLUE}Step $((++step)): $1${NC}"
 }
 
 print_result() {


### PR DESCRIPTION
## Issue

- Closes #66

## 概要

開発環境のセットアップを改善するため、bootstrap スクリプトを追加しました。

## 詳細

以下の変更を実施しました：

1. `mise.toml` にタスク定義を追加
   - `bootstrap`: ワークスペースの初期化を実行
   - `clean`: ワークスペースのクリーンアップを実行

2. `tools/bootstrap.sh` スクリプトを追加
   - mise のインストール
   - bun のパッケージインストール
   - melos のブートストラップ
   - リッチな出力フォーマットでステータスを表示
   - エラーハンドリングの実装

## その他

- スクリプトは bash で実装し、エラーハンドリングを厳密に行っています
- 各ツールが見つからない場合はスキップし、インストール方法のガイダンスを表示します
- 実行時間の計測機能を追加し、セットアップにかかった時間を確認できます

`mise bootstrap` または `mise bs` を実行することで、以下のように出力されます。

```log
-> mise bs   
[bootstrap] $ ./tools/bootstrap.sh 
[INFO] Working directory: /Users/tatsutakein/workspace/flutterkaigi/2025

Step 1: mise install
mise all tools are installed
[✔] mise install

Step 2: bun install
bun install v1.2.10 (db2e7d7f)

+ @cspell/dict-dart@2.3.0
+ @cspell/dict-flutter@1.1.0
+ @cspell/dict-software-terms@5.0.5
+ @cspell/dict-sql@2.2.0
+ cspell@8.19.1
+ supabase@2.22.6

195 packages installed [131.00ms]
[✔] bun install

Step 3: melos bootstrap
Resolving dependencies... 
Downloading packages... 
  _fe_analyzer_shared 80.0.0 (82.0.0 available)
  analyzer 7.3.0 (7.4.4 available)
  async 2.12.0 (2.13.0 available)
  coverage 1.13.0 (1.13.1 available)
  fake_async 1.3.2 (1.3.3 available)
  leak_tracker 10.0.8 (11.0.1 available)
  leak_tracker_flutter_testing 3.0.9 (3.0.10 available)
  leak_tracker_testing 3.0.1 (3.0.2 available)
  lints 5.1.1 (6.0.0 available)
  material_color_utilities 0.11.1 (0.12.0 available)
  vector_math 2.1.4 (2.1.5 available)
  vm_service 14.3.1 (15.0.0 available)
Got dependencies!
12 packages have newer versions incompatible with dependency constraints.
Try `dart pub outdated` for more information.
melos bootstrap
  └> /Users/tatsutakein/workspace/flutterkaigi/2025

Running "flutter pub get" in workspace...
  > SUCCESS

Generating IntelliJ IDE files...
  > SUCCESS

 -> 4 packages bootstrapped
[✔] melos bootstrap

[INFO] Total elapsed time: 3s
[END] Bootstrap finished
```
