### PR TITLE
[Dashboard] fix: authNotifierProvider の監視とクローズ処理を追加し、ビルド時の中断を防止

### DIFF
--- a/apps/dashboard/lib/main.dart
+++ b/apps/dashboard/lib/main.dart
@@ -20,7 +20,10 @@ Future<void> main() async {
         isDebug: kDebugMode,
       );
   try {
+    // `authNotifierProvider` のビルド時に中断されないようにするために監視しておく
+    final authSubscription = container.listen(authNotifierProvider, (_, _) {});
     await container.read(authNotifierProvider.future);
+    authSubscription.close();
   } on Exception catch (e) {
     log(e.toString());
   }


### PR DESCRIPTION
## Issue

N/A

## 概要

正常にアプリが機能するように修正しました。

## 詳細

- Riverpod 3.0.0-dev.12 から挙動が変わっており、監視しておかないと Provider の処理が中断してしまって `await container.read(authNotifierProvider.future);` の処理が戻ってこなくなってしまっていた
  - https://github.com/rrousselGit/riverpod/blob/d22c032051ea279b381096cc1e129eb54814d404/packages/flutter_riverpod/CHANGELOG.md#full-change-list
- 事前に `listen` で監視して、必要な処理が完了したらクローズするようにした

## 画像・動画

https://github.com/user-attachments/assets/dad2aa9b-d3b7-4952-9696-961ec22dd02b

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
