### PR TITLE
[Infra] SupabaseにGoogle Sign inに関する設定をセット

### DIFF
--- a/.env.json
+++ b/.env.json
@@ -1,21 +1,23 @@
 {
-  "CLOUDFLARE_ACCOUNT_ID": "ENC[AES256_GCM,data:HB3wU1ior2p6XA18yoVqCu0EA4zJIvDcC2yyXGwq7rA=,iv:Aeh2QV4raGzk1jE79q7pVKr1jfM4GMtL0SJccnOkSHo=,tag:1CZgxhxtNSAFXm+1T4QCDQ==,type:str]",
-  "CLOUDFLARE_API_TOKEN": "ENC[AES256_GCM,data:shOR7r1Zedh9L6EdXwXK9AsQl2+WkJbJnJRob6B7OgGB3rhBiYuyXQ==,iv:DnAPLpniSyi6AnLxoe600RkAztRbKXFKXOd8tmgEXC8=,tag:yN/KnUZbwqQp0lSPySz8aw==,type:str]",
-  "CLOUDFLARE_FLUTTERKAIGI_ZONE_ID": "ENC[AES256_GCM,data:Dnd8jbV8XTAtJ8dNag6O8QP6vPAx/iIzgR7QaUarcis=,iv:yegksazr+zJsOQgUBhJ4wsLc1+aicgvLPY4uNIWgTyk=,tag:YhkrU5dMQcxpAvj551fg1Q==,type:str]",
-  "TF_VAR_SUPABASE_ACCESS_TOKEN": "ENC[AES256_GCM,data:Yb93RCIXR9tulkrv2UBYWcYWOrmkJNHI6VYwj9F+6LU3m/AHd2ExYyTDGuU=,iv:rLjgAGc33Q8aa9bnlJqA/IiV53LRKzjM8yC6L2Mco0I=,tag:Y1Rh3zn/ovcWPOqihTHBVQ==,type:str]",
-  "TF_VAR_SUPABASE_ORGANIZATION_ID": "ENC[AES256_GCM,data:zpTxC8xqaIIf2zqKAQmBycPaFr8=,iv:F6ffWXSJrXgso5ebot7EpF0WnNaDZo/WNgqSo2R7U2Q=,tag:8EX9pnI/1hJzwgTpPHh3xQ==,type:str]",
-  "TF_VAR_SUPABASE_DB_PASSWORD_PRODUCTION": "ENC[AES256_GCM,data:cY06Pd163+IuoGtX3qhFew==,iv:B3rxAJVIvbz7DwTzYuO1pGjSWUqZjRUjO/q0t1ElGCI=,tag:wmqlf8kOznQxyJT/fureNA==,type:str]",
-  "TF_VAR_SUPABASE_DB_PASSWORD_STAGING": "ENC[AES256_GCM,data:kKfaWqczAyL99Sov5t5QOA==,iv:ziyJAo8iGvKsNXJAZC7F5IfBU6/DfSnwUhDQKsWplP0=,tag:TLIQjx6aO7YN7Tdd6lRffA==,type:str]",
-  "sops": {
-    "age": [
-      {
-        "recipient": "age1xjdqf6nct4pnztwtpsjdjf0n9776nc8kgqu8cymy9uww327f790qgpxwup",
-        "enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwL3ZsdGhuWmNEMWx6L3Mx\nWXpiWVJaczhtRnRjc2V6eTF3K3lLaGFnRlZJCkFoN2I3TmpRRmhwN3poalRiUlM0\nNDdpektCWHF3WGRDVFhsNVZsUDF6NncKLS0tIFV4SWNNZ09vQS9SaVF6bkk5c3hZ\nbFlnTFVLY1hEQnI3MS8xTWNhNWg5VDQKm6d0/XdebXcd2fzRW65vcff/36nKRTcW\nvJbTzXntSK+NTrvpYCXkoQD1A+nyHPNChZrn55e0/TtiByp4ycGKtA==\n-----END AGE ENCRYPTED FILE-----\n"
-      }
-    ],
-    "lastmodified": "2025-05-03T14:29:06Z",
-    "mac": "ENC[AES256_GCM,data:f4d6mfLeNtyS+IRI3Ffdc+1kzmuh7eR3RDoPXGHiW89JD0G2YYmpe896qUnddZmJrkeXVaOFse40ZdJCbRzjRuIYNyLzOxFgWv9tppd13JeLBY/aI2iUZbEy77KTH3vOeC1MB7IolCR4KNtBMckBuB5cZIx3QhoQ+x9B5SWfda8=,iv:M/DGbB+jXtYvQE6XFtq78OuQE0KQTmJgGiPvddGH3rw=,tag:RD2dSbqbuwgw227ikSgL4g==,type:str]",
-    "encrypted_regex": ".*",
-    "version": "3.10.1"
-  }
+	"CLOUDFLARE_ACCOUNT_ID": "ENC[AES256_GCM,data:HB3wU1ior2p6XA18yoVqCu0EA4zJIvDcC2yyXGwq7rA=,iv:Aeh2QV4raGzk1jE79q7pVKr1jfM4GMtL0SJccnOkSHo=,tag:1CZgxhxtNSAFXm+1T4QCDQ==,type:str]",
+	"CLOUDFLARE_API_TOKEN": "ENC[AES256_GCM,data:shOR7r1Zedh9L6EdXwXK9AsQl2+WkJbJnJRob6B7OgGB3rhBiYuyXQ==,iv:DnAPLpniSyi6AnLxoe600RkAztRbKXFKXOd8tmgEXC8=,tag:yN/KnUZbwqQp0lSPySz8aw==,type:str]",
+	"CLOUDFLARE_FLUTTERKAIGI_ZONE_ID": "ENC[AES256_GCM,data:Dnd8jbV8XTAtJ8dNag6O8QP6vPAx/iIzgR7QaUarcis=,iv:yegksazr+zJsOQgUBhJ4wsLc1+aicgvLPY4uNIWgTyk=,tag:YhkrU5dMQcxpAvj551fg1Q==,type:str]",
+	"TF_VAR_SUPABASE_ACCESS_TOKEN": "ENC[AES256_GCM,data:Yb93RCIXR9tulkrv2UBYWcYWOrmkJNHI6VYwj9F+6LU3m/AHd2ExYyTDGuU=,iv:rLjgAGc33Q8aa9bnlJqA/IiV53LRKzjM8yC6L2Mco0I=,tag:Y1Rh3zn/ovcWPOqihTHBVQ==,type:str]",
+	"TF_VAR_SUPABASE_ORGANIZATION_ID": "ENC[AES256_GCM,data:zpTxC8xqaIIf2zqKAQmBycPaFr8=,iv:F6ffWXSJrXgso5ebot7EpF0WnNaDZo/WNgqSo2R7U2Q=,tag:8EX9pnI/1hJzwgTpPHh3xQ==,type:str]",
+	"TF_VAR_SUPABASE_DB_PASSWORD_PRODUCTION": "ENC[AES256_GCM,data:cY06Pd163+IuoGtX3qhFew==,iv:B3rxAJVIvbz7DwTzYuO1pGjSWUqZjRUjO/q0t1ElGCI=,tag:wmqlf8kOznQxyJT/fureNA==,type:str]",
+	"TF_VAR_SUPABASE_DB_PASSWORD_STAGING": "ENC[AES256_GCM,data:kKfaWqczAyL99Sov5t5QOA==,iv:ziyJAo8iGvKsNXJAZC7F5IfBU6/DfSnwUhDQKsWplP0=,tag:TLIQjx6aO7YN7Tdd6lRffA==,type:str]",
+	"SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID": "ENC[AES256_GCM,data:0vEPVZE0jGWAXrP2Bfi46ZyMXSpRKhOODEXVKMKDqNv7pi7bs2blvG/VcFQC0FiGSytOWWfBtH4NEV/dDifhR7ABxAdNpeti,iv:8LrvMqodkqcc4q11zA4+pwiR3/kuu041j73UnuIMEHE=,tag:XzRK/O3QCdV+e3YOglLCBg==,type:str]",
+	"SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET": "ENC[AES256_GCM,data:nFIVcNUgbf6xD6pZKIJPr7ok/jwWKeHxWxGgsZbTDyQ/2fM=,iv:JjrDi8chH9nWsifMekZJdsst3XM6r1iHbBfK/C7a/zs=,tag:9r9aPGVdVRZDR5tmF7ashw==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age1xjdqf6nct4pnztwtpsjdjf0n9776nc8kgqu8cymy9uww327f790qgpxwup",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwL3ZsdGhuWmNEMWx6L3Mx\nWXpiWVJaczhtRnRjc2V6eTF3K3lLaGFnRlZJCkFoN2I3TmpRRmhwN3poalRiUlM0\nNDdpektCWHF3WGRDVFhsNVZsUDF6NncKLS0tIFV4SWNNZ09vQS9SaVF6bkk5c3hZ\nbFlnTFVLY1hEQnI3MS8xTWNhNWg5VDQKm6d0/XdebXcd2fzRW65vcff/36nKRTcW\nvJbTzXntSK+NTrvpYCXkoQD1A+nyHPNChZrn55e0/TtiByp4ycGKtA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-05-10T15:51:29Z",
+		"mac": "ENC[AES256_GCM,data:jOnYVF9KMx2PLxBhKvQ+6C6vuCH6HqYuyOH8BnlGAaAvKnHNO+fcxhknE7clfIrMDOm3mSbSMlxEHL367o7277MmYlBSqSmD5an7PzijHgjTuMJLrkUm8EEV54pTG97jxX8D2q8m9P2SjvAQxtxLckl9rAq9RvPr+DPaWCNWFGc=,iv:HntzcXUKrc+YOHpqP8pqRKZgzWO8oqIeblUI2ffuuuc=,tag:YoGvK2oqMlO7e4ik1ya+yA==,type:str]",
+		"encrypted_regex": ".*",
+		"version": "3.10.1"
+	}
 }

--- a/.github/workflows/supabase-apply.yaml
+++ b/.github/workflows/supabase-apply.yaml
@@ -188,6 +188,9 @@ jobs:
           bunx supabase link \
             --project-ref $PROJECT_ID
 
+      - name: Apply Supabase Configurations
+        run: bunx supabase config push
+
       - name: Apply Supabase Database
         env:
           SUPABASE_DB_PASSWORD: ${{ steps.db-parameters.outputs.db_password }}

--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -16,6 +16,7 @@
   "excludes": [
     "**/ios/Runner/**",
     "**/macos/Runner/**",
+    ".env.json",
   ],
   "plugins": [
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm",

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -235,18 +235,18 @@ max_frequency = "5s"
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
 # `twitter`, `slack`, `spotify`, `workos`, `zoom`.
-[auth.external.apple]
-enabled = false
-client_id = ""
+[auth.external.google]
+enabled = true
+client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
 # DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
-secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET)"
 # Overrides the default auth redirectUrl.
 redirect_uri = ""
 # Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
 # or any other third-party OIDC providers.
 url = ""
 # If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
-skip_nonce_check = false
+skip_nonce_check = true
 
 # Use Firebase Auth as a third-party provider alongside Supabase Auth.
 [auth.third_party.firebase]


### PR DESCRIPTION
## 概要

- Google Sign Inを実現するために、Google OAuthのClient ID, Client SecretをSupabaseに登録しました
  - Google Sign Inに関するGoogle Cloudの設定もTerraformで管理したかったのですが、Terraformから操作しようとしたところ、エラーが発生してしまい 調査に時間が掛かりそうなため断念しました (メモ参照)
  - SupabaseにGoogle Sign Inに関わる設定をセットする部分について、Terraformで行おうとしたのですが 設定が反映されていなかったので、Supabase CLIの`supabase config push`を利用することにしました #120 
- SupabaseのProduction, Stagingは同様のGoogle Cloud Project (`flutterkaigi-2025`)を利用します



## メモ

- Google Cloud Terraformのエラー

![image](https://github.com/user-attachments/assets/f4b2c330-b7f8-418f-a536-f50b17a92338)
```log
╷
│ Error: Error creating Brand: googleapi: Error 400: Project must belong to an organization.
│ 
│   with google_iap_brand.flutterkaigi_brand,
│   on main.tf line 17, in resource "google_iap_brand" "flutterkaigi_brand":
│   17: resource "google_iap_brand" "flutterkaigi_brand" {
│ 
╵
```