### PR TITLE
[All] docs: スペルチェック運用ルール（CSpell）ドキュメント追加 #28

### DIFF
--- a/docs/SPELL_CHECK.md
+++ b/docs/SPELL_CHECK.md
@@ -1,0 +1,99 @@
+# スペルチェック運用ルール
+
+本プロジェクトでは、開発者間での表記揺れやスペルミスによる混乱を防ぐため、[CSpell] を利用したスペルチェックを導入・運用しています。
+
+## CSpell の設定
+
+設定は [cspell.jsonc] に記載しています。
+
+このファイルでは、どのファイルをチェック対象・対象外にするか、どのカスタム辞書・外部辞書を使うかなど、細かな挙動を柔軟に制御できます。
+
+設定例として、`cspell.jsonc` には以下のような内容が含まれます。
+
+```jsonc
+{
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
+  "version": "0.2",
+  "useGitignore": true,
+  "enableGlobDot": true,
+  "dictionaryDefinitions": [
+    {
+      "name": "project-term",
+      "path": "./.cspell/project-term.txt",
+      "addWords": true
+    }
+    // ...他の辞書定義
+  ],
+  "dictionaries": [
+    "project-term"
+    // ...他の辞書
+  ],
+  "files": [
+    "**/*.{md,yaml,yml,dart,ts,js}"
+    // ...他のチェック対象ファイル
+  ],
+  "ignorePaths": [
+    "*.*.dart"
+    // ...他のチェック対象外ファイル
+  ],
+  "import": [
+    "@cspell/dict-software-terms/cspell-ext.json"
+    // ...他の外部辞書
+  ]
+}
+```
+
+設定についての詳しい情報は、以下の公式ドキュメントをご覧ください。
+
+<https://cspell.org/docs/Configuration>
+
+## カスタム辞書の運用
+
+プロジェクトやツールなどで使う単語や略語、固有名詞などは、`.cspell/` ディレクトリ内の各種 `*-term.txt` ファイルにまとめています。もしスペルチェックで誤検知（プロジェクト独自の単語など）があった場合は、該当する辞書ファイルに単語を追加してください。追加した内容は Pull Request として提出し、レビューを受けてから反映します。
+
+カスタム辞書についての詳しい情報は、以下の公式ドキュメントをご覧ください。
+
+<https://cspell.org/docs/dictionaries/custom-dictionaries>
+
+## CI でのスペルチェック
+
+Pull Request 作成時などに GitHub Actions によって自動的にスペルチェックが実行されます。
+
+詳しい設定は以下のファイルをご覧ください。
+
+- [.github/workflows/check-pr.yaml]
+- [.github/workflows/wc-check-spell.yaml]
+
+## 手元でのスペルチェック
+
+まずは、プロジェクトで必要なツールやパッケージをインストールします。
+
+```sh
+# ツールのインストール
+mise install
+
+# パッケージのインストール
+bun install
+```
+
+インストールが終わったら、以下のコマンドを実行してプロジェクト全体のスペルチェックを行います。
+
+```sh
+bunx cspell lint
+```
+
+## VS Code 拡張機能
+
+CSpell の開発企業 [Street Side Software] から VS Code 拡張機能が提供されています。
+
+<https://streetsidesoftware.com/vscode-spell-checker/>
+
+拡張機能をインストールして有効化すると、`cspell.jsonc` やカスタム辞書も自動的に認識され、さまざまな便利な機能が利用できます。
+
+<!-- Links -->
+
+[CSpell]: https://cspell.org/
+[cspell.jsonc]: https://github.com/FlutterKaigi/2025/blob/main/cspell.jsonc
+[.github/workflows/check-pr.yaml]: https://github.com/FlutterKaigi/2025/blob/main/.github/workflows/check-pr.yaml
+[.github/workflows/wc-check-spell.yaml]: https://github.com/FlutterKaigi/2025/blob/main/.github/workflows/wc-check-spell.yaml
+[Street Side Software]: https://streetsidesoftware.com/


### PR DESCRIPTION
## Issue

Closes #28

## 概要

スペルチェック運用ルール（CSpellの導入・運用方法、カスタム辞書、CI連携、VS Code拡張など）をまとめた `docs/SPELL_CHECK.md` を新規追加しました。

## 詳細

- CSpellの設定例や公式ドキュメントへのリンクを記載
- カスタム辞書の運用方法、CI・ローカル・VS Codeでの利用方法を説明
- プロジェクト独自の単語追加手順や参考リンクも記載

## 画像・動画

（なし）

## その他

（なし）
