### PR TITLE
fix: bunx を bun run に変更（CIワークフロー・ドキュメント修正）

### DIFF
--- a/.github/workflows/wc-check-spell.yaml
+++ b/.github/workflows/wc-check-spell.yaml
@@ -30,4 +30,4 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run spell check
-        run: bunx cspell lint
+        run: bun run cspell lint

--- a/docs/SPELL_CHECK.md
+++ b/docs/SPELL_CHECK.md
@@ -79,7 +79,7 @@ bun install
 インストールが終わったら、以下のコマンドを実行してプロジェクト全体のスペルチェックを行います。
 
 ```sh
-bunx cspell lint
+bun run cspell lint
 ```
 
 ## VS Code 拡張機能


### PR DESCRIPTION
## 概要

CIワークフローおよびドキュメント内の `bunx` コマンドを `bun run` に変更しました。

## 詳細

- `.github/workflows/wc-check-spell.yaml` の `bunx cspell lint` を `bun run cspell lint` に修正
- `docs/SPELL_CHECK.md` のコマンド例も同様に修正
- 変更理由: `bunx` コマンドではグローバルで有効になっているコマンドが優先されてしまう場合があるため、プロジェクトローカルのコマンドを確実に実行できる `bun run` へ統一しました。

Issue: なし