### PR TITLE
docs: dashboardアプリの画面設計を拡張し、CLAUDE.mdを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,140 @@
+# FlutterKaigi 2025
+
+This repository contains FlutterKaigi 2025's application projects.
+
+## Common Development Commands
+
+### Project Bootstrap and Setup
+
+```bash
+# Initialize workspace (use mise for tool management)
+mise run bootstrap
+
+# Clean workspace
+mise run clean
+
+# Install dependencies
+melos bootstrap
+```
+
+### Code Generation
+
+```bash
+# Generate all code (build_runner + l10n)
+melos run gen
+
+# Generate only build_runner code
+melos run gen:build
+
+# Generate with watch mode
+melos run gen:build:watch
+
+# Generate for uncommitted changes only
+melos run gen:diff:head
+
+# Generate for changes compared to main
+melos run gen:diff:main
+```
+
+### Code Quality and Testing
+
+```bash
+# Run all tests (dart + flutter)
+melos run test
+
+# Format all code
+melos run format
+
+# Check formatting
+melos run format:check
+
+# Fix code issues
+melos run fix
+
+# Apply custom lint fixes
+melos run fix:custom
+
+# Analyze specific app
+cd apps/dashboard && flutter analyze
+```
+
+### Individual App Development
+
+```bash
+# Dashboard app
+cd apps/dashboard
+flutter pub get
+flutter config --enable-swift-package-manager  # First time only
+flutter run -d {device}
+
+# Website app
+cd apps/website
+make dev
+
+# BFF development
+cd bff/bridge
+bun install
+bun run dev
+```
+
+## Architecture Overview
+
+This is a **monorepo** using **melos** for workspace management with three main application types:
+
+### Apps Structure
+
+- `apps/dashboard/` - Flutter-based dashboard application for FlutterKaigi 2025
+- `apps/dashboard_catalog/` - Widgetbook catalog for dashboard components
+- `apps/website/` - Static website built with Jaspr (Dart-based web framework)
+
+### BFF (Backend for Frontend)
+
+- `bff/engine/` - Dart-based BFF compiled to WebAssembly
+- `bff/bridge/` - TypeScript bridge that calls the WebAssembly engine
+- Deployed to Cloudflare Workers
+
+### Shared Packages
+
+- `packages/auth_client/` - Authentication client
+- `packages/bff_client/` - BFF API client
+- `packages/db_client/` - Database client
+- `packages/db_types/` - Database type definitions
+- `packages/flutterkaigi_lints/` - Custom lint rules
+
+### Key Technologies
+
+- **Flutter** with Swift Package Manager enabled
+- **Dart** with code generation (build_runner, freezed, json_annotation)
+- **TypeScript/JavaScript** with Bun runtime
+- **Supabase** for database and authentication
+- **Cloudflare Workers** for BFF deployment
+
+## Development Workflow
+
+### Branch Strategy
+
+- Main development branch: `main`
+- Feature branches: `feat/GH-{issue}/description`
+- Bug fixes: `fix/GH-{issue}/description`
+- Other types: `docs/`, `chore/`, `ci/`, `refactor/`, `style/`, `test/`, `build/`, `perf/`
+- Keep branches short-lived (target 1 week merge cycle)
+
+### Code Generation Requirements
+
+- Run `melos run gen` after adding new models or routers
+- Generated files use `.g.dart`, `.freezed.dart`, and `.gen.dart` extensions
+- Localization files are generated with `flutter gen-l10n`
+
+### Environment Setup
+
+- Use `mise` for tool version management
+- Flutter requires Swift Package Manager enabled: `flutter config --enable-swift-package-manager`
+- Supabase environment variables required for BFF development
+
+## Important Notes
+
+- **Always run** code generation after model/router changes
+- **Use melos commands** for workspace-wide operations
+- **Check formatting** before committing: `melos run format:check`
+- **Run tests** before pushing: `melos run test`
+- The project uses **Japanese** as the primary language for documentation and UI

--- a/docs/dashboard/SCREENS.md
+++ b/docs/dashboard/SCREENS.md
@@ -10,22 +10,25 @@
 
 <!-- dprint-ignore-start -->
 <!-- cspell:ignoreRegExp [A-Z]{1}-[A-Z]{4} -->
-| ID | カテゴリ | 日本語名 | 英語名 | 実装種別 | 遷移種別 |
-|-|-|-|-|-|-|
-| L-SPLH | 起動 | スプラッシュ画面 | SplashScreen | Flutter | Replace |
-| A-QJTR | 認証 | ログイン画面 | LoginScreen | Flutter | Replace |
-| A-PLXM | - | Google認証画面 | GoogleAuthBottomSheet | InAppBrowser | BottomSheet |
-| A-URVN | - | 招待コード入力画面 | InvitationCodeScreen | Flutter | Push |
-| A-KYSD | - | アカウント作成エラーダイアログ | AccountCreationErrorDialog | Flutter | Dialog |
-| D-HTFA | メイン | メイン画面 | MainScreen | Flutter | Replace |
-| E-INFO | イベント | イベント情報画面 | EventInfoScreen | Flutter | - |
-| E-GLMB | - | お知らせ画面 | NewsScreen | Flutter | Push |
-| S-LIST | スポンサー | スポンサー一覧画面 | SponsorListScreen | Flutter | - |
-| S-DETA | - | スポンサー詳細画面 | SponsorDetailScreen | Flutter | Push |
-| S-YTRO | - | スポンサー編集画面 | SponsorEditScreen | Flutter | Modal |
-| K-INFO | アカウント | アカウント情報画面 | AccountInfoScreen | Flutter | - |
-| K-OVJL | - | プロフィール編集画面 | ProfileEditScreen | Flutter | Modal |
-| K-XRPU | - | 退会申請画面 | WithdrawalScreen | Flutter | Modal |
+| ID | カテゴリ | 日本語名 | 英語名 | 実装種別 | 遷移種別 | 権限 |
+|-|-|-|-|-|-|-|
+| L-SPLH | 起動 | スプラッシュ画面 | SplashScreen | Flutter | Replace | 全員 |
+| A-QJTR | 認証 | ログイン画面 | LoginScreen | Flutter | Replace | 要認証時 |
+| A-PLXM | - | Google認証画面 | GoogleAuthBottomSheet | InAppBrowser | BottomSheet | 要認証時 |
+| A-URVN | - | 招待コード入力画面 | InvitationCodeScreen | Flutter | Push | 要認証時 |
+| A-KYSD | - | アカウント作成エラーダイアログ | AccountCreationErrorDialog | Flutter | Dialog | 要認証時 |
+| D-HTFA | メイン | メイン画面 | MainScreen | Flutter | Replace | 全員（匿名可） |
+| E-INFO | イベント | イベント情報画面 | EventInfoScreen | Flutter | - | 全員（匿名可） |
+| E-GLMB | - | お知らせ画面 | NewsScreen | Flutter | Push | 全員（匿名可） |
+| E-SESS | - | セッション一覧画面 | SessionListScreen | Flutter | - | 全員（匿名可） |
+| E-SEDT | - | セッション詳細画面 | SessionDetailScreen | Flutter | Push | 全員（匿名可） |
+| E-FMAP | - | 会場フロアマップ画面 | VenueFloorMapScreen | Flutter | - | 全員（匿名可） |
+| S-LIST | スポンサー | スポンサー一覧画面 | SponsorListScreen | Flutter | - | 全員（匿名可） |
+| S-DETA | - | スポンサー詳細画面 | SponsorDetailScreen | Flutter | Push | 全員（匿名可） |
+| S-YTRO | - | スポンサー編集画面 | SponsorEditScreen | Flutter | Modal | 企業担当者 |
+| K-INFO | アカウント | アカウント情報画面 | AccountInfoScreen | Flutter | - | 認証ユーザー |
+| K-OVJL | - | プロフィール編集画面 | ProfileEditScreen | Flutter | Modal | 認証ユーザー |
+| K-XRPU | - | 退会申請画面 | WithdrawalScreen | Flutter | Modal | 認証ユーザー |
 <!-- dprint-ignore-end -->
 
 > [!NOTE]
@@ -45,7 +48,7 @@
 
 ## 3. 画面遷移図
 
-### 3-1. スポンサー企業担当者向け
+### 3-1. カンファレンス参加者向け（匿名ログイン含む）
 
 ```mermaid
 flowchart TD
@@ -60,28 +63,39 @@ flowchart TD
       subgraph EventTabScreen[イベントタブ画面]
         EventInfoScreen[イベント情報画面]
       end
+      subgraph SessionTabScreen[セッションタブ画面]
+        SessionListScreen[セッション一覧画面]
+      end
+      subgraph VenueTabScreen[会場タブ画面]
+        VenueFloorMapScreen[会場フロアマップ画面]
+      end
       subgraph SponsorTabScreen[スポンサータブ画面]
         SponsorListScreen[スポンサー一覧画面]
       end
       subgraph AccountTabScreen[アカウントタブ画面]
-        AccountInfoScreen[アカウント情報画面]
+        AccountInfoScreen[アカウント情報画面<br>※匿名時はログイン促進]
       end
     end
     NewsScreen[お知らせ画面]
+    SessionDetailScreen[セッション詳細画面]
     SponsorDetailScreen[スポンサー詳細画面]
-    SponsorEditScreen[スポンサー編集画面]
     ProfileEditScreen[プロフィール編集画面]
     WithdrawalScreen[退会申請画面]
 
     Start((開始)) --> SplashScreen
-    SplashScreen --> SessionCheck{セッション確認}
-    SessionCheck --> |有効| EventInfoScreen
-    SessionCheck --> |無効| LoginScreen
+    SplashScreen --> AnonymousLogin((匿名ログイン自動実行))
+    AnonymousLogin --> EventInfoScreen
+    
+    %% アカウント情報画面からの認証フロー
+    AccountInfoScreen --> AuthCheck{認証状態確認}
+    AuthCheck --> |未認証| LoginScreen
+    AuthCheck --> |認証済み| ProfileEditScreen
+    AuthCheck --> |認証済み| WithdrawalScreen
     
     %% 認証フロー
     LoginScreen --> GoogleAuthBottomSheet((Google認証))
     GoogleAuthBottomSheet --> AccountCheck{アカウント存在確認}
-    AccountCheck --> |存在する| EventInfoScreen
+    AccountCheck --> |存在する| AccountInfoScreen
     AccountCheck --> |存在しない| InvitationCodeScreen
     
     %% 新規登録フロー
@@ -89,12 +103,75 @@ flowchart TD
     DomainCheck --> |一致| CreateAccount((アカウント作成))
     DomainCheck --> |不一致| AccountCreationErrorDialog
     AccountCreationErrorDialog --> InvitationCodeScreen
-    CreateAccount --> EventInfoScreen
+    CreateAccount --> AccountInfoScreen
     
-    %% メイン画面以降のフロー
+    %% メイン画面以降のフロー（匿名でも利用可能）
     EventInfoScreen --> NewsScreen
+    SessionListScreen --> SessionDetailScreen
     SponsorListScreen --> SponsorDetailScreen
-    SponsorDetailScreen --> SponsorEditScreen
-    AccountInfoScreen --> ProfileEditScreen
-    AccountInfoScreen --> WithdrawalScreen
+```
+
+### 3-2. スポンサー企業担当者向け
+
+```mermaid
+flowchart TD
+    %% 画面一覧
+    SplashScreen[スプラッシュ画面]
+    LoginScreen[ログイン画面]
+    GoogleAuthBottomSheet[Google認証画面]
+    InvitationCodeScreen[招待コード入力画面]
+    AccountCreationErrorDialog[アカウント作成<br>エラーダイアログ]
+    subgraph MainScreen[メイン画面]
+      direction LR
+      subgraph EventTabScreen[イベントタブ画面]
+        EventInfoScreen[イベント情報画面]
+      end
+      subgraph SessionTabScreen[セッションタブ画面]
+        SessionListScreen[セッション一覧画面]
+      end
+      subgraph VenueTabScreen[会場タブ画面]
+        VenueFloorMapScreen[会場フロアマップ画面]
+      end
+      subgraph SponsorTabScreen[スポンサータブ画面]
+        SponsorListScreen[スポンサー一覧画面]
+      end
+      subgraph AccountTabScreen[アカウントタブ画面]
+        AccountInfoScreen[アカウント情報画面<br>※匿名時はログイン促進]
+      end
+    end
+    NewsScreen[お知らせ画面]
+    SessionDetailScreen[セッション詳細画面]
+    SponsorDetailScreen[スポンサー詳細画面]
+    SponsorEditScreen[スポンサー編集画面<br>※企業担当者のみ]
+    ProfileEditScreen[プロフィール編集画面]
+    WithdrawalScreen[退会申請画面]
+
+    Start((開始)) --> SplashScreen
+    SplashScreen --> AnonymousLogin((匿名ログイン自動実行))
+    AnonymousLogin --> EventInfoScreen
+    
+    %% アカウント情報画面からの認証フロー
+    AccountInfoScreen --> AuthCheck{認証状態確認}
+    AuthCheck --> |未認証| LoginScreen
+    AuthCheck --> |認証済み| ProfileEditScreen
+    AuthCheck --> |認証済み| WithdrawalScreen
+    
+    %% 認証フロー（企業担当者の場合）
+    LoginScreen --> GoogleAuthBottomSheet((Google認証))
+    GoogleAuthBottomSheet --> AccountCheck{アカウント存在確認}
+    AccountCheck --> |存在する| AccountInfoScreen
+    AccountCheck --> |存在しない| InvitationCodeScreen
+    
+    %% 新規登録フロー（企業担当者の場合）
+    InvitationCodeScreen --> DomainCheck{ドメイン一致確認}
+    DomainCheck --> |一致| CreateAccount((アカウント作成))
+    DomainCheck --> |不一致| AccountCreationErrorDialog
+    AccountCreationErrorDialog --> InvitationCodeScreen
+    CreateAccount --> AccountInfoScreen
+    
+    %% メイン画面以降のフロー（匿名でも利用可能）
+    EventInfoScreen --> NewsScreen
+    SessionListScreen --> SessionDetailScreen
+    SponsorListScreen --> SponsorDetailScreen
+    SponsorDetailScreen --> |企業担当者のみ| SponsorEditScreen
 ```


### PR DESCRIPTION
## 概要

- FlutterKaigi 2025 dashboardアプリの画面設計ドキュメントを拡張
- 新しいセッション関連画面とフロアマップ画面を追加
- 匿名ログイン機能を考慮した画面遷移図を作成
- プロジェクト用のCLAUDE.mdファイルを追加

## 詳細

### 1. CLAUDE.mdの追加
- Claude Code用の開発ガイドラインを作成
- 一般的な開発コマンド、アーキテクチャ概要、開発ワークフローを記載
- 将来のClaude Codeインスタンスが効率的に作業できるよう情報を整理

### 2. 画面設計の拡張
**新規追加画面:**
- E-SESS: セッション一覧画面
- E-SEDT: セッション詳細画面  
- E-FMAP: 会場フロアマップ画面

**タブ構成の変更:**
- メイン画面に「セッション」と「会場」タブを追加
- 合計5つのタブ（イベント、セッション、会場、スポンサー、アカウント）

### 3. 匿名ログイン機能の実装
**権限カラムの更新:**
- 全員（匿名可）: コンテンツ閲覧画面
- 認証ユーザー: アカウント関連画面
- 企業担当者: スポンサー編集画面

**画面遷移フローの変更:**
- 起動時に匿名ログイン自動実行
- アカウント情報画面からの認証動線
- ログイン後はアカウントタブに戻る設計

### 4. ユーザー体験の改善
- 初回起動時から即座にコンテンツが閲覧可能
- 必要に応じてアカウント情報画面からログイン
- 権限に応じた適切な画面制御

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>