### PR TITLE
[web] デザインの微修正&開催日をトップに表示するように

### DIFF
--- a/apps/website/lib/config.dart
+++ b/apps/website/lib/config.dart
@@ -2,7 +2,7 @@ import 'package:flutterkaigi_2025_website/config_stub.dart'
     if (dart.library.js_interop) './config_web.dart';
 import 'package:flutterkaigi_2025_website/text.dart' show Language;
 
-final eventDate = DateTime.parse('2025-11-13T10:00:00+0900').toLocal();
+final _eventDate = DateTime.parse('2025-11-13T10:00:00+0900').toLocal();
 
 String makeTitle([String? sub]) =>
     sub == null ? site.title : '$sub - ${site.title}';
@@ -69,7 +69,7 @@ const site = (
 final event = (
   title: 'FlutterKaigi 2025',
   tagLine: 'Dash into Innovation.',
-  date: DateTime.parse('2025-11-13T10:00:00+0900').toLocal(),
+  date: _eventDate,
   place: (
     name: (ja: 'Otemachi PLACE HALL & CONFERENCE', en: null),
     url: 'https://otemachi-place-hc.jp/',
@@ -104,7 +104,7 @@ final event = (
     ),
     (
       title: (ja: 'FlutterKaigi 2025当日', en: 'FlutterKaigi 2025 Event Day'),
-      date: eventDate,
+      date: _eventDate,
     ),
   ],
   pastEvents: [

--- a/apps/website/lib/config.dart
+++ b/apps/website/lib/config.dart
@@ -2,6 +2,8 @@ import 'package:flutterkaigi_2025_website/config_stub.dart'
     if (dart.library.js_interop) './config_web.dart';
 import 'package:flutterkaigi_2025_website/text.dart' show Language;
 
+final eventDate = DateTime.parse('2025-11-13T10:00:00+0900').toLocal();
+
 String makeTitle([String? sub]) =>
     sub == null ? site.title : '$sub - ${site.title}';
 
@@ -86,7 +88,7 @@ final event = (
   schedule: [
     (
       title: (ja: 'スポンサー募集開始', en: 'Call for Sponsors Opens'),
-      date: DateTime.parse('2026-05-19T00:00:00+0900').toLocal(),
+      date: DateTime.parse('2025-05-19T00:00:00+0900').toLocal(),
     ),
     (
       title: (ja: 'プロポーザル募集開始', en: 'Call for Proposals Opens'),
@@ -102,7 +104,7 @@ final event = (
     ),
     (
       title: (ja: 'FlutterKaigi 2025当日', en: 'FlutterKaigi 2025 Event Day'),
-      date: DateTime.parse('2025-11-13T10:00:00+0900').toLocal(),
+      date: eventDate,
     ),
   ],
   pastEvents: [

--- a/apps/website/lib/src/routes/index.dart
+++ b/apps/website/lib/src/routes/index.dart
@@ -37,6 +37,7 @@ HTMLElement get _mainContent {
         ..style.position = 'relative'
         ..style.whiteSpace = 'nowrap'
         ..style.fontFamily = 'Lexend'
+        ..style.fontWeight = '900'
         ..style.textAlign = 'center'
         ..style.marginTop = '6rem'
         ..style.padding = '6rem 8rem'
@@ -52,6 +53,7 @@ HTMLElement get _mainContent {
               ..style.transform = 'translateX(100vw)'
               ..style.fontStyle = 'italic'
               ..style.fontSize = 'clamp(2.5rem, 6vw, 4.5rem)'
+              ..style.fontWeight = 'inherit'
               ..style.color = 'white'
               ..style.animationDelay = '${i * 0.3}s'
               ..style.animationName = 'slide-in'
@@ -62,27 +64,31 @@ HTMLElement get _mainContent {
       HTMLHeadingElement.h2()
         ..textContent = event.title
         ..style.fontSize = '2rem'
-        ..style.fontWeight = 'bold'
+        ..style.fontWeight = '900'
         ..style.fontFamily = 'Lexend'
         ..style.marginTop = '6rem',
       HTMLParagraphElement()
-        ..textContent = 'on ${formatDate(eventDate)}'
+        ..textContent = 'on ${formatDate(event.date)}'
         ..style.fontSize = '1.5rem'
-        ..style.fontWeight = 'bold'
+        ..style.fontWeight = '900'
         ..style.fontFamily = 'Lexend, sans-serif'
         ..style.marginTop = '1rem'
         ..style.textAlign = 'center',
       HTMLParagraphElement()
         ..style.fontSize = '1.5rem'
-        ..style.fontWeight = 'bold'
+        ..style.fontWeight = '900'
         ..style.fontFamily = 'Lexend, sans-serif'
         ..style.marginTop = '2rem'
         ..style.textAlign = 'center'
         ..appendAll([
           Text('at '),
-          externalLink(text(event.place.name), url: event.place.url)
-            ..style.fontSize = 'inherit'
-            ..style.color = 'inherit',
+          HTMLAnchorElement()
+            ..textContent = text(event.place.name)
+            ..href = event.place.url
+            ..style.cursor = 'pointer'
+            ..style.textDecoration = 'underline'
+            ..style.fontWeight = '900'
+            ..style.fontSize = 'inherit',
         ]),
       HTMLElement.section()
         ..style.position = 'relative'

--- a/apps/website/lib/src/routes/index.dart
+++ b/apps/website/lib/src/routes/index.dart
@@ -70,6 +70,7 @@ HTMLElement get _mainContent {
         ..style.fontWeight = 'bold'
         ..style.fontFamily = 'Lexend, sans-serif'
         ..style.marginTop = '2rem'
+        ..style.textAlign = 'center'
         ..appendAll([
           Text('in '),
           externalLink(text(event.place.name), url: event.place.url)

--- a/apps/website/lib/src/routes/index.dart
+++ b/apps/website/lib/src/routes/index.dart
@@ -66,13 +66,20 @@ HTMLElement get _mainContent {
         ..style.fontFamily = 'Lexend'
         ..style.marginTop = '6rem',
       HTMLParagraphElement()
+        ..textContent = 'on ${formatDate(eventDate)}'
+        ..style.fontSize = '1.5rem'
+        ..style.fontWeight = 'bold'
+        ..style.fontFamily = 'Lexend, sans-serif'
+        ..style.marginTop = '1rem'
+        ..style.textAlign = 'center',
+      HTMLParagraphElement()
         ..style.fontSize = '1.5rem'
         ..style.fontWeight = 'bold'
         ..style.fontFamily = 'Lexend, sans-serif'
         ..style.marginTop = '2rem'
         ..style.textAlign = 'center'
         ..appendAll([
-          Text('in '),
+          Text('at '),
           externalLink(text(event.place.name), url: event.place.url)
             ..style.fontSize = 'inherit'
             ..style.color = 'inherit',

--- a/apps/website/lib/src/routes/index.dart
+++ b/apps/website/lib/src/routes/index.dart
@@ -157,20 +157,22 @@ HTMLElement get _countdown {
   });
   onRemove(timer.cancel);
 
-  return HTMLDivElement()..appendAll([
-    HTMLSpanElement()
-      ..style.display = 'inline-flex'
-      ..style.alignItems = 'baseline'
-      ..style.fontSize = '0.9rem'
-      ..style.marginRight = '1rem'
-      ..style.gap = '0.5rem'
-      ..appendAll([days, Text('days')]),
-    hours,
-    colon(),
-    minutes,
-    colon(),
-    seconds,
-  ]);
+  return HTMLDivElement()
+    ..style.fontFamily = 'Lexend, sans-serif'
+    ..appendAll([
+      HTMLSpanElement()
+        ..style.display = 'inline-flex'
+        ..style.alignItems = 'baseline'
+        ..style.fontSize = '0.9rem'
+        ..style.marginRight = '1rem'
+        ..style.gap = '0.5rem'
+        ..appendAll([days, Text('days')]),
+      hours,
+      colon(),
+      minutes,
+      colon(),
+      seconds,
+    ]);
 }
 
 HTMLElement get _schedule =>

--- a/apps/website/lib/src/routes/index.dart
+++ b/apps/website/lib/src/routes/index.dart
@@ -53,7 +53,7 @@ HTMLElement get _mainContent {
               ..style.transform = 'translateX(100vw)'
               ..style.fontStyle = 'italic'
               ..style.fontSize = 'clamp(2.5rem, 6vw, 4.5rem)'
-              ..style.fontWeight = 'inherit'
+              ..style.fontWeight = '900'
               ..style.color = 'white'
               ..style.animationDelay = '${i * 0.3}s'
               ..style.animationName = 'slide-in'
@@ -82,13 +82,11 @@ HTMLElement get _mainContent {
         ..style.textAlign = 'center'
         ..appendAll([
           Text('at '),
-          HTMLAnchorElement()
-            ..textContent = text(event.place.name)
-            ..href = event.place.url
-            ..style.cursor = 'pointer'
-            ..style.textDecoration = 'underline'
-            ..style.fontWeight = '900'
-            ..style.fontSize = 'inherit',
+          externalLink(text(event.place.name), url: event.place.url)
+            ..style.fontFamily = 'Lexend, sans-serif'
+            ..style.fontWeight = 'inherit'
+            ..style.fontSize = 'inherit'
+            ..style.color = 'inherit',
         ]),
       HTMLElement.section()
         ..style.position = 'relative'

--- a/apps/website/web/styles.css
+++ b/apps/website/web/styles.css
@@ -1,5 +1,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Roboto&display=swap");
-@import url('https://fonts.googleapis.com/css2?family=Lexend:wght@100..900&&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lexend:wght@900&&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lexend:wght@700&&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lexend:wght@400&&display=swap');
 
 :root {
   --color-beyond-red: #e50632;

--- a/apps/website/web/styles.css
+++ b/apps/website/web/styles.css
@@ -1,5 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Roboto&display=swap");
-@import url('https://fonts.googleapis.com/css2?family=Lexend:wght@900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lexend:wght@100..900&&display=swap');
 
 :root {
   --color-beyond-red: #e50632;


### PR DESCRIPTION
## Issue

Closes #{issue_number}

## 概要

<!--
必ず書いてください。
やったことをわかりやすく短く書いてください。
-->

- デザインの微修正
- 開催日の表示

## 詳細

<!--
可能であれば、変更した内容と変更した理由や背景を書いてください。
-->

- モバイル表示だと場所名が見切れる問題を修正
- 開催日を「FlutterKaigi 2025」のあとに表示するように
- スポンサー募集開始日時を修正
- 場所名が具体的になったので接続詞を `at` に変更

## 画像・動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

<img width="403" alt="image" src="https://github.com/user-attachments/assets/132f06c7-0150-417b-9bbc-9deb3c5e7748" />

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
