### PR TITLE
[All] fix: cspell 設定・スペルチェックワークフローの改善と不要定義の削除

### DIFF
--- a/.github/workflows/check-spell.yaml
+++ b/.github/workflows/check-spell.yaml
@@ -21,4 +21,4 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run spell check
-        run: bunx cspell .
+        run: bunx cspell lint

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -49,8 +49,11 @@
             "name": "github-action-term",
             "description": "GitHub Actions related terms",
             "words": [
+                "bobheadxi",
+                "ghaction",
+                "Iseconds",
                 "stefanbuck",
-                "ghaction"
+                "thollander",
             ]
         },
         {

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -5,15 +5,6 @@
     "enableGlobDot": true,
     "dictionaryDefinitions": [
         {
-            "name": "android-term",
-            "description": "Android related terms",
-            "words": [
-                "allprojects",
-                "Subproject",
-                "subprojects"
-            ]
-        },
-        {
             "name": "bun-term",
             "description": "Bun related terms",
             "words": [
@@ -75,8 +66,7 @@
             "name": "supabase-term",
             "description": "Supabase related terms",
             "words": [
-                "Supabase",
-                "plpgsql"
+                "Supabase"
             ]
         },
         {
@@ -91,7 +81,6 @@
         }
     ],
     "dictionaries": [
-        "android-term",
         "bun-term",
         "dart-term",
         "flutter-term",

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -97,20 +97,11 @@
         "supabase-term",
         "terraform-term"
     ],
+    "files": [
+        "**/*.{md,yaml,yml,dart,ts,js}",
+    ],
     "ignorePaths": [
-        "cspell.jsonc",
-        "*.lock",
-        "Runner.xcodeproj",
-        "Runner.xcworkspace",
-        "*.xcconfig",
-        "*.xib",
-        "*.storyboard",
-        "*.plist",
-        "*.properties",
-        "supabase/migrations",
-        "supabase/config.toml",
         "worker-configuration.d.ts",
-        "*.svg"
     ],
     "import": [
         "@cspell/dict-software-terms/cspell-ext.json",

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -103,6 +103,7 @@
     ],
     "ignorePaths": [
         // 自動生成ファイル
+        "*.*.dart",
         "worker-configuration.d.ts",
         // 隠しファイル
         ".*.{yaml,yml}"

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -2,6 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
     "version": "0.2",
     "useGitignore": true,
+    "enableGlobDot": true,
     "dictionaryDefinitions": [
         {
             "name": "android-term",
@@ -101,7 +102,10 @@
         "**/*.{md,yaml,yml,dart,ts,js}",
     ],
     "ignorePaths": [
+        // 自動生成ファイル
         "worker-configuration.d.ts",
+        // 隠しファイル
+        ".*.{yaml,yml}"
     ],
     "import": [
         "@cspell/dict-software-terms/cspell-ext.json",

--- a/supabase/migrations/README.md
+++ b/supabase/migrations/README.md
@@ -32,7 +32,7 @@
     - GOOD: `users`
 - 列名
   - `flg`/`dt`等の略称は利用しない
-    - `flag`/`datatime`
+    - `flag`/`datetime`
   - 日付を表す列は、`[受動態]_on`
     - `start_on`
   - 時刻を表す列は、`[受動態]_at`


### PR DESCRIPTION
## Issue

Closes #89

## 概要

cspell の files オプション追加、enableGlobDot 設定、ignorePaths の整理、不要な dictionaryDefinitions/words の削除、スペルミス修正などを行いました。

## 詳細

- cspell.jsonc に files オプション・enableGlobDot を追加し、対象ファイルや隠しファイルも検出できるように変更
- ignorePaths を整理し、自動生成ファイルや隠しファイルを除外
- 不要になった dictionaryDefinitions, words を削除
- スペルチェックワークフローで bunx cspell lint を使用するよう修正
- supabase/migrations/README.md のスペルミス修正
- GitHub Actions 関連の用語を辞書に追加

## 画像・動画

| Before | After | Design |
|-|-|-|
| | | |

## その他

特になし