### PR TITLE
[All] fix: analysis_options.yaml で node_modules を除外

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  exclude:
+    - "node_modules"


### PR DESCRIPTION
## 関連Issue
#109

## 概要
workspaces 設定により node_modules 内でエラーが発生していた件について、プロジェクト直下に analysis_options.yaml を新規作成し、node_modules ディレクトリを除外する設定を追加しました。

## 詳細
- `analysis_options.yaml` を新規作成
- 以下の内容で node_modules を除外

```yaml
analyzer:
  exclude:
    - "node_modules"
```

これにより、node_modules 配下の不要なエラーが表示されなくなります。