### PR TITLE
[Infra] 汎用Result型の作成

### DIFF
--- a/bff/engine/lib/util/result.dart
+++ b/bff/engine/lib/util/result.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+
+/// [Result]は、成功した場合は[Success]、失敗した場合は[Failure]を返す。
+sealed class Result<T, E extends Exception> {
+  const Result._();
+
+  /// [value]には成功した値を指定する。
+  factory Result.success(T value) = Success<T, E>;
+
+  /// [error]には例外を指定する。
+  factory Result.failure(E error, [StackTrace stackTrace]) = Failure<T, E>;
+
+  T get unwrap => switch (this) {
+    Success(:final value) => value,
+    Failure(:final error) => throw error,
+  };
+
+  /// [fn]を実行し、成功した場合は[Result.success]にラップして返し、
+  /// [E]型の例外が発生した場合は[Result.failure]にラップして返す。
+  static Future<Result<T, E>> capture<T, E extends Exception>(
+    FutureOr<T> Function() fn,
+  ) async {
+    try {
+      return Result.success(await fn());
+    } on E catch (e) {
+      return Result.failure(e);
+    }
+  }
+
+  static Result<T, E> captureSync<T, E extends Exception>(T Function() fn) {
+    try {
+      return Result.success(fn());
+    } on E catch (e) {
+      return Result.failure(e);
+    }
+  }
+}
+
+class Success<T, E extends Exception> extends Result<T, E> {
+  const Success(this.value) : super._();
+
+  final T value;
+
+  @override
+  String toString() => 'Success<$T, $E>($value)';
+}
+
+class Failure<T, E extends Exception> extends Result<T, E> {
+  const Failure(this.error, [this.stackTrace]) : super._();
+
+  final E error;
+  final StackTrace? stackTrace;
+
+  @override
+  String toString() => 'Failure<$T, $E>($error)';
+}


### PR DESCRIPTION
## Issue

<!-- issueはないため、この行はコメント化 -->

## 概要

エラーハンドリングを統一するために汎用Result型を作成しました。

## 詳細

- Result<T, E extends Exception>型を実装
- 成功時はSuccess、失敗時はFailureを返す
- 非同期処理(Future)と同期処理の両方に対応
- sealed classを使用して、パターンマッチングでの扱いを容易に

## 画像・動画

## その他

- Rustの`Result`型やKotlinの`Result`型を参考にしています
- 例外処理を明示的に行うことでエラーハンドリングの一貫性を確保します