### PR TITLE
[Dashboard] feat: 全画面の仮作成

### DIFF
--- a/apps/dashboard/lib/ui/auth/invitation_code_screen.dart
+++ b/apps/dashboard/lib/ui/auth/invitation_code_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// 招待コード入力画面
+///
+/// 主な役割:
+/// - 新規ユーザーが招待コードを入力する
+/// - ドメイン一致確認やアカウント作成処理への導線を提供する
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class InvitationCodeScreen extends StatelessWidget {
   const InvitationCodeScreen({super.key});
 

--- a/apps/dashboard/lib/ui/auth/invitation_code_screen.dart
+++ b/apps/dashboard/lib/ui/auth/invitation_code_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class InvitationCodeScreen extends StatelessWidget {
+  const InvitationCodeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('InvitationCodeScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/auth/login_screen.dart
+++ b/apps/dashboard/lib/ui/auth/login_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class LoginScreen extends StatelessWidget {
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('LoginScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/auth/login_screen.dart
+++ b/apps/dashboard/lib/ui/auth/login_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// ログイン画面
+///
+/// 主な役割:
+/// - ユーザーのログイン認証を行う
+/// - Google認証や招待コード入力画面への遷移を提供する
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class LoginScreen extends StatelessWidget {
   const LoginScreen({super.key});
 

--- a/apps/dashboard/lib/ui/launch/splash_screen.dart
+++ b/apps/dashboard/lib/ui/launch/splash_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class SplashScreen extends StatelessWidget {
+  const SplashScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('SplashScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/launch/splash_screen.dart
+++ b/apps/dashboard/lib/ui/launch/splash_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// スプラッシュ画面
+///
+/// 主な役割:
+/// - アプリ起動時に表示される
+/// - セッション確認や初期化処理を行う
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class SplashScreen extends StatelessWidget {
   const SplashScreen({super.key});
 

--- a/apps/dashboard/lib/ui/main/account/account_info_screen.dart
+++ b/apps/dashboard/lib/ui/main/account/account_info_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class AccountInfoScreen extends StatelessWidget {
+  const AccountInfoScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('AccountInfoScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/main/account/account_info_screen.dart
+++ b/apps/dashboard/lib/ui/main/account/account_info_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// アカウント情報画面
+///
+/// 主な役割:
+/// - ユーザーのアカウント情報を表示する
+/// - プロフィール編集や退会申請画面への導線を提供する
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class AccountInfoScreen extends StatelessWidget {
   const AccountInfoScreen({super.key});
 

--- a/apps/dashboard/lib/ui/main/account/account_tab_screen.dart
+++ b/apps/dashboard/lib/ui/main/account/account_tab_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// アカウントタブ画面
+///
+/// 主な役割:
+/// - アカウント情報やプロフィール編集画面への導線を提供する
+/// - タブ切り替えでアカウント関連画面を表示する
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class AccountTabScreen extends StatelessWidget {
   const AccountTabScreen({super.key});
 

--- a/apps/dashboard/lib/ui/main/account/account_tab_screen.dart
+++ b/apps/dashboard/lib/ui/main/account/account_tab_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class AccountTabScreen extends StatelessWidget {
+  const AccountTabScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('AccountTabScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/main/account/profile_edit_screen.dart
+++ b/apps/dashboard/lib/ui/main/account/profile_edit_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// プロフィール編集画面
+///
+/// 主な役割:
+/// - ユーザーのプロフィール情報を編集する
+/// - アカウント情報画面から遷移して利用される
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class ProfileEditScreen extends StatelessWidget {
   const ProfileEditScreen({super.key});
 

--- a/apps/dashboard/lib/ui/main/account/profile_edit_screen.dart
+++ b/apps/dashboard/lib/ui/main/account/profile_edit_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class ProfileEditScreen extends StatelessWidget {
+  const ProfileEditScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('ProfileEditScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/main/account/withdrawal_screen.dart
+++ b/apps/dashboard/lib/ui/main/account/withdrawal_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class WithdrawalScreen extends StatelessWidget {
+  const WithdrawalScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('WithdrawalScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/main/account/withdrawal_screen.dart
+++ b/apps/dashboard/lib/ui/main/account/withdrawal_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// 退会申請画面
+///
+/// 主な役割:
+/// - ユーザーの退会申請を行う
+/// - アカウント情報画面から遷移して利用される
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class WithdrawalScreen extends StatelessWidget {
   const WithdrawalScreen({super.key});
 

--- a/apps/dashboard/lib/ui/main/event/event_info_screen.dart
+++ b/apps/dashboard/lib/ui/main/event/event_info_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// イベント情報画面
+///
+/// 主な役割:
+/// - イベントの詳細情報を表示する
+/// - メイン画面や他イベント画面から遷移して利用される
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class EventInfoScreen extends StatelessWidget {
   const EventInfoScreen({super.key});
 

--- a/apps/dashboard/lib/ui/main/event/event_info_screen.dart
+++ b/apps/dashboard/lib/ui/main/event/event_info_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class EventInfoScreen extends StatelessWidget {
+  const EventInfoScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('EventInfoScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/main/event/event_tab_screen.dart
+++ b/apps/dashboard/lib/ui/main/event/event_tab_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// イベントタブ画面
+///
+/// 主な役割:
+/// - イベント情報の一覧や詳細への導線を提供する
+/// - タブ切り替えでイベント関連画面を表示する
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class EventTabScreen extends StatelessWidget {
   const EventTabScreen({super.key});
 

--- a/apps/dashboard/lib/ui/main/event/event_tab_screen.dart
+++ b/apps/dashboard/lib/ui/main/event/event_tab_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class EventTabScreen extends StatelessWidget {
+  const EventTabScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('EventTabScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/main/event/news_screen.dart
+++ b/apps/dashboard/lib/ui/main/event/news_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class NewsScreen extends StatelessWidget {
+  const NewsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('NewsScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/main/event/news_screen.dart
+++ b/apps/dashboard/lib/ui/main/event/news_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// お知らせ画面
+///
+/// 主な役割:
+/// - イベントや運営からのお知らせ情報を表示する
+/// - イベント画面などから遷移して利用される
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class NewsScreen extends StatelessWidget {
   const NewsScreen({super.key});
 

--- a/apps/dashboard/lib/ui/main/main_screen.dart
+++ b/apps/dashboard/lib/ui/main/main_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class MainScreen extends StatelessWidget {
+  const MainScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('MainScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/main/main_screen.dart
+++ b/apps/dashboard/lib/ui/main/main_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// メイン画面
+///
+/// 主な役割:
+/// - アプリの主要なタブ画面（イベント・スポンサー・アカウント）を統括する
+/// - 各タブへのナビゲーションを提供する
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class MainScreen extends StatelessWidget {
   const MainScreen({super.key});
 

--- a/apps/dashboard/lib/ui/main/sponsor/sponsor_detail_screen.dart
+++ b/apps/dashboard/lib/ui/main/sponsor/sponsor_detail_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class SponsorDetailScreen extends StatelessWidget {
+  const SponsorDetailScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('SponsorDetailScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/main/sponsor/sponsor_detail_screen.dart
+++ b/apps/dashboard/lib/ui/main/sponsor/sponsor_detail_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// スポンサー詳細画面
+///
+/// 主な役割:
+/// - スポンサー企業の詳細情報を表示する
+/// - 編集画面への導線を提供する
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class SponsorDetailScreen extends StatelessWidget {
   const SponsorDetailScreen({super.key});
 

--- a/apps/dashboard/lib/ui/main/sponsor/sponsor_edit_screen.dart
+++ b/apps/dashboard/lib/ui/main/sponsor/sponsor_edit_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class SponsorEditScreen extends StatelessWidget {
+  const SponsorEditScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('SponsorEditScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/main/sponsor/sponsor_edit_screen.dart
+++ b/apps/dashboard/lib/ui/main/sponsor/sponsor_edit_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// スポンサー編集画面
+///
+/// 主な役割:
+/// - スポンサー企業情報の編集を行う
+/// - 詳細画面から遷移して利用される
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class SponsorEditScreen extends StatelessWidget {
   const SponsorEditScreen({super.key});
 

--- a/apps/dashboard/lib/ui/main/sponsor/sponsor_list_screen.dart
+++ b/apps/dashboard/lib/ui/main/sponsor/sponsor_list_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// スポンサー一覧画面
+///
+/// 主な役割:
+/// - スポンサー企業の一覧を表示する
+/// - 詳細画面や編集画面への導線を提供する
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class SponsorListScreen extends StatelessWidget {
   const SponsorListScreen({super.key});
 

--- a/apps/dashboard/lib/ui/main/sponsor/sponsor_list_screen.dart
+++ b/apps/dashboard/lib/ui/main/sponsor/sponsor_list_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class SponsorListScreen extends StatelessWidget {
+  const SponsorListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('SponsorListScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/main/sponsor/sponsor_tab_screen.dart
+++ b/apps/dashboard/lib/ui/main/sponsor/sponsor_tab_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class SponsorTabScreen extends StatelessWidget {
+  const SponsorTabScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('SponsorTabScreen')));
+  }
+}

--- a/apps/dashboard/lib/ui/main/sponsor/sponsor_tab_screen.dart
+++ b/apps/dashboard/lib/ui/main/sponsor/sponsor_tab_screen.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/material.dart';
 
+/// スポンサータブ画面
+///
+/// 主な役割:
+/// - スポンサー情報の一覧や詳細への導線を提供する
+/// - タブ切り替えでスポンサー関連画面を表示する
+///
+/// 参考:
+/// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class SponsorTabScreen extends StatelessWidget {
   const SponsorTabScreen({super.key});
 


### PR DESCRIPTION
## Issue

Closes #79

## 概要
- 画面設計に基づき、全ての画面（各Screenクラス）のスタブを新規作成しました。
- 各画面クラスには「主な役割」形式のドキュメンテーションコメントを追加し、SCREENS.mdへのリンクも記載しています。

## 詳細
- 画面ごとに責務や利用シーンが分かるようにコメントを記載
- コメント内容はSCREENS.mdの設計内容と齟齬がないよう精査済み
