### PR TITLE
[All] ci: PR チェックするワークフローを一本化

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -14,6 +14,9 @@ jobs:
   skip-job-no-changes:
     runs-on: ubuntu-24.04
     needs: changes
+    timeout-minutes: 1
+    permissions:
+      pull-requests: write
     if: ${{ needs.changes.outputs.any == 'false'}}
     steps:
       # https://github.com/peter-evans/create-or-update-comment

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -1,0 +1,39 @@
+name: Check Pull Request
+
+on:
+  pull_request:
+
+concurrency:
+  group: check-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    uses: ./.github/workflows/wc-check-changes.yaml
+
+  skip-job-no-changes:
+    runs-on: ubuntu-24.04
+    needs: changes
+    if: ${{ needs.changes.outputs.any == 'false'}}
+    steps:
+      # https://github.com/peter-evans/create-or-update-comment
+      - name: Skip comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            チェック対象ファイルに変更がないため、ジョブの実行をスキップしました。
+
+  check-spell:
+    needs: changes
+    if: ${{ needs.changes.outputs.spell == 'true' }}
+    uses: ./.github/workflows/wc-check-spell.yaml 
+
+  status-check:
+    runs-on: ubuntu-24.04
+    needs:
+      - check-spell
+    permissions: {}
+    if: failure()
+    steps:
+      - run: exit 1 

--- a/.github/workflows/wc-check-changes.yaml
+++ b/.github/workflows/wc-check-changes.yaml
@@ -1,0 +1,33 @@
+name: Check Changes
+
+on:
+  workflow_call:
+    outputs:
+      any:
+        value: ${{ jobs.changes.outputs.any }}
+      spell:
+        value: ${{ jobs.changes.outputs.spell }}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      any: ${{ steps.filter.outputs.changes != '[]' }}
+      spell: ${{ steps.filter.outputs.spell }}
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # https://github.com/dorny/paths-filter
+      - name: Paths Changes Filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            spell:
+              - "**/*.{md,yaml,yml,dart,ts,js}"

--- a/.github/workflows/wc-check-spell.yaml
+++ b/.github/workflows/wc-check-spell.yaml
@@ -1,7 +1,7 @@
 name: Check Spell
 
 on:
-  pull_request:
+  workflow_call:
 
 jobs:
   check-spell:

--- a/.github/workflows/wc-check-spell.yaml
+++ b/.github/workflows/wc-check-spell.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   check-spell:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       # https://github.com/actions/checkout
       - name: Checkout

--- a/.github/workflows/wc-check-spell.yaml
+++ b/.github/workflows/wc-check-spell.yaml
@@ -11,6 +11,11 @@ jobs:
       # https://github.com/actions/checkout
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Make sure the actual branch is checked out when running on pull requests
+          ref: ${{ github.head_ref }}
+          # This is important to fetch the changes to the previous commit
+          fetch-depth: 0
 
       # https://github.com/jdx/mise-action
       - name: Install Mise dependencies

--- a/.github/workflows/wc-check-spell.yaml
+++ b/.github/workflows/wc-check-spell.yaml
@@ -3,6 +3,9 @@ name: Check Spell
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   check-spell:
     runs-on: ubuntu-24.04

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -46,6 +46,7 @@
                 "Iseconds",
                 "stefanbuck",
                 "thollander",
+                "dorny",
             ]
         },
         {


### PR DESCRIPTION
## Issue

Closes #30

## 概要

PR チェック用の GitHub Actions ワークフローを一本化し、管理・保守性を向上させました。

## 詳細

- これまで複数に分かれていた PR チェック関連のワークフローを `.github/workflows/check-pr.yaml` に統合しました。
- 変更がない場合のスキップ処理やスペルチェック、失敗時のステータスチェックなどを一元管理します。
- ワークフローの実行効率化と、今後の拡張・修正の容易さを目的としています。

## 画像・動画

N/A

## その他

- 詳細なワークフロー内容は `.github/workflows/check-pr.yaml` を参照してください。
- 参考: [peter-evans/create-or-update-comment](https://github.com/peter-evans/create-or-update-comment)
