### PR TITLE
chore: BFF用DockerコマンドをVSCodeタスクに追加

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -129,6 +129,61 @@
         "--workdir",
         "${workspaceFolder}/supabase"
       ]
+    },
+    {
+      "label": "bff-up",
+      "type": "shell",
+      "command": "docker",
+      "args": [
+        "compose",
+        "up",
+        "--detach",
+        "--build",
+        "--remove-orphans"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/bff/engine"
+      }
+    },
+    {
+      "label": "bff-down",
+      "type": "shell",
+      "command": "docker",
+      "args": [
+        "compose",
+        "down",
+        "--remove-orphans"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/bff/engine"
+      }
+    },
+    {
+      "label": "bff-clean",
+      "type": "shell",
+      "command": "docker",
+      "args": [
+        "compose",
+        "down",
+        "--rmi",
+        "--volumes",
+        "--remove-orphans"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/bff/engine"
+      }
+    },
+    {
+      "label": "bff-status",
+      "type": "shell",
+      "command": "docker",
+      "args": [
+        "compose",
+        "ps"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/bff/engine"
+      }
     }
   ],
   "inputs": [


### PR DESCRIPTION
## 概要
BFF用のDocker操作コマンド（up/down/clean/status）を`.vscode/tasks.json`に追加しました。

## 詳細
- `bff-up`: BFFエンジンのDocker Composeをバックグラウンドで起動（ビルド・不要コンテナ削除込み）
- `bff-down`: BFFエンジンのDocker Composeを停止
- `bff-clean`: BFFエンジンのDocker Composeを停止し、イメージ・ボリュームも削除
- `bff-status`: BFFエンジンのDocker Composeの状態確認

Issue: なし