### PR TITLE
supabaseのバージョン指定方法を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@cspell/dict-software-terms": "^5.1.4",
     "@cspell/dict-sql": "^2.2.1",
     "cspell": "^8.19.4",
-    "supabase": "2.30.4"
+    "supabase": "^2.30.4"
   },
   "workspaces": [
     "bff/bridge",


### PR DESCRIPTION
## 概要
supabaseのバージョン指定方法を修正しました。

## 詳細
- package.json の supabase のバージョン指定を "2.30.4" から "^2.30.4" に変更しました。

Issueはありません。