### PR TITLE
Create stripe payment intent webhook endpoint

### DIFF
--- a/bff/stripe-webhook/.dev.vars.example
+++ b/bff/stripe-webhook/.dev.vars.example
@@ -2,3 +2,5 @@ STRIPE_API_KEY=sk_test_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
 
 POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/postgres
+
+BFF_ENGINE_API_KEY=your-secret-api-key-here

--- a/bff/stripe-webhook/README.md
+++ b/bff/stripe-webhook/README.md
@@ -1,3 +1,5 @@
+# Stripe Webhook Service
+
 ```txt
 npm install
 npm run dev
@@ -19,3 +21,41 @@ Pass the `CloudflareBindings` as generics when instantiation `Hono`:
 // src/index.ts
 const app = new Hono<{ Bindings: CloudflareBindings }>()
 ```
+
+## API Endpoints
+
+### Create Payment Intent
+
+Creates a Stripe Payment Intent for a ticket checkout session.
+
+**Endpoint:** `PUT /api/v1/payment-intents/:userId/:ticketCheckoutId`
+
+**Authentication:** Requires `x-api-key` header with BFF Engine API key
+
+**Parameters:**
+- `userId` (path): User ID
+- `ticketCheckoutId` (path): Ticket checkout session ID
+
+**Request Body:**
+```json
+{
+  "price": 5000,
+  "currency": "jpy",
+  "metadata": {
+    "custom_field": "value"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "url": "https://checkout.stripe.com/pay/pi_xxx#xxx"
+}
+```
+
+**Features:**
+- Idempotent operation per user and ticket checkout ID
+- Returns existing URL if Payment Intent already exists
+- Validates ticket checkout session existence
+- Updates checkout session with Payment Intent ID

--- a/bff/stripe-webhook/src/index.ts
+++ b/bff/stripe-webhook/src/index.ts
@@ -1,11 +1,103 @@
 import Stripe from "stripe";
 import { Hono } from "hono";
 import { drizzle } from "drizzle-orm/node-postgres";
+import { eq, and } from "drizzle-orm";
 import * as schema from "../drizzle/schema";
 
 const app = new Hono<{
   Bindings: Cloudflare.Env;
 }>();
+
+// Middleware for API key authentication
+app.use("/api/v1/*", async (c, next) => {
+  const apiKey = c.req.header("x-api-key");
+  if (!apiKey || apiKey !== c.env.BFF_ENGINE_API_KEY) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  await next();
+});
+
+// PUT endpoint for creating Payment Intent (idempotent by user and ticket checkout ID)
+app.put("/api/v1/payment-intents/:userId/:ticketCheckoutId", async (c) => {
+  try {
+    const userId = c.req.param("userId");
+    const ticketCheckoutId = c.req.param("ticketCheckoutId");
+    
+    if (!userId || !ticketCheckoutId) {
+      return c.json({ error: "userId and ticketCheckoutId are required" }, 400);
+    }
+
+    // Parse request body
+    const body = await c.req.json();
+    const { price, currency, metadata } = body;
+
+    if (!price || !currency) {
+      return c.json({ error: "price and currency are required" }, 400);
+    }
+
+    // Validate price is a positive integer
+    if (typeof price !== "number" || price <= 0 || !Number.isInteger(price)) {
+      return c.json({ error: "price must be a positive integer (in cents)" }, 400);
+    }
+
+    // Initialize Stripe and DB
+    const stripe = new Stripe(c.env.STRIPE_API_KEY);
+    const db = drizzle(c.env.HYPERDRIVE.connectionString, {
+      schema,
+    });
+
+    // Check if checkout session exists
+    const existingCheckout = await db
+      .select()
+      .from(schema.ticketCheckoutSessions)
+      .where(eq(schema.ticketCheckoutSessions.id, ticketCheckoutId))
+      .limit(1);
+
+    if (existingCheckout.length === 0) {
+      return c.json({ error: "Ticket checkout session not found" }, 404);
+    }
+
+    const checkout = existingCheckout[0];
+
+    // If Payment Intent already exists for this checkout, return existing URL
+    if (checkout.stripePaymentIntentId) {
+      const paymentIntent = await stripe.paymentIntents.retrieve(checkout.stripePaymentIntentId);
+      const url = `https://checkout.stripe.com/pay/${paymentIntent.client_secret}`;
+      return c.json({ url });
+    }
+
+    // Create new Payment Intent
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: price,
+      currency: currency.toLowerCase(),
+      metadata: {
+        userId,
+        ticketCheckoutId,
+        ...metadata
+      },
+      automatic_payment_methods: {
+        enabled: true,
+      },
+    });
+
+    // Update checkout session with Payment Intent ID
+    await db
+      .update(schema.ticketCheckoutSessions)
+      .set({
+        stripePaymentIntentId: paymentIntent.id,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(schema.ticketCheckoutSessions.id, ticketCheckoutId));
+
+    // Generate checkout URL
+    const url = `https://checkout.stripe.com/pay/${paymentIntent.client_secret}`;
+
+    return c.json({ url });
+  } catch (error) {
+    console.error("Error creating Payment Intent:", error);
+    return c.json({ error: "Internal server error" }, 500);
+  }
+});
 
 app.post("/webhook", async (c) => {
   const stripe = new Stripe(c.env.STRIPE_API_KEY);

--- a/bff/stripe-webhook/worker-configuration.d.ts
+++ b/bff/stripe-webhook/worker-configuration.d.ts
@@ -6,6 +6,7 @@ declare namespace Cloudflare {
 		ENVIRONMENT: "staging" | "production";
 		STRIPE_API_KEY: string;
 		STRIPE_WEBHOOK_SECRET: string;
+		BFF_ENGINE_API_KEY: string;
 		HYPERDRIVE: Hyperdrive;
 	}
 }


### PR DESCRIPTION
## Issue

Closes #{issue_number}

## 概要

BFF Engineからのリクエストを受け付け、Stripe Payment Intentを作成するエンドポイントを追加しました。

## 詳細

-   `PUT /api/v1/payment-intents/:userId/:ticketCheckoutId` エンドポイントを新設しました。
-   `x-api-key` ヘッダーによるBFF Engineからの認証を導入しました。
-   `userId`と`ticketCheckoutId`の組み合わせで冪等性を保証します。既にPayment Intentが存在する場合は、そのURLを返します。
-   リクエストボディから`price` (セント単位), `currency`, `metadata`を受け取り、Stripe Payment Intentを作成します。
-   作成したPayment Intent IDを`ticketCheckoutSessions`テーブルに保存し、Stripe Checkout URLを返します。
-   関連する環境変数 (`BFF_ENGINE_API_KEY`)、型定義、READMEを更新しました。

## 画像・動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

| Before | After | Design |
| ------ | ----- | ------ |
|        |       |        |

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->

---

[Open in Web](https://www.cursor.com/agents?id=bc-fd8bd838-7a6b-466f-a236-99fc741cc260) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-fd8bd838-7a6b-466f-a236-99fc741cc260)