### PR TITLE
chore(dashboard): IDEAの実行設定にargs追加

### DIFF
--- a/.idea/runConfigurations/flutter_run_dashboard_development_debug.xml
+++ b/.idea/runConfigurations/flutter_run_dashboard_development_debug.xml
@@ -1,5 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Flutter Run -&gt; 'dashboard development debug'" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--dart-define-from-file environments/.env.dev" />
     <option name="filePath" value="$PROJECT_DIR$/apps/dashboard/lib/main.dart" />
     <method v="2" />
   </configuration>


### PR DESCRIPTION
## 概要
IntelliJ IDEAの実行設定ファイルに`--dart-define-from-file`引数を追加しました。

## 変更内容
- `.idea/runConfigurations/flutter_run_dashboard_development_debug.xml`に開発用環境変数ファイルを指定する引数を追加

## 関連Issue
Closes #273