### PR TITLE
chore: 企業テーブル構造の見直し（name/logo_nameの移動・必須化、company_drafts 拡張）

### DIFF
--- a/supabase/migrations/20250713065753_move_name_logo_from_company_drafts_to_companies.sql
+++ b/supabase/migrations/20250713065753_move_name_logo_from_company_drafts_to_companies.sql
@@ -1,0 +1,15 @@
+alter table "public"."company_drafts" drop constraint "company_drafts_name_check";
+
+alter table "public"."companies" add column "logo_name" text;
+
+alter table "public"."companies" add column "name" text not null;
+
+alter table "public"."company_drafts" drop column "logo_name";
+
+alter table "public"."company_drafts" drop column "name";
+
+alter table "public"."companies" add constraint "companies_name_check" CHECK ((name <> ''::text)) not valid;
+
+alter table "public"."companies" validate constraint "companies_name_check";
+
+

--- a/supabase/migrations/20250713070601_add_description_website_url_to_company_drafts.sql
+++ b/supabase/migrations/20250713070601_add_description_website_url_to_company_drafts.sql
@@ -1,0 +1,13 @@
+alter table "public"."company_drafts" add column "description" text not null;
+
+alter table "public"."company_drafts" add column "website_url" text not null;
+
+alter table "public"."company_drafts" add constraint "company_drafts_description_check" CHECK ((description <> ''::text)) not valid;
+
+alter table "public"."company_drafts" validate constraint "company_drafts_description_check";
+
+alter table "public"."company_drafts" add constraint "company_drafts_website_url_check" CHECK ((website_url <> ''::text)) not valid;
+
+alter table "public"."company_drafts" validate constraint "company_drafts_website_url_check";
+
+

--- a/supabase/migrations/20250713070847_make_logo_name_not_null_in_companies.sql
+++ b/supabase/migrations/20250713070847_make_logo_name_not_null_in_companies.sql
@@ -1,0 +1,7 @@
+alter table "public"."companies" alter column "logo_name" set not null;
+
+alter table "public"."companies" add constraint "companies_logo_name_check" CHECK ((logo_name <> ''::text)) not valid;
+
+alter table "public"."companies" validate constraint "companies_logo_name_check";
+
+

--- a/supabase/schemas/001_companies.sql
+++ b/supabase/schemas/001_companies.sql
@@ -1,5 +1,7 @@
 CREATE TABLE public.companies (
   id smallint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  name text NOT NULL CHECK (name <> ''),
+  logo_name text,
   created_at timestamp DEFAULT now() NOT NULL,
   updated_at timestamp DEFAULT now() NOT NULL
 );

--- a/supabase/schemas/001_companies.sql
+++ b/supabase/schemas/001_companies.sql
@@ -1,7 +1,7 @@
 CREATE TABLE public.companies (
   id smallint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
   name text NOT NULL CHECK (name <> ''),
-  logo_name text,
+  logo_name text NOT NULL CHECK (logo_name <> ''),
   created_at timestamp DEFAULT now() NOT NULL,
   updated_at timestamp DEFAULT now() NOT NULL
 );

--- a/supabase/schemas/003_company_drafts.sql
+++ b/supabase/schemas/003_company_drafts.sql
@@ -2,9 +2,7 @@
 CREATE TABLE public.company_drafts (
   id smallint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
   company_id smallint REFERENCES public.companies (id) ON DELETE CASCADE NULL,
-  name text NOT NULL CHECK (name <> ''),
   slug text NOT NULL UNIQUE CHECK (slug <> ''),
-  logo_name text,
   created_at timestamp DEFAULT now() NOT NULL,
   updated_at timestamp DEFAULT now() NOT NULL
 );

--- a/supabase/schemas/003_company_drafts.sql
+++ b/supabase/schemas/003_company_drafts.sql
@@ -3,6 +3,8 @@ CREATE TABLE public.company_drafts (
   id smallint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
   company_id smallint REFERENCES public.companies (id) ON DELETE CASCADE NULL,
   slug text NOT NULL UNIQUE CHECK (slug <> ''),
+  description text NOT NULL CHECK (description <> ''),
+  website_url text NOT NULL CHECK (website_url <> ''),
   created_at timestamp DEFAULT now() NOT NULL,
   updated_at timestamp DEFAULT now() NOT NULL
 );


### PR DESCRIPTION
### 概要

- companiesテーブルのlogo_nameカラムを必須（NOT NULL・空文字不可）に変更
- company_draftsテーブルにdescription, website_urlカラムを追加（どちらもNOT NULL・空文字不可）
- 企業の基本情報（name, logo_name）をcompany_draftsからcompaniesテーブルに移動

### 詳細

- 企業の基本情報（name, logo_name）は企業自身が変更できないものとし、companiesテーブルで一元管理する構造に変更しました。
- 企業の説明やWebサイトURLは変更申請（company_drafts）で管理するようにしました。
- これにより、企業の基本情報の整合性を担保しつつ、申請内容の柔軟な管理が可能となります。

