### PR TITLE
[Dashboard] feat: メイン画面以降の画面遷移実装（event/sponsor/account分割・モーダル遷移対応）

### DIFF
--- a/apps/dashboard/lib/core/router/account.dart
+++ b/apps/dashboard/lib/core/router/account.dart
@@ -1,7 +1,17 @@
 part of 'router.dart';
 
 const _accountRoutes = [
-  TypedGoRoute<AccountInfoRoute>(path: '/account'),
+  TypedGoRoute<AccountInfoRoute>(
+    path: '/account',
+    routes: [
+      TypedGoRoute<ProfileEditRoute>(
+        path: 'profile-edit',
+      ),
+      TypedGoRoute<WithdrawalRoute>(
+        path: 'withdrawal',
+      ),
+    ],
+  ),
 ];
 
 class AccountBranch extends StatefulShellBranchData {}
@@ -12,4 +22,20 @@ class AccountInfoRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const AccountInfoScreen();
+}
+
+class ProfileEditRoute extends GoRouteData {
+  const ProfileEditRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const ProfileEditScreen();
+}
+
+class WithdrawalRoute extends GoRouteData {
+  const WithdrawalRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const WithdrawalScreen();
 }

--- a/apps/dashboard/lib/core/router/account.dart
+++ b/apps/dashboard/lib/core/router/account.dart
@@ -1,5 +1,9 @@
 part of 'router.dart';
 
+const _accountRoutes = [
+  TypedGoRoute<AccountInfoRoute>(path: '/account'),
+];
+
 class AccountBranch extends StatefulShellBranchData {}
 
 class AccountInfoRoute extends GoRouteData {

--- a/apps/dashboard/lib/core/router/account.dart
+++ b/apps/dashboard/lib/core/router/account.dart
@@ -1,0 +1,11 @@
+part of 'router.dart';
+
+class AccountBranch extends StatefulShellBranchData {}
+
+class AccountInfoRoute extends GoRouteData {
+  const AccountInfoRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const AccountInfoScreen();
+}

--- a/apps/dashboard/lib/core/router/account.dart
+++ b/apps/dashboard/lib/core/router/account.dart
@@ -27,6 +27,9 @@ class AccountInfoRoute extends GoRouteData {
 class ProfileEditRoute extends GoRouteData {
   const ProfileEditRoute();
 
+  static final GlobalKey<NavigatorState> $parentNavigatorKey =
+      _rootNavigatorKey;
+
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const ProfileEditScreen();
@@ -34,6 +37,9 @@ class ProfileEditRoute extends GoRouteData {
 
 class WithdrawalRoute extends GoRouteData {
   const WithdrawalRoute();
+
+  static final GlobalKey<NavigatorState> $parentNavigatorKey =
+      _rootNavigatorKey;
 
   @override
   Widget build(BuildContext context, GoRouterState state) =>

--- a/apps/dashboard/lib/core/router/event.dart
+++ b/apps/dashboard/lib/core/router/event.dart
@@ -1,5 +1,9 @@
 part of 'router.dart';
 
+const _eventRoutes = [
+  TypedGoRoute<EventInfoRoute>(path: '/event'),
+];
+
 class EventBranch extends StatefulShellBranchData {}
 
 class EventInfoRoute extends GoRouteData {

--- a/apps/dashboard/lib/core/router/event.dart
+++ b/apps/dashboard/lib/core/router/event.dart
@@ -1,7 +1,14 @@
 part of 'router.dart';
 
 const _eventRoutes = [
-  TypedGoRoute<EventInfoRoute>(path: '/event'),
+  TypedGoRoute<EventInfoRoute>(
+    path: '/event',
+    routes: [
+      TypedGoRoute<NewsRoute>(
+        path: 'news',
+      ),
+    ],
+  ),
 ];
 
 class EventBranch extends StatefulShellBranchData {}
@@ -12,4 +19,11 @@ class EventInfoRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const EventInfoScreen();
+}
+
+class NewsRoute extends GoRouteData {
+  const NewsRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) => const NewsScreen();
 }

--- a/apps/dashboard/lib/core/router/event.dart
+++ b/apps/dashboard/lib/core/router/event.dart
@@ -1,0 +1,11 @@
+part of 'router.dart';
+
+class EventBranch extends StatefulShellBranchData {}
+
+class EventInfoRoute extends GoRouteData {
+  const EventInfoRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const EventInfoScreen();
+}

--- a/apps/dashboard/lib/core/router/router.dart
+++ b/apps/dashboard/lib/core/router/router.dart
@@ -1,5 +1,7 @@
 import 'package:dashboard/core/ui/main/main_screen.dart';
 import 'package:dashboard/features/account/ui/account_info_screen.dart';
+import 'package:dashboard/features/account/ui/profile_edit_screen.dart';
+import 'package:dashboard/features/account/ui/withdrawal_screen.dart';
 import 'package:dashboard/features/auth/data/notifier/auth_notifier.dart';
 import 'package:dashboard/features/auth/ui/login_screen.dart';
 import 'package:dashboard/features/event/ui/event_info_screen.dart';

--- a/apps/dashboard/lib/core/router/router.dart
+++ b/apps/dashboard/lib/core/router/router.dart
@@ -19,6 +19,8 @@ part 'event.dart';
 part 'router.g.dart';
 part 'sponsor.dart';
 
+final _rootNavigatorKey = GlobalKey<NavigatorState>();
+
 @Riverpod(keepAlive: true)
 GoRouter router(Ref ref) {
   final isAuthorizedNotifier = ValueNotifier<bool>(
@@ -33,6 +35,7 @@ GoRouter router(Ref ref) {
     ..onDispose(isAuthorizedNotifier.dispose);
 
   return GoRouter(
+    navigatorKey: _rootNavigatorKey,
     routes: $appRoutes,
     debugLogDiagnostics: kDebugMode,
     refreshListenable: isAuthorizedNotifier,

--- a/apps/dashboard/lib/core/router/router.dart
+++ b/apps/dashboard/lib/core/router/router.dart
@@ -9,10 +9,10 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part 'router.g.dart';
-part 'event.dart';
-part 'sponsor.dart';
 part 'account.dart';
+part 'event.dart';
+part 'router.g.dart';
+part 'sponsor.dart';
 
 @Riverpod(keepAlive: true)
 GoRouter router(Ref ref) {

--- a/apps/dashboard/lib/core/router/router.dart
+++ b/apps/dashboard/lib/core/router/router.dart
@@ -10,6 +10,9 @@ import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'router.g.dart';
+part 'event.dart';
+part 'sponsor.dart';
+part 'account.dart';
 
 @Riverpod(keepAlive: true)
 GoRouter router(Ref ref) {
@@ -76,34 +79,4 @@ class MainRoute extends StatefulShellRouteData {
   ) {
     return MainScreen(navigationShell: navigationShell);
   }
-}
-
-class EventBranch extends StatefulShellBranchData {}
-
-class SponsorBranch extends StatefulShellBranchData {}
-
-class AccountBranch extends StatefulShellBranchData {}
-
-class EventInfoRoute extends GoRouteData {
-  const EventInfoRoute();
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      const EventInfoScreen();
-}
-
-class SponsorListRoute extends GoRouteData {
-  const SponsorListRoute();
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      const SponsorListScreen();
-}
-
-class AccountInfoRoute extends GoRouteData {
-  const AccountInfoRoute();
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      const AccountInfoScreen();
 }

--- a/apps/dashboard/lib/core/router/router.dart
+++ b/apps/dashboard/lib/core/router/router.dart
@@ -4,6 +4,8 @@ import 'package:dashboard/features/auth/data/notifier/auth_notifier.dart';
 import 'package:dashboard/features/auth/ui/login_screen.dart';
 import 'package:dashboard/features/event/ui/event_info_screen.dart';
 import 'package:dashboard/features/news/ui/news_screen.dart';
+import 'package:dashboard/features/sponsor/ui/sponsor_detail_screen.dart';
+import 'package:dashboard/features/sponsor/ui/sponsor_edit_screen.dart';
 import 'package:dashboard/features/sponsor/ui/sponsor_list_screen.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/apps/dashboard/lib/core/router/router.dart
+++ b/apps/dashboard/lib/core/router/router.dart
@@ -57,15 +57,9 @@ class LoginRoute extends GoRouteData {
 
 @TypedStatefulShellRoute<MainRoute>(
   branches: [
-    TypedStatefulShellBranch<EventBranch>(
-      routes: [TypedGoRoute<EventInfoRoute>(path: '/event')],
-    ),
-    TypedStatefulShellBranch<SponsorBranch>(
-      routes: [TypedGoRoute<SponsorListRoute>(path: '/sponsors')],
-    ),
-    TypedStatefulShellBranch<AccountBranch>(
-      routes: [TypedGoRoute<AccountInfoRoute>(path: '/account')],
-    ),
+    TypedStatefulShellBranch<EventBranch>(routes: _eventRoutes),
+    TypedStatefulShellBranch<SponsorBranch>(routes: _sponsorRoutes),
+    TypedStatefulShellBranch<AccountBranch>(routes: _accountRoutes),
   ],
 )
 class MainRoute extends StatefulShellRouteData {

--- a/apps/dashboard/lib/core/router/router.dart
+++ b/apps/dashboard/lib/core/router/router.dart
@@ -3,6 +3,7 @@ import 'package:dashboard/features/account/ui/account_info_screen.dart';
 import 'package:dashboard/features/auth/data/notifier/auth_notifier.dart';
 import 'package:dashboard/features/auth/ui/login_screen.dart';
 import 'package:dashboard/features/event/ui/event_info_screen.dart';
+import 'package:dashboard/features/news/ui/news_screen.dart';
 import 'package:dashboard/features/sponsor/ui/sponsor_list_screen.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/apps/dashboard/lib/core/router/router.g.dart
+++ b/apps/dashboard/lib/core/router/router.g.dart
@@ -65,6 +65,8 @@ RouteBase get $mainRoute => StatefulShellRouteData.$route(
                 GoRouteData.$route(
                   path: 'edit',
 
+                  parentNavigatorKey: SponsorEditRoute.$parentNavigatorKey,
+
                   factory: $SponsorEditRouteExtension._fromState,
                 ),
               ],
@@ -83,10 +85,14 @@ RouteBase get $mainRoute => StatefulShellRouteData.$route(
             GoRouteData.$route(
               path: 'profile-edit',
 
+              parentNavigatorKey: ProfileEditRoute.$parentNavigatorKey,
+
               factory: $ProfileEditRouteExtension._fromState,
             ),
             GoRouteData.$route(
               path: 'withdrawal',
+
+              parentNavigatorKey: WithdrawalRoute.$parentNavigatorKey,
 
               factory: $WithdrawalRouteExtension._fromState,
             ),
@@ -272,7 +278,7 @@ final class RouterProvider extends $FunctionalProvider<GoRouter, GoRouter>
   }
 }
 
-String _$routerHash() => r'529f08a3cab04410aedb49fb9aaf9b38cccf2bfc';
+String _$routerHash() => r'ecc626acb78b04853f89f21c9027f94b9d700e5f';
 
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/dashboard/lib/core/router/router.g.dart
+++ b/apps/dashboard/lib/core/router/router.g.dart
@@ -56,6 +56,20 @@ RouteBase get $mainRoute => StatefulShellRouteData.$route(
           path: '/sponsors',
 
           factory: $SponsorListRouteExtension._fromState,
+          routes: [
+            GoRouteData.$route(
+              path: ':slug',
+
+              factory: $SponsorDetailRouteExtension._fromState,
+              routes: [
+                GoRouteData.$route(
+                  path: 'edit',
+
+                  factory: $SponsorEditRouteExtension._fromState,
+                ),
+              ],
+            ),
+          ],
         ),
       ],
     ),
@@ -111,6 +125,40 @@ extension $SponsorListRouteExtension on SponsorListRoute {
       const SponsorListRoute();
 
   String get location => GoRouteData.$location('/sponsors');
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $SponsorDetailRouteExtension on SponsorDetailRoute {
+  static SponsorDetailRoute _fromState(GoRouterState state) =>
+      SponsorDetailRoute(slug: state.pathParameters['slug']!);
+
+  String get location =>
+      GoRouteData.$location('/sponsors/${Uri.encodeComponent(slug)}');
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $SponsorEditRouteExtension on SponsorEditRoute {
+  static SponsorEditRoute _fromState(GoRouterState state) =>
+      SponsorEditRoute(slug: state.pathParameters['slug']!);
+
+  String get location =>
+      GoRouteData.$location('/sponsors/${Uri.encodeComponent(slug)}/edit');
 
   void go(BuildContext context) => context.go(location);
 

--- a/apps/dashboard/lib/core/router/router.g.dart
+++ b/apps/dashboard/lib/core/router/router.g.dart
@@ -79,6 +79,18 @@ RouteBase get $mainRoute => StatefulShellRouteData.$route(
           path: '/account',
 
           factory: $AccountInfoRouteExtension._fromState,
+          routes: [
+            GoRouteData.$route(
+              path: 'profile-edit',
+
+              factory: $ProfileEditRouteExtension._fromState,
+            ),
+            GoRouteData.$route(
+              path: 'withdrawal',
+
+              factory: $WithdrawalRouteExtension._fromState,
+            ),
+          ],
         ),
       ],
     ),
@@ -175,6 +187,38 @@ extension $AccountInfoRouteExtension on AccountInfoRoute {
       const AccountInfoRoute();
 
   String get location => GoRouteData.$location('/account');
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $ProfileEditRouteExtension on ProfileEditRoute {
+  static ProfileEditRoute _fromState(GoRouterState state) =>
+      const ProfileEditRoute();
+
+  String get location => GoRouteData.$location('/account/profile-edit');
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $WithdrawalRouteExtension on WithdrawalRoute {
+  static WithdrawalRoute _fromState(GoRouterState state) =>
+      const WithdrawalRoute();
+
+  String get location => GoRouteData.$location('/account/withdrawal');
 
   void go(BuildContext context) => context.go(location);
 

--- a/apps/dashboard/lib/core/router/router.g.dart
+++ b/apps/dashboard/lib/core/router/router.g.dart
@@ -40,6 +40,13 @@ RouteBase get $mainRoute => StatefulShellRouteData.$route(
           path: '/event',
 
           factory: $EventInfoRouteExtension._fromState,
+          routes: [
+            GoRouteData.$route(
+              path: 'news',
+
+              factory: $NewsRouteExtension._fromState,
+            ),
+          ],
         ),
       ],
     ),
@@ -73,6 +80,21 @@ extension $EventInfoRouteExtension on EventInfoRoute {
       const EventInfoRoute();
 
   String get location => GoRouteData.$location('/event');
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $NewsRouteExtension on NewsRoute {
+  static NewsRoute _fromState(GoRouterState state) => const NewsRoute();
+
+  String get location => GoRouteData.$location('/event/news');
 
   void go(BuildContext context) => context.go(location);
 

--- a/apps/dashboard/lib/core/router/sponsor.dart
+++ b/apps/dashboard/lib/core/router/sponsor.dart
@@ -1,5 +1,9 @@
 part of 'router.dart';
 
+const _sponsorRoutes = [
+  TypedGoRoute<SponsorListRoute>(path: '/sponsors'),
+];
+
 class SponsorBranch extends StatefulShellBranchData {}
 
 class SponsorListRoute extends GoRouteData {

--- a/apps/dashboard/lib/core/router/sponsor.dart
+++ b/apps/dashboard/lib/core/router/sponsor.dart
@@ -41,6 +41,9 @@ class SponsorEditRoute extends GoRouteData {
 
   final String slug;
 
+  static final GlobalKey<NavigatorState> $parentNavigatorKey =
+      _rootNavigatorKey;
+
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       SponsorEditScreen(slug: slug);

--- a/apps/dashboard/lib/core/router/sponsor.dart
+++ b/apps/dashboard/lib/core/router/sponsor.dart
@@ -1,7 +1,19 @@
 part of 'router.dart';
 
 const _sponsorRoutes = [
-  TypedGoRoute<SponsorListRoute>(path: '/sponsors'),
+  TypedGoRoute<SponsorListRoute>(
+    path: '/sponsors',
+    routes: [
+      TypedGoRoute<SponsorDetailRoute>(
+        path: ':slug',
+        routes: [
+          TypedGoRoute<SponsorEditRoute>(
+            path: 'edit',
+          ),
+        ],
+      ),
+    ],
+  ),
 ];
 
 class SponsorBranch extends StatefulShellBranchData {}
@@ -12,4 +24,24 @@ class SponsorListRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const SponsorListScreen();
+}
+
+class SponsorDetailRoute extends GoRouteData {
+  const SponsorDetailRoute({required this.slug});
+
+  final String slug;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      SponsorDetailScreen(slug: slug);
+}
+
+class SponsorEditRoute extends GoRouteData {
+  const SponsorEditRoute({required this.slug});
+
+  final String slug;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      SponsorEditScreen(slug: slug);
 }

--- a/apps/dashboard/lib/core/router/sponsor.dart
+++ b/apps/dashboard/lib/core/router/sponsor.dart
@@ -1,0 +1,11 @@
+part of 'router.dart';
+
+class SponsorBranch extends StatefulShellBranchData {}
+
+class SponsorListRoute extends GoRouteData {
+  const SponsorListRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const SponsorListScreen();
+}

--- a/apps/dashboard/lib/features/account/ui/account_info_screen.dart
+++ b/apps/dashboard/lib/features/account/ui/account_info_screen.dart
@@ -50,12 +50,12 @@ class _Body extends ConsumerWidget {
               child: const Text('ログアウト'),
             ),
             const SizedBox(height: 16),
-            TextButton(
+            FilledButton(
               onPressed: () => const ProfileEditRoute().go(context),
               child: const Text('GO TO PROFILE EDIT'),
             ),
             const SizedBox(height: 8),
-            TextButton(
+            FilledButton(
               onPressed: () => const WithdrawalRoute().go(context),
               child: const Text('GO TO WITHDRAWAL'),
             ),

--- a/apps/dashboard/lib/features/account/ui/account_info_screen.dart
+++ b/apps/dashboard/lib/features/account/ui/account_info_screen.dart
@@ -1,6 +1,7 @@
 import 'package:dashboard/features/auth/data/notifier/auth_notifier.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:dashboard/core/router/router.dart';
 
 /// アカウント情報画面
 ///
@@ -47,6 +48,16 @@ class _Body extends ConsumerWidget {
               onPressed: () =>
                   ref.read(authNotifierProvider.notifier).signOut(),
               child: const Text('ログアウト'),
+            ),
+            const SizedBox(height: 16),
+            TextButton(
+              onPressed: () => const ProfileEditRoute().go(context),
+              child: const Text('GO TO PROFILE EDIT'),
+            ),
+            const SizedBox(height: 8),
+            TextButton(
+              onPressed: () => const WithdrawalRoute().go(context),
+              child: const Text('GO TO WITHDRAWAL'),
             ),
           ],
         ),

--- a/apps/dashboard/lib/features/account/ui/account_info_screen.dart
+++ b/apps/dashboard/lib/features/account/ui/account_info_screen.dart
@@ -52,12 +52,12 @@ class _Body extends ConsumerWidget {
             const SizedBox(height: 16),
             FilledButton(
               onPressed: () => const ProfileEditRoute().go(context),
-              child: const Text('GO TO PROFILE EDIT'),
+              child: const Text('プロフィール編集へ'),
             ),
             const SizedBox(height: 8),
             FilledButton(
               onPressed: () => const WithdrawalRoute().go(context),
-              child: const Text('GO TO WITHDRAWAL'),
+              child: const Text('退会申請へ'),
             ),
           ],
         ),

--- a/apps/dashboard/lib/features/account/ui/account_info_screen.dart
+++ b/apps/dashboard/lib/features/account/ui/account_info_screen.dart
@@ -1,7 +1,7 @@
+import 'package:dashboard/core/router/router.dart';
 import 'package:dashboard/features/auth/data/notifier/auth_notifier.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:dashboard/core/router/router.dart';
 
 /// アカウント情報画面
 ///

--- a/apps/dashboard/lib/features/account/ui/profile_edit_screen.dart
+++ b/apps/dashboard/lib/features/account/ui/profile_edit_screen.dart
@@ -13,6 +13,11 @@ class ProfileEditScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(body: Center(child: Text('ProfileEditScreen')));
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('ProfileEditScreen'),
+      ),
+      body: const Center(),
+    );
   }
 }

--- a/apps/dashboard/lib/features/account/ui/withdrawal_screen.dart
+++ b/apps/dashboard/lib/features/account/ui/withdrawal_screen.dart
@@ -13,6 +13,11 @@ class WithdrawalScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(body: Center(child: Text('WithdrawalScreen')));
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('WithdrawalScreen'),
+      ),
+      body: const Center(),
+    );
   }
 }

--- a/apps/dashboard/lib/features/event/ui/event_info_screen.dart
+++ b/apps/dashboard/lib/features/event/ui/event_info_screen.dart
@@ -18,7 +18,7 @@ class EventInfoScreen extends StatelessWidget {
       body: Center(
         child: FilledButton(
           onPressed: () async => const NewsRoute().go(context),
-          child: const Text('GO TO NEWS'),
+          child: const Text('ニュース画面へ'),
         ),
       ),
     );

--- a/apps/dashboard/lib/features/event/ui/event_info_screen.dart
+++ b/apps/dashboard/lib/features/event/ui/event_info_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dashboard/core/router/router.dart';
 import 'package:flutter/material.dart';
 
 /// イベント情報画面
@@ -13,6 +14,13 @@ class EventInfoScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(body: Center(child: Text('EventInfoScreen')));
+    return Scaffold(
+      body: Center(
+        child: TextButton(
+          onPressed: () async => const NewsRoute().go(context),
+          child: const Text('GO TO NEWS'),
+        ),
+      ),
+    );
   }
 }

--- a/apps/dashboard/lib/features/event/ui/event_info_screen.dart
+++ b/apps/dashboard/lib/features/event/ui/event_info_screen.dart
@@ -16,7 +16,7 @@ class EventInfoScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Center(
-        child: TextButton(
+        child: FilledButton(
           onPressed: () async => const NewsRoute().go(context),
           child: const Text('GO TO NEWS'),
         ),

--- a/apps/dashboard/lib/features/news/ui/news_screen.dart
+++ b/apps/dashboard/lib/features/news/ui/news_screen.dart
@@ -13,6 +13,15 @@ class NewsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(body: Center(child: Text('NewsScreen')));
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('News'),
+      ),
+      body: const Center(
+        child: Text(
+          'NewsScreen',
+        ),
+      ),
+    );
   }
 }

--- a/apps/dashboard/lib/features/sponsor/ui/sponsor_detail_screen.dart
+++ b/apps/dashboard/lib/features/sponsor/ui/sponsor_detail_screen.dart
@@ -9,10 +9,18 @@ import 'package:flutter/material.dart';
 /// 参考:
 /// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class SponsorDetailScreen extends StatelessWidget {
-  const SponsorDetailScreen({super.key});
+  const SponsorDetailScreen({required this.slug, super.key});
+  final String slug;
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(body: Center(child: Text('SponsorDetailScreen')));
+    return Scaffold(
+      body: Center(
+        child: Text(
+          'SponsorDetailScreen: slug = '
+          '[1m$slug[0m',
+        ),
+      ),
+    );
   }
 }

--- a/apps/dashboard/lib/features/sponsor/ui/sponsor_detail_screen.dart
+++ b/apps/dashboard/lib/features/sponsor/ui/sponsor_detail_screen.dart
@@ -26,7 +26,7 @@ class SponsorDetailScreen extends StatelessWidget {
       body: Center(
         child: FilledButton(
           onPressed: () => SponsorEditRoute(slug: slug).go(context),
-          child: const Text('GO TO SPONSOR EDIT'),
+          child: const Text('スポンサー編集へ'),
         ),
       ),
     );

--- a/apps/dashboard/lib/features/sponsor/ui/sponsor_detail_screen.dart
+++ b/apps/dashboard/lib/features/sponsor/ui/sponsor_detail_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dashboard/core/router/router.dart';
 import 'package:flutter/material.dart';
 
 /// スポンサー詳細画面
@@ -9,16 +10,23 @@ import 'package:flutter/material.dart';
 /// 参考:
 /// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class SponsorDetailScreen extends StatelessWidget {
-  const SponsorDetailScreen({required this.slug, super.key});
+  const SponsorDetailScreen({
+    required this.slug,
+    super.key,
+  });
+
   final String slug;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        title: Text('SponsorDetailScreen: $slug'),
+      ),
       body: Center(
-        child: Text(
-          'SponsorDetailScreen: slug = '
-          '[1m$slug[0m',
+        child: TextButton(
+          onPressed: () => SponsorEditRoute(slug: slug).go(context),
+          child: const Text('GO TO SPONSOR EDIT'),
         ),
       ),
     );

--- a/apps/dashboard/lib/features/sponsor/ui/sponsor_detail_screen.dart
+++ b/apps/dashboard/lib/features/sponsor/ui/sponsor_detail_screen.dart
@@ -24,7 +24,7 @@ class SponsorDetailScreen extends StatelessWidget {
         title: Text('SponsorDetailScreen: $slug'),
       ),
       body: Center(
-        child: TextButton(
+        child: FilledButton(
           onPressed: () => SponsorEditRoute(slug: slug).go(context),
           child: const Text('GO TO SPONSOR EDIT'),
         ),

--- a/apps/dashboard/lib/features/sponsor/ui/sponsor_edit_screen.dart
+++ b/apps/dashboard/lib/features/sponsor/ui/sponsor_edit_screen.dart
@@ -9,18 +9,20 @@ import 'package:flutter/material.dart';
 /// 参考:
 /// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class SponsorEditScreen extends StatelessWidget {
-  const SponsorEditScreen({required this.slug, super.key});
+  const SponsorEditScreen({
+    required this.slug,
+    super.key,
+  });
+
   final String slug;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Center(
-        child: Text(
-          'SponsorEditScreen: slug = '
-          '[1m$slug[0m',
-        ),
+      appBar: AppBar(
+        title: Text('SponsorEditScreen: $slug'),
       ),
+      body: const Center(),
     );
   }
 }

--- a/apps/dashboard/lib/features/sponsor/ui/sponsor_edit_screen.dart
+++ b/apps/dashboard/lib/features/sponsor/ui/sponsor_edit_screen.dart
@@ -9,10 +9,18 @@ import 'package:flutter/material.dart';
 /// 参考:
 /// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
 class SponsorEditScreen extends StatelessWidget {
-  const SponsorEditScreen({super.key});
+  const SponsorEditScreen({required this.slug, super.key});
+  final String slug;
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(body: Center(child: Text('SponsorEditScreen')));
+    return Scaffold(
+      body: Center(
+        child: Text(
+          'SponsorEditScreen: slug = '
+          '[1m$slug[0m',
+        ),
+      ),
+    );
   }
 }

--- a/apps/dashboard/lib/features/sponsor/ui/sponsor_list_screen.dart
+++ b/apps/dashboard/lib/features/sponsor/ui/sponsor_list_screen.dart
@@ -19,7 +19,7 @@ class SponsorListScreen extends StatelessWidget {
         child: FilledButton(
           onPressed: () =>
               const SponsorDetailRoute(slug: 'sample-sponsor').go(context),
-          child: const Text('GO TO SPONSOR DETAIL'),
+          child: const Text('スポンサー詳細へ'),
         ),
       ),
     );

--- a/apps/dashboard/lib/features/sponsor/ui/sponsor_list_screen.dart
+++ b/apps/dashboard/lib/features/sponsor/ui/sponsor_list_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dashboard/core/router/router.dart';
 import 'package:flutter/material.dart';
 
 /// スポンサー一覧画面
@@ -13,6 +14,14 @@ class SponsorListScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(body: Center(child: Text('SponsorListScreen')));
+    return Scaffold(
+      body: Center(
+        child: TextButton(
+          onPressed: () =>
+              const SponsorDetailRoute(slug: 'sample-sponsor').go(context),
+          child: const Text('GO TO SPONSOR DETAIL'),
+        ),
+      ),
+    );
   }
 }

--- a/apps/dashboard/lib/features/sponsor/ui/sponsor_list_screen.dart
+++ b/apps/dashboard/lib/features/sponsor/ui/sponsor_list_screen.dart
@@ -16,7 +16,7 @@ class SponsorListScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Center(
-        child: TextButton(
+        child: FilledButton(
           onPressed: () =>
               const SponsorDetailRoute(slug: 'sample-sponsor').go(context),
           child: const Text('GO TO SPONSOR DETAIL'),


### PR DESCRIPTION
## Issue

Closes #158

## 概要

- event/sponsor/account 各タブごとに router 定義を分割
- SCREENS.md に基づくメイン画面以降の画面遷移ルートを実装

## 詳細

- GoRouter のルート定義を event.dart, sponsor.dart, account.dart に分割
- 各画面遷移サンプルを FilledButton で実装
- 編集・モーダル系画面（スポンサー編集、プロフィール編集、退会申請）は親 Navigator で表示されるよう parentNavigatorKey を設定

## 画像・動画

https://github.com/user-attachments/assets/1d6ee39e-c943-4b8b-a6d0-6c7bd389af63
