### PR TITLE
fix: DateTime型の型キャストエラーを修正

### DIFF
--- a/packages/db_types/lib/src/converters/date_time_converter.dart
+++ b/packages/db_types/lib/src/converters/date_time_converter.dart
@@ -1,0 +1,49 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+class DateTimeConverter implements JsonConverter<DateTime?, dynamic> {
+  const DateTimeConverter();
+
+  @override
+  DateTime? fromJson(dynamic json) {
+    if (json == null) {
+      return null;
+    }
+    if (json is DateTime) {
+      return json;
+    }
+    if (json is String) {
+      return DateTime.parse(json);
+    }
+    throw ArgumentError(
+      'Expected DateTime, String, or null, got ${json.runtimeType}',
+    );
+  }
+
+  @override
+  String? toJson(DateTime? object) {
+    return object?.toIso8601String();
+  }
+}
+
+class RequiredDateTimeConverter implements JsonConverter<DateTime, dynamic> {
+  const RequiredDateTimeConverter();
+
+  @override
+  DateTime fromJson(dynamic json) {
+    if (json == null) {
+      throw ArgumentError('Required DateTime field cannot be null');
+    }
+    if (json is DateTime) {
+      return json;
+    }
+    if (json is String) {
+      return DateTime.parse(json);
+    }
+    throw ArgumentError('Expected DateTime or String, got ${json.runtimeType}');
+  }
+
+  @override
+  String toJson(DateTime object) {
+    return object.toIso8601String();
+  }
+}

--- a/packages/db_types/lib/src/tables/companies.dart
+++ b/packages/db_types/lib/src/tables/companies.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'companies.freezed.dart';
@@ -7,8 +8,8 @@ part 'companies.g.dart';
 abstract class Companies with _$Companies {
   const factory Companies({
     required int id,
-    required DateTime createdAt,
-    required DateTime updatedAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
   }) = _Companies;
 
   factory Companies.fromJson(Map<String, dynamic> json) =>

--- a/packages/db_types/lib/src/tables/companies.freezed.dart
+++ b/packages/db_types/lib/src/tables/companies.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Companies {
 
- int get id; DateTime get createdAt; DateTime get updatedAt;
+ int get id;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;
 /// Create a copy of Companies
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $CompaniesCopyWith<$Res>  {
   factory $CompaniesCopyWith(Companies value, $Res Function(Companies) _then) = _$CompaniesCopyWithImpl;
 @useResult
 $Res call({
- int id, DateTime createdAt, DateTime updatedAt
+ int id,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -155,7 +155,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  DateTime createdAt,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Companies() when $default != null:
 return $default(_that.id,_that.createdAt,_that.updatedAt);case _:
@@ -176,7 +176,7 @@ return $default(_that.id,_that.createdAt,_that.updatedAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  DateTime createdAt,  DateTime updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _Companies():
 return $default(_that.id,_that.createdAt,_that.updatedAt);case _:
@@ -196,7 +196,7 @@ return $default(_that.id,_that.createdAt,_that.updatedAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  DateTime createdAt,  DateTime updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _Companies() when $default != null:
 return $default(_that.id,_that.createdAt,_that.updatedAt);case _:
@@ -211,12 +211,12 @@ return $default(_that.id,_that.createdAt,_that.updatedAt);case _:
 @JsonSerializable()
 
 class _Companies implements Companies {
-  const _Companies({required this.id, required this.createdAt, required this.updatedAt});
+  const _Companies({required this.id, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt});
   factory _Companies.fromJson(Map<String, dynamic> json) => _$CompaniesFromJson(json);
 
 @override final  int id;
-@override final  DateTime createdAt;
-@override final  DateTime updatedAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime updatedAt;
 
 /// Create a copy of Companies
 /// with the given fields replaced by the non-null parameter values.
@@ -251,7 +251,7 @@ abstract mixin class _$CompaniesCopyWith<$Res> implements $CompaniesCopyWith<$Re
   factory _$CompaniesCopyWith(_Companies value, $Res Function(_Companies) _then) = __$CompaniesCopyWithImpl;
 @override @useResult
 $Res call({
- int id, DateTime createdAt, DateTime updatedAt
+ int id,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 

--- a/packages/db_types/lib/src/tables/companies.g.dart
+++ b/packages/db_types/lib/src/tables/companies.g.dart
@@ -16,11 +16,11 @@ _Companies _$CompaniesFromJson(Map<String, dynamic> json) => $checkedCreate(
       id: $checkedConvert('id', (v) => (v as num).toInt()),
       createdAt: $checkedConvert(
         'created_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
       updatedAt: $checkedConvert(
         'updated_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
     );
     return val;
@@ -28,9 +28,10 @@ _Companies _$CompaniesFromJson(Map<String, dynamic> json) => $checkedCreate(
   fieldKeyMap: const {'createdAt': 'created_at', 'updatedAt': 'updated_at'},
 );
 
-Map<String, dynamic> _$CompaniesToJson(_Companies instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'created_at': instance.createdAt.toIso8601String(),
-      'updated_at': instance.updatedAt.toIso8601String(),
-    };
+Map<String, dynamic> _$CompaniesToJson(
+  _Companies instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const RequiredDateTimeConverter().toJson(instance.updatedAt),
+};

--- a/packages/db_types/lib/src/tables/company_drafts.dart
+++ b/packages/db_types/lib/src/tables/company_drafts.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'company_drafts.freezed.dart';
@@ -11,8 +12,8 @@ abstract class CompanyDrafts with _$CompanyDrafts {
     required String name,
     required String slug,
     required String? logoName,
-    required DateTime createdAt,
-    required DateTime updatedAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
   }) = _CompanyDrafts;
 
   factory CompanyDrafts.fromJson(Map<String, dynamic> json) =>
@@ -26,7 +27,7 @@ abstract class CompanyDraftApprovals with _$CompanyDraftApprovals {
     required int companyDraftId,
     // 承認したユーザがアカウントを削除した場合、nullになる
     required String? approvedById,
-    required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
   }) = _CompanyDraftApprovals;
 
   factory CompanyDraftApprovals.fromJson(Map<String, dynamic> json) =>

--- a/packages/db_types/lib/src/tables/company_drafts.freezed.dart
+++ b/packages/db_types/lib/src/tables/company_drafts.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CompanyDrafts {
 
- int get id; int get companyId; String get name; String get slug; String? get logoName; DateTime get createdAt; DateTime get updatedAt;
+ int get id; int get companyId; String get name; String get slug; String? get logoName;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;
 /// Create a copy of CompanyDrafts
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $CompanyDraftsCopyWith<$Res>  {
   factory $CompanyDraftsCopyWith(CompanyDrafts value, $Res Function(CompanyDrafts) _then) = _$CompanyDraftsCopyWithImpl;
 @useResult
 $Res call({
- int id, int companyId, String name, String slug, String? logoName, DateTime createdAt, DateTime updatedAt
+ int id, int companyId, String name, String slug, String? logoName,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -159,7 +159,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int companyId,  String name,  String slug,  String? logoName,  DateTime createdAt,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int companyId,  String name,  String slug,  String? logoName, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _CompanyDrafts() when $default != null:
 return $default(_that.id,_that.companyId,_that.name,_that.slug,_that.logoName,_that.createdAt,_that.updatedAt);case _:
@@ -180,7 +180,7 @@ return $default(_that.id,_that.companyId,_that.name,_that.slug,_that.logoName,_t
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int companyId,  String name,  String slug,  String? logoName,  DateTime createdAt,  DateTime updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int companyId,  String name,  String slug,  String? logoName, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _CompanyDrafts():
 return $default(_that.id,_that.companyId,_that.name,_that.slug,_that.logoName,_that.createdAt,_that.updatedAt);case _:
@@ -200,7 +200,7 @@ return $default(_that.id,_that.companyId,_that.name,_that.slug,_that.logoName,_t
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int companyId,  String name,  String slug,  String? logoName,  DateTime createdAt,  DateTime updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int companyId,  String name,  String slug,  String? logoName, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _CompanyDrafts() when $default != null:
 return $default(_that.id,_that.companyId,_that.name,_that.slug,_that.logoName,_that.createdAt,_that.updatedAt);case _:
@@ -215,7 +215,7 @@ return $default(_that.id,_that.companyId,_that.name,_that.slug,_that.logoName,_t
 @JsonSerializable()
 
 class _CompanyDrafts implements CompanyDrafts {
-  const _CompanyDrafts({required this.id, required this.companyId, required this.name, required this.slug, required this.logoName, required this.createdAt, required this.updatedAt});
+  const _CompanyDrafts({required this.id, required this.companyId, required this.name, required this.slug, required this.logoName, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt});
   factory _CompanyDrafts.fromJson(Map<String, dynamic> json) => _$CompanyDraftsFromJson(json);
 
 @override final  int id;
@@ -223,8 +223,8 @@ class _CompanyDrafts implements CompanyDrafts {
 @override final  String name;
 @override final  String slug;
 @override final  String? logoName;
-@override final  DateTime createdAt;
-@override final  DateTime updatedAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime updatedAt;
 
 /// Create a copy of CompanyDrafts
 /// with the given fields replaced by the non-null parameter values.
@@ -259,7 +259,7 @@ abstract mixin class _$CompanyDraftsCopyWith<$Res> implements $CompanyDraftsCopy
   factory _$CompanyDraftsCopyWith(_CompanyDrafts value, $Res Function(_CompanyDrafts) _then) = __$CompanyDraftsCopyWithImpl;
 @override @useResult
 $Res call({
- int id, int companyId, String name, String slug, String? logoName, DateTime createdAt, DateTime updatedAt
+ int id, int companyId, String name, String slug, String? logoName,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -297,7 +297,7 @@ as DateTime,
 mixin _$CompanyDraftApprovals {
 
  int get id; int get companyDraftId;// 承認したユーザがアカウントを削除した場合、nullになる
- String? get approvedById; DateTime get createdAt;
+ String? get approvedById;@RequiredDateTimeConverter() DateTime get createdAt;
 /// Create a copy of CompanyDraftApprovals
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -330,7 +330,7 @@ abstract mixin class $CompanyDraftApprovalsCopyWith<$Res>  {
   factory $CompanyDraftApprovalsCopyWith(CompanyDraftApprovals value, $Res Function(CompanyDraftApprovals) _then) = _$CompanyDraftApprovalsCopyWithImpl;
 @useResult
 $Res call({
- int id, int companyDraftId, String? approvedById, DateTime createdAt
+ int id, int companyDraftId, String? approvedById,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -438,7 +438,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int companyDraftId,  String? approvedById,  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int companyDraftId,  String? approvedById, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _CompanyDraftApprovals() when $default != null:
 return $default(_that.id,_that.companyDraftId,_that.approvedById,_that.createdAt);case _:
@@ -459,7 +459,7 @@ return $default(_that.id,_that.companyDraftId,_that.approvedById,_that.createdAt
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int companyDraftId,  String? approvedById,  DateTime createdAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int companyDraftId,  String? approvedById, @RequiredDateTimeConverter()  DateTime createdAt)  $default,) {final _that = this;
 switch (_that) {
 case _CompanyDraftApprovals():
 return $default(_that.id,_that.companyDraftId,_that.approvedById,_that.createdAt);case _:
@@ -479,7 +479,7 @@ return $default(_that.id,_that.companyDraftId,_that.approvedById,_that.createdAt
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int companyDraftId,  String? approvedById,  DateTime createdAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int companyDraftId,  String? approvedById, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,) {final _that = this;
 switch (_that) {
 case _CompanyDraftApprovals() when $default != null:
 return $default(_that.id,_that.companyDraftId,_that.approvedById,_that.createdAt);case _:
@@ -494,14 +494,14 @@ return $default(_that.id,_that.companyDraftId,_that.approvedById,_that.createdAt
 @JsonSerializable()
 
 class _CompanyDraftApprovals implements CompanyDraftApprovals {
-  const _CompanyDraftApprovals({required this.id, required this.companyDraftId, required this.approvedById, required this.createdAt});
+  const _CompanyDraftApprovals({required this.id, required this.companyDraftId, required this.approvedById, @RequiredDateTimeConverter() required this.createdAt});
   factory _CompanyDraftApprovals.fromJson(Map<String, dynamic> json) => _$CompanyDraftApprovalsFromJson(json);
 
 @override final  int id;
 @override final  int companyDraftId;
 // 承認したユーザがアカウントを削除した場合、nullになる
 @override final  String? approvedById;
-@override final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
 
 /// Create a copy of CompanyDraftApprovals
 /// with the given fields replaced by the non-null parameter values.
@@ -536,7 +536,7 @@ abstract mixin class _$CompanyDraftApprovalsCopyWith<$Res> implements $CompanyDr
   factory _$CompanyDraftApprovalsCopyWith(_CompanyDraftApprovals value, $Res Function(_CompanyDraftApprovals) _then) = __$CompanyDraftApprovalsCopyWithImpl;
 @override @useResult
 $Res call({
- int id, int companyDraftId, String? approvedById, DateTime createdAt
+ int id, int companyDraftId, String? approvedById,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 

--- a/packages/db_types/lib/src/tables/company_drafts.g.dart
+++ b/packages/db_types/lib/src/tables/company_drafts.g.dart
@@ -21,11 +21,11 @@ _CompanyDrafts _$CompanyDraftsFromJson(Map<String, dynamic> json) =>
           logoName: $checkedConvert('logo_name', (v) => v as String?),
           createdAt: $checkedConvert(
             'created_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
           updatedAt: $checkedConvert(
             'updated_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
         );
         return val;
@@ -38,16 +38,17 @@ _CompanyDrafts _$CompanyDraftsFromJson(Map<String, dynamic> json) =>
       },
     );
 
-Map<String, dynamic> _$CompanyDraftsToJson(_CompanyDrafts instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'company_id': instance.companyId,
-      'name': instance.name,
-      'slug': instance.slug,
-      'logo_name': instance.logoName,
-      'created_at': instance.createdAt.toIso8601String(),
-      'updated_at': instance.updatedAt.toIso8601String(),
-    };
+Map<String, dynamic> _$CompanyDraftsToJson(
+  _CompanyDrafts instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'company_id': instance.companyId,
+  'name': instance.name,
+  'slug': instance.slug,
+  'logo_name': instance.logoName,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const RequiredDateTimeConverter().toJson(instance.updatedAt),
+};
 
 _CompanyDraftApprovals _$CompanyDraftApprovalsFromJson(
   Map<String, dynamic> json,
@@ -64,7 +65,7 @@ _CompanyDraftApprovals _$CompanyDraftApprovalsFromJson(
       approvedById: $checkedConvert('approved_by_id', (v) => v as String?),
       createdAt: $checkedConvert(
         'created_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
     );
     return val;
@@ -82,5 +83,5 @@ Map<String, dynamic> _$CompanyDraftApprovalsToJson(
   'id': instance.id,
   'company_draft_id': instance.companyDraftId,
   'approved_by_id': instance.approvedById,
-  'created_at': instance.createdAt.toIso8601String(),
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
 };

--- a/packages/db_types/lib/src/tables/company_invitation.dart
+++ b/packages/db_types/lib/src/tables/company_invitation.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'company_invitation.freezed.dart';
@@ -8,9 +9,9 @@ abstract class CompanyInvitation with _$CompanyInvitation {
   const factory CompanyInvitation({
     required int companyId,
     required String key,
-    required DateTime createdAt,
-    required DateTime updatedAt,
-    required DateTime? disabledAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
+    @DateTimeConverter() required DateTime? disabledAt,
   }) = _CompanyInvitation;
 
   factory CompanyInvitation.fromJson(Map<String, dynamic> json) =>

--- a/packages/db_types/lib/src/tables/company_invitation.freezed.dart
+++ b/packages/db_types/lib/src/tables/company_invitation.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CompanyInvitation {
 
- int get companyId; String get key; DateTime get createdAt; DateTime get updatedAt; DateTime? get disabledAt;
+ int get companyId; String get key;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;@DateTimeConverter() DateTime? get disabledAt;
 /// Create a copy of CompanyInvitation
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $CompanyInvitationCopyWith<$Res>  {
   factory $CompanyInvitationCopyWith(CompanyInvitation value, $Res Function(CompanyInvitation) _then) = _$CompanyInvitationCopyWithImpl;
 @useResult
 $Res call({
- int companyId, String key, DateTime createdAt, DateTime updatedAt, DateTime? disabledAt
+ int companyId, String key,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt,@DateTimeConverter() DateTime? disabledAt
 });
 
 
@@ -157,7 +157,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int companyId,  String key,  DateTime createdAt,  DateTime updatedAt,  DateTime? disabledAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int companyId,  String key, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt, @DateTimeConverter()  DateTime? disabledAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _CompanyInvitation() when $default != null:
 return $default(_that.companyId,_that.key,_that.createdAt,_that.updatedAt,_that.disabledAt);case _:
@@ -178,7 +178,7 @@ return $default(_that.companyId,_that.key,_that.createdAt,_that.updatedAt,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int companyId,  String key,  DateTime createdAt,  DateTime updatedAt,  DateTime? disabledAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int companyId,  String key, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt, @DateTimeConverter()  DateTime? disabledAt)  $default,) {final _that = this;
 switch (_that) {
 case _CompanyInvitation():
 return $default(_that.companyId,_that.key,_that.createdAt,_that.updatedAt,_that.disabledAt);case _:
@@ -198,7 +198,7 @@ return $default(_that.companyId,_that.key,_that.createdAt,_that.updatedAt,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int companyId,  String key,  DateTime createdAt,  DateTime updatedAt,  DateTime? disabledAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int companyId,  String key, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt, @DateTimeConverter()  DateTime? disabledAt)?  $default,) {final _that = this;
 switch (_that) {
 case _CompanyInvitation() when $default != null:
 return $default(_that.companyId,_that.key,_that.createdAt,_that.updatedAt,_that.disabledAt);case _:
@@ -213,14 +213,14 @@ return $default(_that.companyId,_that.key,_that.createdAt,_that.updatedAt,_that.
 @JsonSerializable()
 
 class _CompanyInvitation implements CompanyInvitation {
-  const _CompanyInvitation({required this.companyId, required this.key, required this.createdAt, required this.updatedAt, required this.disabledAt});
+  const _CompanyInvitation({required this.companyId, required this.key, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt, @DateTimeConverter() required this.disabledAt});
   factory _CompanyInvitation.fromJson(Map<String, dynamic> json) => _$CompanyInvitationFromJson(json);
 
 @override final  int companyId;
 @override final  String key;
-@override final  DateTime createdAt;
-@override final  DateTime updatedAt;
-@override final  DateTime? disabledAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime updatedAt;
+@override@DateTimeConverter() final  DateTime? disabledAt;
 
 /// Create a copy of CompanyInvitation
 /// with the given fields replaced by the non-null parameter values.
@@ -255,7 +255,7 @@ abstract mixin class _$CompanyInvitationCopyWith<$Res> implements $CompanyInvita
   factory _$CompanyInvitationCopyWith(_CompanyInvitation value, $Res Function(_CompanyInvitation) _then) = __$CompanyInvitationCopyWithImpl;
 @override @useResult
 $Res call({
- int companyId, String key, DateTime createdAt, DateTime updatedAt, DateTime? disabledAt
+ int companyId, String key,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt,@DateTimeConverter() DateTime? disabledAt
 });
 
 

--- a/packages/db_types/lib/src/tables/company_invitation.g.dart
+++ b/packages/db_types/lib/src/tables/company_invitation.g.dart
@@ -18,15 +18,15 @@ _CompanyInvitation _$CompanyInvitationFromJson(Map<String, dynamic> json) =>
           key: $checkedConvert('key', (v) => v as String),
           createdAt: $checkedConvert(
             'created_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
           updatedAt: $checkedConvert(
             'updated_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
           disabledAt: $checkedConvert(
             'disabled_at',
-            (v) => v == null ? null : DateTime.parse(v as String),
+            (v) => const DateTimeConverter().fromJson(v),
           ),
         );
         return val;
@@ -39,11 +39,12 @@ _CompanyInvitation _$CompanyInvitationFromJson(Map<String, dynamic> json) =>
       },
     );
 
-Map<String, dynamic> _$CompanyInvitationToJson(_CompanyInvitation instance) =>
-    <String, dynamic>{
-      'company_id': instance.companyId,
-      'key': instance.key,
-      'created_at': instance.createdAt.toIso8601String(),
-      'updated_at': instance.updatedAt.toIso8601String(),
-      'disabled_at': instance.disabledAt?.toIso8601String(),
-    };
+Map<String, dynamic> _$CompanyInvitationToJson(
+  _CompanyInvitation instance,
+) => <String, dynamic>{
+  'company_id': instance.companyId,
+  'key': instance.key,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const RequiredDateTimeConverter().toJson(instance.updatedAt),
+  'disabled_at': const DateTimeConverter().toJson(instance.disabledAt),
+};

--- a/packages/db_types/lib/src/tables/individual_drafts.dart
+++ b/packages/db_types/lib/src/tables/individual_drafts.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'individual_drafts.freezed.dart';
@@ -11,8 +12,8 @@ abstract class IndividualDrafts with _$IndividualDrafts {
     required String name,
     required String slug,
     required String? logoName,
-    required DateTime createdAt,
-    required DateTime updatedAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
   }) = _IndividualDrafts;
 
   factory IndividualDrafts.fromJson(Map<String, dynamic> json) =>
@@ -26,7 +27,7 @@ abstract class IndividualDraftApprovals with _$IndividualDraftApprovals {
     required int individualDraftId,
     // 承認したユーザがアカウントを削除した場合、nullになる
     required String? approvedById,
-    required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
   }) = _IndividualDraftApprovals;
 
   factory IndividualDraftApprovals.fromJson(Map<String, dynamic> json) =>

--- a/packages/db_types/lib/src/tables/individual_drafts.freezed.dart
+++ b/packages/db_types/lib/src/tables/individual_drafts.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$IndividualDrafts {
 
- int get id; int get individualId; String get name; String get slug; String? get logoName; DateTime get createdAt; DateTime get updatedAt;
+ int get id; int get individualId; String get name; String get slug; String? get logoName;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;
 /// Create a copy of IndividualDrafts
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $IndividualDraftsCopyWith<$Res>  {
   factory $IndividualDraftsCopyWith(IndividualDrafts value, $Res Function(IndividualDrafts) _then) = _$IndividualDraftsCopyWithImpl;
 @useResult
 $Res call({
- int id, int individualId, String name, String slug, String? logoName, DateTime createdAt, DateTime updatedAt
+ int id, int individualId, String name, String slug, String? logoName,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -159,7 +159,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int individualId,  String name,  String slug,  String? logoName,  DateTime createdAt,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int individualId,  String name,  String slug,  String? logoName, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _IndividualDrafts() when $default != null:
 return $default(_that.id,_that.individualId,_that.name,_that.slug,_that.logoName,_that.createdAt,_that.updatedAt);case _:
@@ -180,7 +180,7 @@ return $default(_that.id,_that.individualId,_that.name,_that.slug,_that.logoName
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int individualId,  String name,  String slug,  String? logoName,  DateTime createdAt,  DateTime updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int individualId,  String name,  String slug,  String? logoName, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _IndividualDrafts():
 return $default(_that.id,_that.individualId,_that.name,_that.slug,_that.logoName,_that.createdAt,_that.updatedAt);case _:
@@ -200,7 +200,7 @@ return $default(_that.id,_that.individualId,_that.name,_that.slug,_that.logoName
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int individualId,  String name,  String slug,  String? logoName,  DateTime createdAt,  DateTime updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int individualId,  String name,  String slug,  String? logoName, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _IndividualDrafts() when $default != null:
 return $default(_that.id,_that.individualId,_that.name,_that.slug,_that.logoName,_that.createdAt,_that.updatedAt);case _:
@@ -215,7 +215,7 @@ return $default(_that.id,_that.individualId,_that.name,_that.slug,_that.logoName
 @JsonSerializable()
 
 class _IndividualDrafts implements IndividualDrafts {
-  const _IndividualDrafts({required this.id, required this.individualId, required this.name, required this.slug, required this.logoName, required this.createdAt, required this.updatedAt});
+  const _IndividualDrafts({required this.id, required this.individualId, required this.name, required this.slug, required this.logoName, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt});
   factory _IndividualDrafts.fromJson(Map<String, dynamic> json) => _$IndividualDraftsFromJson(json);
 
 @override final  int id;
@@ -223,8 +223,8 @@ class _IndividualDrafts implements IndividualDrafts {
 @override final  String name;
 @override final  String slug;
 @override final  String? logoName;
-@override final  DateTime createdAt;
-@override final  DateTime updatedAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime updatedAt;
 
 /// Create a copy of IndividualDrafts
 /// with the given fields replaced by the non-null parameter values.
@@ -259,7 +259,7 @@ abstract mixin class _$IndividualDraftsCopyWith<$Res> implements $IndividualDraf
   factory _$IndividualDraftsCopyWith(_IndividualDrafts value, $Res Function(_IndividualDrafts) _then) = __$IndividualDraftsCopyWithImpl;
 @override @useResult
 $Res call({
- int id, int individualId, String name, String slug, String? logoName, DateTime createdAt, DateTime updatedAt
+ int id, int individualId, String name, String slug, String? logoName,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -297,7 +297,7 @@ as DateTime,
 mixin _$IndividualDraftApprovals {
 
  int get id; int get individualDraftId;// 承認したユーザがアカウントを削除した場合、nullになる
- String? get approvedById; DateTime get createdAt;
+ String? get approvedById;@RequiredDateTimeConverter() DateTime get createdAt;
 /// Create a copy of IndividualDraftApprovals
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -330,7 +330,7 @@ abstract mixin class $IndividualDraftApprovalsCopyWith<$Res>  {
   factory $IndividualDraftApprovalsCopyWith(IndividualDraftApprovals value, $Res Function(IndividualDraftApprovals) _then) = _$IndividualDraftApprovalsCopyWithImpl;
 @useResult
 $Res call({
- int id, int individualDraftId, String? approvedById, DateTime createdAt
+ int id, int individualDraftId, String? approvedById,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -438,7 +438,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int individualDraftId,  String? approvedById,  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int individualDraftId,  String? approvedById, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _IndividualDraftApprovals() when $default != null:
 return $default(_that.id,_that.individualDraftId,_that.approvedById,_that.createdAt);case _:
@@ -459,7 +459,7 @@ return $default(_that.id,_that.individualDraftId,_that.approvedById,_that.create
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int individualDraftId,  String? approvedById,  DateTime createdAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int individualDraftId,  String? approvedById, @RequiredDateTimeConverter()  DateTime createdAt)  $default,) {final _that = this;
 switch (_that) {
 case _IndividualDraftApprovals():
 return $default(_that.id,_that.individualDraftId,_that.approvedById,_that.createdAt);case _:
@@ -479,7 +479,7 @@ return $default(_that.id,_that.individualDraftId,_that.approvedById,_that.create
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int individualDraftId,  String? approvedById,  DateTime createdAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int individualDraftId,  String? approvedById, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,) {final _that = this;
 switch (_that) {
 case _IndividualDraftApprovals() when $default != null:
 return $default(_that.id,_that.individualDraftId,_that.approvedById,_that.createdAt);case _:
@@ -494,14 +494,14 @@ return $default(_that.id,_that.individualDraftId,_that.approvedById,_that.create
 @JsonSerializable()
 
 class _IndividualDraftApprovals implements IndividualDraftApprovals {
-  const _IndividualDraftApprovals({required this.id, required this.individualDraftId, required this.approvedById, required this.createdAt});
+  const _IndividualDraftApprovals({required this.id, required this.individualDraftId, required this.approvedById, @RequiredDateTimeConverter() required this.createdAt});
   factory _IndividualDraftApprovals.fromJson(Map<String, dynamic> json) => _$IndividualDraftApprovalsFromJson(json);
 
 @override final  int id;
 @override final  int individualDraftId;
 // 承認したユーザがアカウントを削除した場合、nullになる
 @override final  String? approvedById;
-@override final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
 
 /// Create a copy of IndividualDraftApprovals
 /// with the given fields replaced by the non-null parameter values.
@@ -536,7 +536,7 @@ abstract mixin class _$IndividualDraftApprovalsCopyWith<$Res> implements $Indivi
   factory _$IndividualDraftApprovalsCopyWith(_IndividualDraftApprovals value, $Res Function(_IndividualDraftApprovals) _then) = __$IndividualDraftApprovalsCopyWithImpl;
 @override @useResult
 $Res call({
- int id, int individualDraftId, String? approvedById, DateTime createdAt
+ int id, int individualDraftId, String? approvedById,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 

--- a/packages/db_types/lib/src/tables/individual_drafts.g.dart
+++ b/packages/db_types/lib/src/tables/individual_drafts.g.dart
@@ -24,11 +24,11 @@ _IndividualDrafts _$IndividualDraftsFromJson(Map<String, dynamic> json) =>
           logoName: $checkedConvert('logo_name', (v) => v as String?),
           createdAt: $checkedConvert(
             'created_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
           updatedAt: $checkedConvert(
             'updated_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
         );
         return val;
@@ -41,16 +41,17 @@ _IndividualDrafts _$IndividualDraftsFromJson(Map<String, dynamic> json) =>
       },
     );
 
-Map<String, dynamic> _$IndividualDraftsToJson(_IndividualDrafts instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'individual_id': instance.individualId,
-      'name': instance.name,
-      'slug': instance.slug,
-      'logo_name': instance.logoName,
-      'created_at': instance.createdAt.toIso8601String(),
-      'updated_at': instance.updatedAt.toIso8601String(),
-    };
+Map<String, dynamic> _$IndividualDraftsToJson(
+  _IndividualDrafts instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'individual_id': instance.individualId,
+  'name': instance.name,
+  'slug': instance.slug,
+  'logo_name': instance.logoName,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const RequiredDateTimeConverter().toJson(instance.updatedAt),
+};
 
 _IndividualDraftApprovals _$IndividualDraftApprovalsFromJson(
   Map<String, dynamic> json,
@@ -67,7 +68,7 @@ _IndividualDraftApprovals _$IndividualDraftApprovalsFromJson(
       approvedById: $checkedConvert('approved_by_id', (v) => v as String?),
       createdAt: $checkedConvert(
         'created_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
     );
     return val;
@@ -85,5 +86,5 @@ Map<String, dynamic> _$IndividualDraftApprovalsToJson(
   'id': instance.id,
   'individual_draft_id': instance.individualDraftId,
   'approved_by_id': instance.approvedById,
-  'created_at': instance.createdAt.toIso8601String(),
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
 };

--- a/packages/db_types/lib/src/tables/individuals.dart
+++ b/packages/db_types/lib/src/tables/individuals.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'individuals.freezed.dart';
@@ -8,8 +9,8 @@ abstract class Individuals with _$Individuals {
   const factory Individuals({
     required int id,
     required String userId,
-    required DateTime createdAt,
-    required DateTime updatedAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
   }) = _Individuals;
 
   factory Individuals.fromJson(Map<String, dynamic> json) =>

--- a/packages/db_types/lib/src/tables/individuals.freezed.dart
+++ b/packages/db_types/lib/src/tables/individuals.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Individuals {
 
- int get id; String get userId; DateTime get createdAt; DateTime get updatedAt;
+ int get id; String get userId;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;
 /// Create a copy of Individuals
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $IndividualsCopyWith<$Res>  {
   factory $IndividualsCopyWith(Individuals value, $Res Function(Individuals) _then) = _$IndividualsCopyWithImpl;
 @useResult
 $Res call({
- int id, String userId, DateTime createdAt, DateTime updatedAt
+ int id, String userId,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -156,7 +156,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String userId,  DateTime createdAt,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String userId, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Individuals() when $default != null:
 return $default(_that.id,_that.userId,_that.createdAt,_that.updatedAt);case _:
@@ -177,7 +177,7 @@ return $default(_that.id,_that.userId,_that.createdAt,_that.updatedAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String userId,  DateTime createdAt,  DateTime updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String userId, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _Individuals():
 return $default(_that.id,_that.userId,_that.createdAt,_that.updatedAt);case _:
@@ -197,7 +197,7 @@ return $default(_that.id,_that.userId,_that.createdAt,_that.updatedAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String userId,  DateTime createdAt,  DateTime updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String userId, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _Individuals() when $default != null:
 return $default(_that.id,_that.userId,_that.createdAt,_that.updatedAt);case _:
@@ -212,13 +212,13 @@ return $default(_that.id,_that.userId,_that.createdAt,_that.updatedAt);case _:
 @JsonSerializable()
 
 class _Individuals implements Individuals {
-  const _Individuals({required this.id, required this.userId, required this.createdAt, required this.updatedAt});
+  const _Individuals({required this.id, required this.userId, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt});
   factory _Individuals.fromJson(Map<String, dynamic> json) => _$IndividualsFromJson(json);
 
 @override final  int id;
 @override final  String userId;
-@override final  DateTime createdAt;
-@override final  DateTime updatedAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime updatedAt;
 
 /// Create a copy of Individuals
 /// with the given fields replaced by the non-null parameter values.
@@ -253,7 +253,7 @@ abstract mixin class _$IndividualsCopyWith<$Res> implements $IndividualsCopyWith
   factory _$IndividualsCopyWith(_Individuals value, $Res Function(_Individuals) _then) = __$IndividualsCopyWithImpl;
 @override @useResult
 $Res call({
- int id, String userId, DateTime createdAt, DateTime updatedAt
+ int id, String userId,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 

--- a/packages/db_types/lib/src/tables/individuals.g.dart
+++ b/packages/db_types/lib/src/tables/individuals.g.dart
@@ -17,11 +17,11 @@ _Individuals _$IndividualsFromJson(Map<String, dynamic> json) => $checkedCreate(
       userId: $checkedConvert('user_id', (v) => v as String),
       createdAt: $checkedConvert(
         'created_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
       updatedAt: $checkedConvert(
         'updated_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
     );
     return val;
@@ -33,10 +33,11 @@ _Individuals _$IndividualsFromJson(Map<String, dynamic> json) => $checkedCreate(
   },
 );
 
-Map<String, dynamic> _$IndividualsToJson(_Individuals instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'user_id': instance.userId,
-      'created_at': instance.createdAt.toIso8601String(),
-      'updated_at': instance.updatedAt.toIso8601String(),
-    };
+Map<String, dynamic> _$IndividualsToJson(
+  _Individuals instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'user_id': instance.userId,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const RequiredDateTimeConverter().toJson(instance.updatedAt),
+};

--- a/packages/db_types/lib/src/tables/news.dart
+++ b/packages/db_types/lib/src/tables/news.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'news.freezed.dart';
@@ -9,10 +10,10 @@ abstract class News with _$News {
     required int id,
     required String title,
     String? url,
-    DateTime? startsAt,
-    DateTime? endsAt,
-    required DateTime createdAt,
-    required DateTime updatedAt,
+    @DateTimeConverter() DateTime? startsAt,
+    @DateTimeConverter() DateTime? endsAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
   }) = _News;
 
   factory News.fromJson(Map<String, dynamic> json) => _$NewsFromJson(json);

--- a/packages/db_types/lib/src/tables/news.freezed.dart
+++ b/packages/db_types/lib/src/tables/news.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$News {
 
- int get id; String get title; String? get url; DateTime? get startsAt; DateTime? get endsAt; DateTime get createdAt; DateTime get updatedAt;
+ int get id; String get title; String? get url;@DateTimeConverter() DateTime? get startsAt;@DateTimeConverter() DateTime? get endsAt;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;
 /// Create a copy of News
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $NewsCopyWith<$Res>  {
   factory $NewsCopyWith(News value, $Res Function(News) _then) = _$NewsCopyWithImpl;
 @useResult
 $Res call({
- int id, String title, String? url, DateTime? startsAt, DateTime? endsAt, DateTime createdAt, DateTime updatedAt
+ int id, String title, String? url,@DateTimeConverter() DateTime? startsAt,@DateTimeConverter() DateTime? endsAt,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -159,7 +159,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String title,  String? url,  DateTime? startsAt,  DateTime? endsAt,  DateTime createdAt,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String title,  String? url, @DateTimeConverter()  DateTime? startsAt, @DateTimeConverter()  DateTime? endsAt, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _News() when $default != null:
 return $default(_that.id,_that.title,_that.url,_that.startsAt,_that.endsAt,_that.createdAt,_that.updatedAt);case _:
@@ -180,7 +180,7 @@ return $default(_that.id,_that.title,_that.url,_that.startsAt,_that.endsAt,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String title,  String? url,  DateTime? startsAt,  DateTime? endsAt,  DateTime createdAt,  DateTime updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String title,  String? url, @DateTimeConverter()  DateTime? startsAt, @DateTimeConverter()  DateTime? endsAt, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _News():
 return $default(_that.id,_that.title,_that.url,_that.startsAt,_that.endsAt,_that.createdAt,_that.updatedAt);case _:
@@ -200,7 +200,7 @@ return $default(_that.id,_that.title,_that.url,_that.startsAt,_that.endsAt,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String title,  String? url,  DateTime? startsAt,  DateTime? endsAt,  DateTime createdAt,  DateTime updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String title,  String? url, @DateTimeConverter()  DateTime? startsAt, @DateTimeConverter()  DateTime? endsAt, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _News() when $default != null:
 return $default(_that.id,_that.title,_that.url,_that.startsAt,_that.endsAt,_that.createdAt,_that.updatedAt);case _:
@@ -215,16 +215,16 @@ return $default(_that.id,_that.title,_that.url,_that.startsAt,_that.endsAt,_that
 @JsonSerializable()
 
 class _News implements News {
-  const _News({required this.id, required this.title, this.url, this.startsAt, this.endsAt, required this.createdAt, required this.updatedAt});
+  const _News({required this.id, required this.title, this.url, @DateTimeConverter() this.startsAt, @DateTimeConverter() this.endsAt, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt});
   factory _News.fromJson(Map<String, dynamic> json) => _$NewsFromJson(json);
 
 @override final  int id;
 @override final  String title;
 @override final  String? url;
-@override final  DateTime? startsAt;
-@override final  DateTime? endsAt;
-@override final  DateTime createdAt;
-@override final  DateTime updatedAt;
+@override@DateTimeConverter() final  DateTime? startsAt;
+@override@DateTimeConverter() final  DateTime? endsAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime updatedAt;
 
 /// Create a copy of News
 /// with the given fields replaced by the non-null parameter values.
@@ -259,7 +259,7 @@ abstract mixin class _$NewsCopyWith<$Res> implements $NewsCopyWith<$Res> {
   factory _$NewsCopyWith(_News value, $Res Function(_News) _then) = __$NewsCopyWithImpl;
 @override @useResult
 $Res call({
- int id, String title, String? url, DateTime? startsAt, DateTime? endsAt, DateTime createdAt, DateTime updatedAt
+ int id, String title, String? url,@DateTimeConverter() DateTime? startsAt,@DateTimeConverter() DateTime? endsAt,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 

--- a/packages/db_types/lib/src/tables/news.g.dart
+++ b/packages/db_types/lib/src/tables/news.g.dart
@@ -18,19 +18,19 @@ _News _$NewsFromJson(Map<String, dynamic> json) => $checkedCreate(
       url: $checkedConvert('url', (v) => v as String?),
       startsAt: $checkedConvert(
         'starts_at',
-        (v) => v == null ? null : DateTime.parse(v as String),
+        (v) => const DateTimeConverter().fromJson(v),
       ),
       endsAt: $checkedConvert(
         'ends_at',
-        (v) => v == null ? null : DateTime.parse(v as String),
+        (v) => const DateTimeConverter().fromJson(v),
       ),
       createdAt: $checkedConvert(
         'created_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
       updatedAt: $checkedConvert(
         'updated_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
     );
     return val;
@@ -47,8 +47,8 @@ Map<String, dynamic> _$NewsToJson(_News instance) => <String, dynamic>{
   'id': instance.id,
   'title': instance.title,
   'url': instance.url,
-  'starts_at': instance.startsAt?.toIso8601String(),
-  'ends_at': instance.endsAt?.toIso8601String(),
-  'created_at': instance.createdAt.toIso8601String(),
-  'updated_at': instance.updatedAt.toIso8601String(),
+  'starts_at': const DateTimeConverter().toJson(instance.startsAt),
+  'ends_at': const DateTimeConverter().toJson(instance.endsAt),
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const RequiredDateTimeConverter().toJson(instance.updatedAt),
 };

--- a/packages/db_types/lib/src/tables/sponsors.dart
+++ b/packages/db_types/lib/src/tables/sponsors.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'sponsors.freezed.dart';
@@ -8,7 +9,7 @@ abstract class SponsorIndividuals with _$SponsorIndividuals {
   const factory SponsorIndividuals({
     required int id,
     required int individualId,
-    required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
   }) = _SponsorIndividuals;
 
   factory SponsorIndividuals.fromJson(Map<String, dynamic> json) =>
@@ -20,7 +21,7 @@ abstract class SponsorNamingRights with _$SponsorNamingRights {
   const factory SponsorNamingRights({
     required int id,
     required int companyId,
-    required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
   }) = _SponsorNamingRights;
 
   factory SponsorNamingRights.fromJson(Map<String, dynamic> json) =>
@@ -32,7 +33,7 @@ abstract class SponsorNameplate with _$SponsorNameplate {
   const factory SponsorNameplate({
     required int id,
     required int companyId,
-    required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
   }) = _SponsorNameplate;
 
   factory SponsorNameplate.fromJson(Map<String, dynamic> json) =>
@@ -44,7 +45,7 @@ abstract class SponsorLunch with _$SponsorLunch {
   const factory SponsorLunch({
     required int id,
     required int companyId,
-    required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
   }) = _SponsorLunch;
 
   factory SponsorLunch.fromJson(Map<String, dynamic> json) =>
@@ -56,7 +57,7 @@ abstract class SponsorScholarship with _$SponsorScholarship {
   const factory SponsorScholarship({
     required int id,
     required int companyId,
-    required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
   }) = _SponsorScholarship;
 
   factory SponsorScholarship.fromJson(Map<String, dynamic> json) =>

--- a/packages/db_types/lib/src/tables/sponsors.freezed.dart
+++ b/packages/db_types/lib/src/tables/sponsors.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SponsorIndividuals {
 
- int get id; int get individualId; DateTime get createdAt;
+ int get id; int get individualId;@RequiredDateTimeConverter() DateTime get createdAt;
 /// Create a copy of SponsorIndividuals
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $SponsorIndividualsCopyWith<$Res>  {
   factory $SponsorIndividualsCopyWith(SponsorIndividuals value, $Res Function(SponsorIndividuals) _then) = _$SponsorIndividualsCopyWithImpl;
 @useResult
 $Res call({
- int id, int individualId, DateTime createdAt
+ int id, int individualId,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -155,7 +155,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int individualId,  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int individualId, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _SponsorIndividuals() when $default != null:
 return $default(_that.id,_that.individualId,_that.createdAt);case _:
@@ -176,7 +176,7 @@ return $default(_that.id,_that.individualId,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int individualId,  DateTime createdAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int individualId, @RequiredDateTimeConverter()  DateTime createdAt)  $default,) {final _that = this;
 switch (_that) {
 case _SponsorIndividuals():
 return $default(_that.id,_that.individualId,_that.createdAt);case _:
@@ -196,7 +196,7 @@ return $default(_that.id,_that.individualId,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int individualId,  DateTime createdAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int individualId, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,) {final _that = this;
 switch (_that) {
 case _SponsorIndividuals() when $default != null:
 return $default(_that.id,_that.individualId,_that.createdAt);case _:
@@ -211,12 +211,12 @@ return $default(_that.id,_that.individualId,_that.createdAt);case _:
 @JsonSerializable()
 
 class _SponsorIndividuals implements SponsorIndividuals {
-  const _SponsorIndividuals({required this.id, required this.individualId, required this.createdAt});
+  const _SponsorIndividuals({required this.id, required this.individualId, @RequiredDateTimeConverter() required this.createdAt});
   factory _SponsorIndividuals.fromJson(Map<String, dynamic> json) => _$SponsorIndividualsFromJson(json);
 
 @override final  int id;
 @override final  int individualId;
-@override final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
 
 /// Create a copy of SponsorIndividuals
 /// with the given fields replaced by the non-null parameter values.
@@ -251,7 +251,7 @@ abstract mixin class _$SponsorIndividualsCopyWith<$Res> implements $SponsorIndiv
   factory _$SponsorIndividualsCopyWith(_SponsorIndividuals value, $Res Function(_SponsorIndividuals) _then) = __$SponsorIndividualsCopyWithImpl;
 @override @useResult
 $Res call({
- int id, int individualId, DateTime createdAt
+ int id, int individualId,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -284,7 +284,7 @@ as DateTime,
 /// @nodoc
 mixin _$SponsorNamingRights {
 
- int get id; int get companyId; DateTime get createdAt;
+ int get id; int get companyId;@RequiredDateTimeConverter() DateTime get createdAt;
 /// Create a copy of SponsorNamingRights
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -317,7 +317,7 @@ abstract mixin class $SponsorNamingRightsCopyWith<$Res>  {
   factory $SponsorNamingRightsCopyWith(SponsorNamingRights value, $Res Function(SponsorNamingRights) _then) = _$SponsorNamingRightsCopyWithImpl;
 @useResult
 $Res call({
- int id, int companyId, DateTime createdAt
+ int id, int companyId,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -424,7 +424,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int companyId,  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int companyId, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _SponsorNamingRights() when $default != null:
 return $default(_that.id,_that.companyId,_that.createdAt);case _:
@@ -445,7 +445,7 @@ return $default(_that.id,_that.companyId,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int companyId,  DateTime createdAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int companyId, @RequiredDateTimeConverter()  DateTime createdAt)  $default,) {final _that = this;
 switch (_that) {
 case _SponsorNamingRights():
 return $default(_that.id,_that.companyId,_that.createdAt);case _:
@@ -465,7 +465,7 @@ return $default(_that.id,_that.companyId,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int companyId,  DateTime createdAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int companyId, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,) {final _that = this;
 switch (_that) {
 case _SponsorNamingRights() when $default != null:
 return $default(_that.id,_that.companyId,_that.createdAt);case _:
@@ -480,12 +480,12 @@ return $default(_that.id,_that.companyId,_that.createdAt);case _:
 @JsonSerializable()
 
 class _SponsorNamingRights implements SponsorNamingRights {
-  const _SponsorNamingRights({required this.id, required this.companyId, required this.createdAt});
+  const _SponsorNamingRights({required this.id, required this.companyId, @RequiredDateTimeConverter() required this.createdAt});
   factory _SponsorNamingRights.fromJson(Map<String, dynamic> json) => _$SponsorNamingRightsFromJson(json);
 
 @override final  int id;
 @override final  int companyId;
-@override final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
 
 /// Create a copy of SponsorNamingRights
 /// with the given fields replaced by the non-null parameter values.
@@ -520,7 +520,7 @@ abstract mixin class _$SponsorNamingRightsCopyWith<$Res> implements $SponsorNami
   factory _$SponsorNamingRightsCopyWith(_SponsorNamingRights value, $Res Function(_SponsorNamingRights) _then) = __$SponsorNamingRightsCopyWithImpl;
 @override @useResult
 $Res call({
- int id, int companyId, DateTime createdAt
+ int id, int companyId,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -553,7 +553,7 @@ as DateTime,
 /// @nodoc
 mixin _$SponsorNameplate {
 
- int get id; int get companyId; DateTime get createdAt;
+ int get id; int get companyId;@RequiredDateTimeConverter() DateTime get createdAt;
 /// Create a copy of SponsorNameplate
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -586,7 +586,7 @@ abstract mixin class $SponsorNameplateCopyWith<$Res>  {
   factory $SponsorNameplateCopyWith(SponsorNameplate value, $Res Function(SponsorNameplate) _then) = _$SponsorNameplateCopyWithImpl;
 @useResult
 $Res call({
- int id, int companyId, DateTime createdAt
+ int id, int companyId,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -693,7 +693,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int companyId,  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int companyId, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _SponsorNameplate() when $default != null:
 return $default(_that.id,_that.companyId,_that.createdAt);case _:
@@ -714,7 +714,7 @@ return $default(_that.id,_that.companyId,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int companyId,  DateTime createdAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int companyId, @RequiredDateTimeConverter()  DateTime createdAt)  $default,) {final _that = this;
 switch (_that) {
 case _SponsorNameplate():
 return $default(_that.id,_that.companyId,_that.createdAt);case _:
@@ -734,7 +734,7 @@ return $default(_that.id,_that.companyId,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int companyId,  DateTime createdAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int companyId, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,) {final _that = this;
 switch (_that) {
 case _SponsorNameplate() when $default != null:
 return $default(_that.id,_that.companyId,_that.createdAt);case _:
@@ -749,12 +749,12 @@ return $default(_that.id,_that.companyId,_that.createdAt);case _:
 @JsonSerializable()
 
 class _SponsorNameplate implements SponsorNameplate {
-  const _SponsorNameplate({required this.id, required this.companyId, required this.createdAt});
+  const _SponsorNameplate({required this.id, required this.companyId, @RequiredDateTimeConverter() required this.createdAt});
   factory _SponsorNameplate.fromJson(Map<String, dynamic> json) => _$SponsorNameplateFromJson(json);
 
 @override final  int id;
 @override final  int companyId;
-@override final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
 
 /// Create a copy of SponsorNameplate
 /// with the given fields replaced by the non-null parameter values.
@@ -789,7 +789,7 @@ abstract mixin class _$SponsorNameplateCopyWith<$Res> implements $SponsorNamepla
   factory _$SponsorNameplateCopyWith(_SponsorNameplate value, $Res Function(_SponsorNameplate) _then) = __$SponsorNameplateCopyWithImpl;
 @override @useResult
 $Res call({
- int id, int companyId, DateTime createdAt
+ int id, int companyId,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -822,7 +822,7 @@ as DateTime,
 /// @nodoc
 mixin _$SponsorLunch {
 
- int get id; int get companyId; DateTime get createdAt;
+ int get id; int get companyId;@RequiredDateTimeConverter() DateTime get createdAt;
 /// Create a copy of SponsorLunch
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -855,7 +855,7 @@ abstract mixin class $SponsorLunchCopyWith<$Res>  {
   factory $SponsorLunchCopyWith(SponsorLunch value, $Res Function(SponsorLunch) _then) = _$SponsorLunchCopyWithImpl;
 @useResult
 $Res call({
- int id, int companyId, DateTime createdAt
+ int id, int companyId,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -962,7 +962,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int companyId,  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int companyId, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _SponsorLunch() when $default != null:
 return $default(_that.id,_that.companyId,_that.createdAt);case _:
@@ -983,7 +983,7 @@ return $default(_that.id,_that.companyId,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int companyId,  DateTime createdAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int companyId, @RequiredDateTimeConverter()  DateTime createdAt)  $default,) {final _that = this;
 switch (_that) {
 case _SponsorLunch():
 return $default(_that.id,_that.companyId,_that.createdAt);case _:
@@ -1003,7 +1003,7 @@ return $default(_that.id,_that.companyId,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int companyId,  DateTime createdAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int companyId, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,) {final _that = this;
 switch (_that) {
 case _SponsorLunch() when $default != null:
 return $default(_that.id,_that.companyId,_that.createdAt);case _:
@@ -1018,12 +1018,12 @@ return $default(_that.id,_that.companyId,_that.createdAt);case _:
 @JsonSerializable()
 
 class _SponsorLunch implements SponsorLunch {
-  const _SponsorLunch({required this.id, required this.companyId, required this.createdAt});
+  const _SponsorLunch({required this.id, required this.companyId, @RequiredDateTimeConverter() required this.createdAt});
   factory _SponsorLunch.fromJson(Map<String, dynamic> json) => _$SponsorLunchFromJson(json);
 
 @override final  int id;
 @override final  int companyId;
-@override final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
 
 /// Create a copy of SponsorLunch
 /// with the given fields replaced by the non-null parameter values.
@@ -1058,7 +1058,7 @@ abstract mixin class _$SponsorLunchCopyWith<$Res> implements $SponsorLunchCopyWi
   factory _$SponsorLunchCopyWith(_SponsorLunch value, $Res Function(_SponsorLunch) _then) = __$SponsorLunchCopyWithImpl;
 @override @useResult
 $Res call({
- int id, int companyId, DateTime createdAt
+ int id, int companyId,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -1091,7 +1091,7 @@ as DateTime,
 /// @nodoc
 mixin _$SponsorScholarship {
 
- int get id; int get companyId; DateTime get createdAt;
+ int get id; int get companyId;@RequiredDateTimeConverter() DateTime get createdAt;
 /// Create a copy of SponsorScholarship
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1124,7 +1124,7 @@ abstract mixin class $SponsorScholarshipCopyWith<$Res>  {
   factory $SponsorScholarshipCopyWith(SponsorScholarship value, $Res Function(SponsorScholarship) _then) = _$SponsorScholarshipCopyWithImpl;
 @useResult
 $Res call({
- int id, int companyId, DateTime createdAt
+ int id, int companyId,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -1231,7 +1231,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int companyId,  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int companyId, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _SponsorScholarship() when $default != null:
 return $default(_that.id,_that.companyId,_that.createdAt);case _:
@@ -1252,7 +1252,7 @@ return $default(_that.id,_that.companyId,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int companyId,  DateTime createdAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int companyId, @RequiredDateTimeConverter()  DateTime createdAt)  $default,) {final _that = this;
 switch (_that) {
 case _SponsorScholarship():
 return $default(_that.id,_that.companyId,_that.createdAt);case _:
@@ -1272,7 +1272,7 @@ return $default(_that.id,_that.companyId,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int companyId,  DateTime createdAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int companyId, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,) {final _that = this;
 switch (_that) {
 case _SponsorScholarship() when $default != null:
 return $default(_that.id,_that.companyId,_that.createdAt);case _:
@@ -1287,12 +1287,12 @@ return $default(_that.id,_that.companyId,_that.createdAt);case _:
 @JsonSerializable()
 
 class _SponsorScholarship implements SponsorScholarship {
-  const _SponsorScholarship({required this.id, required this.companyId, required this.createdAt});
+  const _SponsorScholarship({required this.id, required this.companyId, @RequiredDateTimeConverter() required this.createdAt});
   factory _SponsorScholarship.fromJson(Map<String, dynamic> json) => _$SponsorScholarshipFromJson(json);
 
 @override final  int id;
 @override final  int companyId;
-@override final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
 
 /// Create a copy of SponsorScholarship
 /// with the given fields replaced by the non-null parameter values.
@@ -1327,7 +1327,7 @@ abstract mixin class _$SponsorScholarshipCopyWith<$Res> implements $SponsorSchol
   factory _$SponsorScholarshipCopyWith(_SponsorScholarship value, $Res Function(_SponsorScholarship) _then) = __$SponsorScholarshipCopyWithImpl;
 @override @useResult
 $Res call({
- int id, int companyId, DateTime createdAt
+ int id, int companyId,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 

--- a/packages/db_types/lib/src/tables/sponsors.g.dart
+++ b/packages/db_types/lib/src/tables/sponsors.g.dart
@@ -21,7 +21,7 @@ _SponsorIndividuals _$SponsorIndividualsFromJson(Map<String, dynamic> json) =>
           ),
           createdAt: $checkedConvert(
             'created_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
         );
         return val;
@@ -32,12 +32,13 @@ _SponsorIndividuals _$SponsorIndividualsFromJson(Map<String, dynamic> json) =>
       },
     );
 
-Map<String, dynamic> _$SponsorIndividualsToJson(_SponsorIndividuals instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'individual_id': instance.individualId,
-      'created_at': instance.createdAt.toIso8601String(),
-    };
+Map<String, dynamic> _$SponsorIndividualsToJson(
+  _SponsorIndividuals instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'individual_id': instance.individualId,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+};
 
 _SponsorNamingRights _$SponsorNamingRightsFromJson(Map<String, dynamic> json) =>
     $checkedCreate(
@@ -49,7 +50,7 @@ _SponsorNamingRights _$SponsorNamingRightsFromJson(Map<String, dynamic> json) =>
           companyId: $checkedConvert('company_id', (v) => (v as num).toInt()),
           createdAt: $checkedConvert(
             'created_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
         );
         return val;
@@ -62,7 +63,7 @@ Map<String, dynamic> _$SponsorNamingRightsToJson(
 ) => <String, dynamic>{
   'id': instance.id,
   'company_id': instance.companyId,
-  'created_at': instance.createdAt.toIso8601String(),
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
 };
 
 _SponsorNameplate _$SponsorNameplateFromJson(Map<String, dynamic> json) =>
@@ -75,7 +76,7 @@ _SponsorNameplate _$SponsorNameplateFromJson(Map<String, dynamic> json) =>
           companyId: $checkedConvert('company_id', (v) => (v as num).toInt()),
           createdAt: $checkedConvert(
             'created_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
         );
         return val;
@@ -83,12 +84,13 @@ _SponsorNameplate _$SponsorNameplateFromJson(Map<String, dynamic> json) =>
       fieldKeyMap: const {'companyId': 'company_id', 'createdAt': 'created_at'},
     );
 
-Map<String, dynamic> _$SponsorNameplateToJson(_SponsorNameplate instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'company_id': instance.companyId,
-      'created_at': instance.createdAt.toIso8601String(),
-    };
+Map<String, dynamic> _$SponsorNameplateToJson(
+  _SponsorNameplate instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'company_id': instance.companyId,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+};
 
 _SponsorLunch _$SponsorLunchFromJson(Map<String, dynamic> json) =>
     $checkedCreate(
@@ -100,7 +102,7 @@ _SponsorLunch _$SponsorLunchFromJson(Map<String, dynamic> json) =>
           companyId: $checkedConvert('company_id', (v) => (v as num).toInt()),
           createdAt: $checkedConvert(
             'created_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
         );
         return val;
@@ -108,12 +110,13 @@ _SponsorLunch _$SponsorLunchFromJson(Map<String, dynamic> json) =>
       fieldKeyMap: const {'companyId': 'company_id', 'createdAt': 'created_at'},
     );
 
-Map<String, dynamic> _$SponsorLunchToJson(_SponsorLunch instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'company_id': instance.companyId,
-      'created_at': instance.createdAt.toIso8601String(),
-    };
+Map<String, dynamic> _$SponsorLunchToJson(
+  _SponsorLunch instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'company_id': instance.companyId,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+};
 
 _SponsorScholarship _$SponsorScholarshipFromJson(Map<String, dynamic> json) =>
     $checkedCreate(
@@ -125,7 +128,7 @@ _SponsorScholarship _$SponsorScholarshipFromJson(Map<String, dynamic> json) =>
           companyId: $checkedConvert('company_id', (v) => (v as num).toInt()),
           createdAt: $checkedConvert(
             'created_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
         );
         return val;
@@ -133,9 +136,10 @@ _SponsorScholarship _$SponsorScholarshipFromJson(Map<String, dynamic> json) =>
       fieldKeyMap: const {'companyId': 'company_id', 'createdAt': 'created_at'},
     );
 
-Map<String, dynamic> _$SponsorScholarshipToJson(_SponsorScholarship instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'company_id': instance.companyId,
-      'created_at': instance.createdAt.toIso8601String(),
-    };
+Map<String, dynamic> _$SponsorScholarshipToJson(
+  _SponsorScholarship instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'company_id': instance.companyId,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+};

--- a/packages/db_types/lib/src/tables/stripe_webhook_logs.dart
+++ b/packages/db_types/lib/src/tables/stripe_webhook_logs.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'stripe_webhook_logs.freezed.dart';
@@ -13,7 +14,7 @@ abstract class StripeWebhookLogs with _$StripeWebhookLogs {
     required bool processed,
     String? errorMessage,
     required Map<String, dynamic> rawData,
-    required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
   }) = _StripeWebhookLogs;
 
   factory StripeWebhookLogs.fromJson(Map<String, dynamic> json) =>

--- a/packages/db_types/lib/src/tables/stripe_webhook_logs.freezed.dart
+++ b/packages/db_types/lib/src/tables/stripe_webhook_logs.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$StripeWebhookLogs {
 
- int get id; String get stripeEventId; String get eventType; String? get paymentIntentId; bool get processed; String? get errorMessage; Map<String, dynamic> get rawData; DateTime get createdAt;
+ int get id; String get stripeEventId; String get eventType; String? get paymentIntentId; bool get processed; String? get errorMessage; Map<String, dynamic> get rawData;@RequiredDateTimeConverter() DateTime get createdAt;
 /// Create a copy of StripeWebhookLogs
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $StripeWebhookLogsCopyWith<$Res>  {
   factory $StripeWebhookLogsCopyWith(StripeWebhookLogs value, $Res Function(StripeWebhookLogs) _then) = _$StripeWebhookLogsCopyWithImpl;
 @useResult
 $Res call({
- int id, String stripeEventId, String eventType, String? paymentIntentId, bool processed, String? errorMessage, Map<String, dynamic> rawData, DateTime createdAt
+ int id, String stripeEventId, String eventType, String? paymentIntentId, bool processed, String? errorMessage, Map<String, dynamic> rawData,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -160,7 +160,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String stripeEventId,  String eventType,  String? paymentIntentId,  bool processed,  String? errorMessage,  Map<String, dynamic> rawData,  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String stripeEventId,  String eventType,  String? paymentIntentId,  bool processed,  String? errorMessage,  Map<String, dynamic> rawData, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _StripeWebhookLogs() when $default != null:
 return $default(_that.id,_that.stripeEventId,_that.eventType,_that.paymentIntentId,_that.processed,_that.errorMessage,_that.rawData,_that.createdAt);case _:
@@ -181,7 +181,7 @@ return $default(_that.id,_that.stripeEventId,_that.eventType,_that.paymentIntent
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String stripeEventId,  String eventType,  String? paymentIntentId,  bool processed,  String? errorMessage,  Map<String, dynamic> rawData,  DateTime createdAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String stripeEventId,  String eventType,  String? paymentIntentId,  bool processed,  String? errorMessage,  Map<String, dynamic> rawData, @RequiredDateTimeConverter()  DateTime createdAt)  $default,) {final _that = this;
 switch (_that) {
 case _StripeWebhookLogs():
 return $default(_that.id,_that.stripeEventId,_that.eventType,_that.paymentIntentId,_that.processed,_that.errorMessage,_that.rawData,_that.createdAt);case _:
@@ -201,7 +201,7 @@ return $default(_that.id,_that.stripeEventId,_that.eventType,_that.paymentIntent
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String stripeEventId,  String eventType,  String? paymentIntentId,  bool processed,  String? errorMessage,  Map<String, dynamic> rawData,  DateTime createdAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String stripeEventId,  String eventType,  String? paymentIntentId,  bool processed,  String? errorMessage,  Map<String, dynamic> rawData, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,) {final _that = this;
 switch (_that) {
 case _StripeWebhookLogs() when $default != null:
 return $default(_that.id,_that.stripeEventId,_that.eventType,_that.paymentIntentId,_that.processed,_that.errorMessage,_that.rawData,_that.createdAt);case _:
@@ -216,7 +216,7 @@ return $default(_that.id,_that.stripeEventId,_that.eventType,_that.paymentIntent
 @JsonSerializable()
 
 class _StripeWebhookLogs implements StripeWebhookLogs {
-  const _StripeWebhookLogs({required this.id, required this.stripeEventId, required this.eventType, this.paymentIntentId, required this.processed, this.errorMessage, required final  Map<String, dynamic> rawData, required this.createdAt}): _rawData = rawData;
+  const _StripeWebhookLogs({required this.id, required this.stripeEventId, required this.eventType, this.paymentIntentId, required this.processed, this.errorMessage, required final  Map<String, dynamic> rawData, @RequiredDateTimeConverter() required this.createdAt}): _rawData = rawData;
   factory _StripeWebhookLogs.fromJson(Map<String, dynamic> json) => _$StripeWebhookLogsFromJson(json);
 
 @override final  int id;
@@ -232,7 +232,7 @@ class _StripeWebhookLogs implements StripeWebhookLogs {
   return EqualUnmodifiableMapView(_rawData);
 }
 
-@override final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
 
 /// Create a copy of StripeWebhookLogs
 /// with the given fields replaced by the non-null parameter values.
@@ -267,7 +267,7 @@ abstract mixin class _$StripeWebhookLogsCopyWith<$Res> implements $StripeWebhook
   factory _$StripeWebhookLogsCopyWith(_StripeWebhookLogs value, $Res Function(_StripeWebhookLogs) _then) = __$StripeWebhookLogsCopyWithImpl;
 @override @useResult
 $Res call({
- int id, String stripeEventId, String eventType, String? paymentIntentId, bool processed, String? errorMessage, Map<String, dynamic> rawData, DateTime createdAt
+ int id, String stripeEventId, String eventType, String? paymentIntentId, bool processed, String? errorMessage, Map<String, dynamic> rawData,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 

--- a/packages/db_types/lib/src/tables/stripe_webhook_logs.g.dart
+++ b/packages/db_types/lib/src/tables/stripe_webhook_logs.g.dart
@@ -29,7 +29,7 @@ _StripeWebhookLogs _$StripeWebhookLogsFromJson(Map<String, dynamic> json) =>
           ),
           createdAt: $checkedConvert(
             'created_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
         );
         return val;
@@ -44,14 +44,15 @@ _StripeWebhookLogs _$StripeWebhookLogsFromJson(Map<String, dynamic> json) =>
       },
     );
 
-Map<String, dynamic> _$StripeWebhookLogsToJson(_StripeWebhookLogs instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'stripe_event_id': instance.stripeEventId,
-      'event_type': instance.eventType,
-      'payment_intent_id': instance.paymentIntentId,
-      'processed': instance.processed,
-      'error_message': instance.errorMessage,
-      'raw_data': instance.rawData,
-      'created_at': instance.createdAt.toIso8601String(),
-    };
+Map<String, dynamic> _$StripeWebhookLogsToJson(
+  _StripeWebhookLogs instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'stripe_event_id': instance.stripeEventId,
+  'event_type': instance.eventType,
+  'payment_intent_id': instance.paymentIntentId,
+  'processed': instance.processed,
+  'error_message': instance.errorMessage,
+  'raw_data': instance.rawData,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+};

--- a/packages/db_types/lib/src/tables/ticket_checkout_sessions.dart
+++ b/packages/db_types/lib/src/tables/ticket_checkout_sessions.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'ticket_checkout_sessions.freezed.dart';
@@ -20,9 +21,9 @@ abstract class TicketCheckoutSessions with _$TicketCheckoutSessions {
     String? stripePaymentIntentId,
     String? stripeCheckoutSessionId,
     required int totalAmount,
-    required DateTime expiresAt,
-    required DateTime createdAt,
-    required DateTime updatedAt,
+    @RequiredDateTimeConverter() required DateTime expiresAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
   }) = _TicketCheckoutSessions;
 
   factory TicketCheckoutSessions.fromJson(Map<String, dynamic> json) =>
@@ -36,8 +37,8 @@ abstract class TicketCheckoutOptions with _$TicketCheckoutOptions {
     required String checkoutSessionId,
     required String ticketOptionId,
     String? optionValue,
-    required DateTime createdAt,
-    required DateTime updatedAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
   }) = _TicketCheckoutOptions;
 
   factory TicketCheckoutOptions.fromJson(Map<String, dynamic> json) =>

--- a/packages/db_types/lib/src/tables/ticket_checkout_sessions.freezed.dart
+++ b/packages/db_types/lib/src/tables/ticket_checkout_sessions.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$TicketCheckoutSessions {
 
- String get id; String get userId; String get ticketTypeId; TicketCheckoutStatus get status; String? get stripePaymentIntentId; String? get stripeCheckoutSessionId; int get totalAmount; DateTime get expiresAt; DateTime get createdAt; DateTime get updatedAt;
+ String get id; String get userId; String get ticketTypeId; TicketCheckoutStatus get status; String? get stripePaymentIntentId; String? get stripeCheckoutSessionId; int get totalAmount;@RequiredDateTimeConverter() DateTime get expiresAt;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;
 /// Create a copy of TicketCheckoutSessions
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $TicketCheckoutSessionsCopyWith<$Res>  {
   factory $TicketCheckoutSessionsCopyWith(TicketCheckoutSessions value, $Res Function(TicketCheckoutSessions) _then) = _$TicketCheckoutSessionsCopyWithImpl;
 @useResult
 $Res call({
- String id, String userId, String ticketTypeId, TicketCheckoutStatus status, String? stripePaymentIntentId, String? stripeCheckoutSessionId, int totalAmount, DateTime expiresAt, DateTime createdAt, DateTime updatedAt
+ String id, String userId, String ticketTypeId, TicketCheckoutStatus status, String? stripePaymentIntentId, String? stripeCheckoutSessionId, int totalAmount,@RequiredDateTimeConverter() DateTime expiresAt,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -162,7 +162,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String userId,  String ticketTypeId,  TicketCheckoutStatus status,  String? stripePaymentIntentId,  String? stripeCheckoutSessionId,  int totalAmount,  DateTime expiresAt,  DateTime createdAt,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String userId,  String ticketTypeId,  TicketCheckoutStatus status,  String? stripePaymentIntentId,  String? stripeCheckoutSessionId,  int totalAmount, @RequiredDateTimeConverter()  DateTime expiresAt, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _TicketCheckoutSessions() when $default != null:
 return $default(_that.id,_that.userId,_that.ticketTypeId,_that.status,_that.stripePaymentIntentId,_that.stripeCheckoutSessionId,_that.totalAmount,_that.expiresAt,_that.createdAt,_that.updatedAt);case _:
@@ -183,7 +183,7 @@ return $default(_that.id,_that.userId,_that.ticketTypeId,_that.status,_that.stri
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String userId,  String ticketTypeId,  TicketCheckoutStatus status,  String? stripePaymentIntentId,  String? stripeCheckoutSessionId,  int totalAmount,  DateTime expiresAt,  DateTime createdAt,  DateTime updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String userId,  String ticketTypeId,  TicketCheckoutStatus status,  String? stripePaymentIntentId,  String? stripeCheckoutSessionId,  int totalAmount, @RequiredDateTimeConverter()  DateTime expiresAt, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _TicketCheckoutSessions():
 return $default(_that.id,_that.userId,_that.ticketTypeId,_that.status,_that.stripePaymentIntentId,_that.stripeCheckoutSessionId,_that.totalAmount,_that.expiresAt,_that.createdAt,_that.updatedAt);case _:
@@ -203,7 +203,7 @@ return $default(_that.id,_that.userId,_that.ticketTypeId,_that.status,_that.stri
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String userId,  String ticketTypeId,  TicketCheckoutStatus status,  String? stripePaymentIntentId,  String? stripeCheckoutSessionId,  int totalAmount,  DateTime expiresAt,  DateTime createdAt,  DateTime updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String userId,  String ticketTypeId,  TicketCheckoutStatus status,  String? stripePaymentIntentId,  String? stripeCheckoutSessionId,  int totalAmount, @RequiredDateTimeConverter()  DateTime expiresAt, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _TicketCheckoutSessions() when $default != null:
 return $default(_that.id,_that.userId,_that.ticketTypeId,_that.status,_that.stripePaymentIntentId,_that.stripeCheckoutSessionId,_that.totalAmount,_that.expiresAt,_that.createdAt,_that.updatedAt);case _:
@@ -218,7 +218,7 @@ return $default(_that.id,_that.userId,_that.ticketTypeId,_that.status,_that.stri
 @JsonSerializable()
 
 class _TicketCheckoutSessions implements TicketCheckoutSessions {
-  const _TicketCheckoutSessions({required this.id, required this.userId, required this.ticketTypeId, required this.status, this.stripePaymentIntentId, this.stripeCheckoutSessionId, required this.totalAmount, required this.expiresAt, required this.createdAt, required this.updatedAt});
+  const _TicketCheckoutSessions({required this.id, required this.userId, required this.ticketTypeId, required this.status, this.stripePaymentIntentId, this.stripeCheckoutSessionId, required this.totalAmount, @RequiredDateTimeConverter() required this.expiresAt, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt});
   factory _TicketCheckoutSessions.fromJson(Map<String, dynamic> json) => _$TicketCheckoutSessionsFromJson(json);
 
 @override final  String id;
@@ -228,9 +228,9 @@ class _TicketCheckoutSessions implements TicketCheckoutSessions {
 @override final  String? stripePaymentIntentId;
 @override final  String? stripeCheckoutSessionId;
 @override final  int totalAmount;
-@override final  DateTime expiresAt;
-@override final  DateTime createdAt;
-@override final  DateTime updatedAt;
+@override@RequiredDateTimeConverter() final  DateTime expiresAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime updatedAt;
 
 /// Create a copy of TicketCheckoutSessions
 /// with the given fields replaced by the non-null parameter values.
@@ -265,7 +265,7 @@ abstract mixin class _$TicketCheckoutSessionsCopyWith<$Res> implements $TicketCh
   factory _$TicketCheckoutSessionsCopyWith(_TicketCheckoutSessions value, $Res Function(_TicketCheckoutSessions) _then) = __$TicketCheckoutSessionsCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String userId, String ticketTypeId, TicketCheckoutStatus status, String? stripePaymentIntentId, String? stripeCheckoutSessionId, int totalAmount, DateTime expiresAt, DateTime createdAt, DateTime updatedAt
+ String id, String userId, String ticketTypeId, TicketCheckoutStatus status, String? stripePaymentIntentId, String? stripeCheckoutSessionId, int totalAmount,@RequiredDateTimeConverter() DateTime expiresAt,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -305,7 +305,7 @@ as DateTime,
 /// @nodoc
 mixin _$TicketCheckoutOptions {
 
- String get id; String get checkoutSessionId; String get ticketOptionId; String? get optionValue; DateTime get createdAt; DateTime get updatedAt;
+ String get id; String get checkoutSessionId; String get ticketOptionId; String? get optionValue;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;
 /// Create a copy of TicketCheckoutOptions
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -338,7 +338,7 @@ abstract mixin class $TicketCheckoutOptionsCopyWith<$Res>  {
   factory $TicketCheckoutOptionsCopyWith(TicketCheckoutOptions value, $Res Function(TicketCheckoutOptions) _then) = _$TicketCheckoutOptionsCopyWithImpl;
 @useResult
 $Res call({
- String id, String checkoutSessionId, String ticketOptionId, String? optionValue, DateTime createdAt, DateTime updatedAt
+ String id, String checkoutSessionId, String ticketOptionId, String? optionValue,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -448,7 +448,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String checkoutSessionId,  String ticketOptionId,  String? optionValue,  DateTime createdAt,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String checkoutSessionId,  String ticketOptionId,  String? optionValue, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _TicketCheckoutOptions() when $default != null:
 return $default(_that.id,_that.checkoutSessionId,_that.ticketOptionId,_that.optionValue,_that.createdAt,_that.updatedAt);case _:
@@ -469,7 +469,7 @@ return $default(_that.id,_that.checkoutSessionId,_that.ticketOptionId,_that.opti
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String checkoutSessionId,  String ticketOptionId,  String? optionValue,  DateTime createdAt,  DateTime updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String checkoutSessionId,  String ticketOptionId,  String? optionValue, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _TicketCheckoutOptions():
 return $default(_that.id,_that.checkoutSessionId,_that.ticketOptionId,_that.optionValue,_that.createdAt,_that.updatedAt);case _:
@@ -489,7 +489,7 @@ return $default(_that.id,_that.checkoutSessionId,_that.ticketOptionId,_that.opti
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String checkoutSessionId,  String ticketOptionId,  String? optionValue,  DateTime createdAt,  DateTime updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String checkoutSessionId,  String ticketOptionId,  String? optionValue, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _TicketCheckoutOptions() when $default != null:
 return $default(_that.id,_that.checkoutSessionId,_that.ticketOptionId,_that.optionValue,_that.createdAt,_that.updatedAt);case _:
@@ -504,15 +504,15 @@ return $default(_that.id,_that.checkoutSessionId,_that.ticketOptionId,_that.opti
 @JsonSerializable()
 
 class _TicketCheckoutOptions implements TicketCheckoutOptions {
-  const _TicketCheckoutOptions({required this.id, required this.checkoutSessionId, required this.ticketOptionId, this.optionValue, required this.createdAt, required this.updatedAt});
+  const _TicketCheckoutOptions({required this.id, required this.checkoutSessionId, required this.ticketOptionId, this.optionValue, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt});
   factory _TicketCheckoutOptions.fromJson(Map<String, dynamic> json) => _$TicketCheckoutOptionsFromJson(json);
 
 @override final  String id;
 @override final  String checkoutSessionId;
 @override final  String ticketOptionId;
 @override final  String? optionValue;
-@override final  DateTime createdAt;
-@override final  DateTime updatedAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime updatedAt;
 
 /// Create a copy of TicketCheckoutOptions
 /// with the given fields replaced by the non-null parameter values.
@@ -547,7 +547,7 @@ abstract mixin class _$TicketCheckoutOptionsCopyWith<$Res> implements $TicketChe
   factory _$TicketCheckoutOptionsCopyWith(_TicketCheckoutOptions value, $Res Function(_TicketCheckoutOptions) _then) = __$TicketCheckoutOptionsCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String checkoutSessionId, String ticketOptionId, String? optionValue, DateTime createdAt, DateTime updatedAt
+ String id, String checkoutSessionId, String ticketOptionId, String? optionValue,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 

--- a/packages/db_types/lib/src/tables/ticket_checkout_sessions.g.dart
+++ b/packages/db_types/lib/src/tables/ticket_checkout_sessions.g.dart
@@ -33,15 +33,15 @@ _TicketCheckoutSessions _$TicketCheckoutSessionsFromJson(
       totalAmount: $checkedConvert('total_amount', (v) => (v as num).toInt()),
       expiresAt: $checkedConvert(
         'expires_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
       createdAt: $checkedConvert(
         'created_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
       updatedAt: $checkedConvert(
         'updated_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
     );
     return val;
@@ -68,9 +68,9 @@ Map<String, dynamic> _$TicketCheckoutSessionsToJson(
   'stripe_payment_intent_id': instance.stripePaymentIntentId,
   'stripe_checkout_session_id': instance.stripeCheckoutSessionId,
   'total_amount': instance.totalAmount,
-  'expires_at': instance.expiresAt.toIso8601String(),
-  'created_at': instance.createdAt.toIso8601String(),
-  'updated_at': instance.updatedAt.toIso8601String(),
+  'expires_at': const RequiredDateTimeConverter().toJson(instance.expiresAt),
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const RequiredDateTimeConverter().toJson(instance.updatedAt),
 };
 
 const _$TicketCheckoutStatusEnumMap = {
@@ -96,11 +96,11 @@ _TicketCheckoutOptions _$TicketCheckoutOptionsFromJson(
       optionValue: $checkedConvert('option_value', (v) => v as String?),
       createdAt: $checkedConvert(
         'created_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
       updatedAt: $checkedConvert(
         'updated_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
     );
     return val;
@@ -121,6 +121,6 @@ Map<String, dynamic> _$TicketCheckoutOptionsToJson(
   'checkout_session_id': instance.checkoutSessionId,
   'ticket_option_id': instance.ticketOptionId,
   'option_value': instance.optionValue,
-  'created_at': instance.createdAt.toIso8601String(),
-  'updated_at': instance.updatedAt.toIso8601String(),
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const RequiredDateTimeConverter().toJson(instance.updatedAt),
 };

--- a/packages/db_types/lib/src/tables/ticket_options.dart
+++ b/packages/db_types/lib/src/tables/ticket_options.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'ticket_options.freezed.dart';
@@ -10,8 +11,8 @@ abstract class TicketOptions with _$TicketOptions {
     required String ticketTypeId,
     required String name,
     String? description,
-    required DateTime createdAt,
-    required DateTime updatedAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
   }) = _TicketOptions;
 
   factory TicketOptions.fromJson(Map<String, dynamic> json) =>

--- a/packages/db_types/lib/src/tables/ticket_options.freezed.dart
+++ b/packages/db_types/lib/src/tables/ticket_options.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$TicketOptions {
 
- String get id; String get ticketTypeId; String get name; String? get description; DateTime get createdAt; DateTime get updatedAt;
+ String get id; String get ticketTypeId; String get name; String? get description;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;
 /// Create a copy of TicketOptions
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $TicketOptionsCopyWith<$Res>  {
   factory $TicketOptionsCopyWith(TicketOptions value, $Res Function(TicketOptions) _then) = _$TicketOptionsCopyWithImpl;
 @useResult
 $Res call({
- String id, String ticketTypeId, String name, String? description, DateTime createdAt, DateTime updatedAt
+ String id, String ticketTypeId, String name, String? description,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -158,7 +158,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String ticketTypeId,  String name,  String? description,  DateTime createdAt,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String ticketTypeId,  String name,  String? description, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _TicketOptions() when $default != null:
 return $default(_that.id,_that.ticketTypeId,_that.name,_that.description,_that.createdAt,_that.updatedAt);case _:
@@ -179,7 +179,7 @@ return $default(_that.id,_that.ticketTypeId,_that.name,_that.description,_that.c
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String ticketTypeId,  String name,  String? description,  DateTime createdAt,  DateTime updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String ticketTypeId,  String name,  String? description, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _TicketOptions():
 return $default(_that.id,_that.ticketTypeId,_that.name,_that.description,_that.createdAt,_that.updatedAt);case _:
@@ -199,7 +199,7 @@ return $default(_that.id,_that.ticketTypeId,_that.name,_that.description,_that.c
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String ticketTypeId,  String name,  String? description,  DateTime createdAt,  DateTime updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String ticketTypeId,  String name,  String? description, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _TicketOptions() when $default != null:
 return $default(_that.id,_that.ticketTypeId,_that.name,_that.description,_that.createdAt,_that.updatedAt);case _:
@@ -214,15 +214,15 @@ return $default(_that.id,_that.ticketTypeId,_that.name,_that.description,_that.c
 @JsonSerializable()
 
 class _TicketOptions implements TicketOptions {
-  const _TicketOptions({required this.id, required this.ticketTypeId, required this.name, this.description, required this.createdAt, required this.updatedAt});
+  const _TicketOptions({required this.id, required this.ticketTypeId, required this.name, this.description, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt});
   factory _TicketOptions.fromJson(Map<String, dynamic> json) => _$TicketOptionsFromJson(json);
 
 @override final  String id;
 @override final  String ticketTypeId;
 @override final  String name;
 @override final  String? description;
-@override final  DateTime createdAt;
-@override final  DateTime updatedAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime updatedAt;
 
 /// Create a copy of TicketOptions
 /// with the given fields replaced by the non-null parameter values.
@@ -257,7 +257,7 @@ abstract mixin class _$TicketOptionsCopyWith<$Res> implements $TicketOptionsCopy
   factory _$TicketOptionsCopyWith(_TicketOptions value, $Res Function(_TicketOptions) _then) = __$TicketOptionsCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String ticketTypeId, String name, String? description, DateTime createdAt, DateTime updatedAt
+ String id, String ticketTypeId, String name, String? description,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 

--- a/packages/db_types/lib/src/tables/ticket_options.g.dart
+++ b/packages/db_types/lib/src/tables/ticket_options.g.dart
@@ -20,11 +20,11 @@ _TicketOptions _$TicketOptionsFromJson(Map<String, dynamic> json) =>
           description: $checkedConvert('description', (v) => v as String?),
           createdAt: $checkedConvert(
             'created_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
           updatedAt: $checkedConvert(
             'updated_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
         );
         return val;
@@ -36,12 +36,13 @@ _TicketOptions _$TicketOptionsFromJson(Map<String, dynamic> json) =>
       },
     );
 
-Map<String, dynamic> _$TicketOptionsToJson(_TicketOptions instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'ticket_type_id': instance.ticketTypeId,
-      'name': instance.name,
-      'description': instance.description,
-      'created_at': instance.createdAt.toIso8601String(),
-      'updated_at': instance.updatedAt.toIso8601String(),
-    };
+Map<String, dynamic> _$TicketOptionsToJson(
+  _TicketOptions instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'ticket_type_id': instance.ticketTypeId,
+  'name': instance.name,
+  'description': instance.description,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const RequiredDateTimeConverter().toJson(instance.updatedAt),
+};

--- a/packages/db_types/lib/src/tables/ticket_purchases.dart
+++ b/packages/db_types/lib/src/tables/ticket_purchases.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'ticket_purchases.freezed.dart';
@@ -16,8 +17,8 @@ abstract class TicketPurchases with _$TicketPurchases {
     required String ticketTypeId,
     required TicketPurchaseStatus status,
     String? stripePaymentIntentId,
-    required DateTime createdAt,
-    required DateTime updatedAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
   }) = _TicketPurchases;
 
   factory TicketPurchases.fromJson(Map<String, dynamic> json) =>
@@ -31,8 +32,8 @@ abstract class TicketPurchaseOptions with _$TicketPurchaseOptions {
     required String ticketPurchaseId,
     required String ticketOptionId,
     String? optionValue,
-    required DateTime createdAt,
-    required DateTime updatedAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
   }) = _TicketPurchaseOptions;
 
   factory TicketPurchaseOptions.fromJson(Map<String, dynamic> json) =>

--- a/packages/db_types/lib/src/tables/ticket_purchases.freezed.dart
+++ b/packages/db_types/lib/src/tables/ticket_purchases.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$TicketPurchases {
 
- String get id; String get userId; String get ticketTypeId; TicketPurchaseStatus get status; String? get stripePaymentIntentId; DateTime get createdAt; DateTime get updatedAt;
+ String get id; String get userId; String get ticketTypeId; TicketPurchaseStatus get status; String? get stripePaymentIntentId;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;
 /// Create a copy of TicketPurchases
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $TicketPurchasesCopyWith<$Res>  {
   factory $TicketPurchasesCopyWith(TicketPurchases value, $Res Function(TicketPurchases) _then) = _$TicketPurchasesCopyWithImpl;
 @useResult
 $Res call({
- String id, String userId, String ticketTypeId, TicketPurchaseStatus status, String? stripePaymentIntentId, DateTime createdAt, DateTime updatedAt
+ String id, String userId, String ticketTypeId, TicketPurchaseStatus status, String? stripePaymentIntentId,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -159,7 +159,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String userId,  String ticketTypeId,  TicketPurchaseStatus status,  String? stripePaymentIntentId,  DateTime createdAt,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String userId,  String ticketTypeId,  TicketPurchaseStatus status,  String? stripePaymentIntentId, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _TicketPurchases() when $default != null:
 return $default(_that.id,_that.userId,_that.ticketTypeId,_that.status,_that.stripePaymentIntentId,_that.createdAt,_that.updatedAt);case _:
@@ -180,7 +180,7 @@ return $default(_that.id,_that.userId,_that.ticketTypeId,_that.status,_that.stri
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String userId,  String ticketTypeId,  TicketPurchaseStatus status,  String? stripePaymentIntentId,  DateTime createdAt,  DateTime updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String userId,  String ticketTypeId,  TicketPurchaseStatus status,  String? stripePaymentIntentId, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _TicketPurchases():
 return $default(_that.id,_that.userId,_that.ticketTypeId,_that.status,_that.stripePaymentIntentId,_that.createdAt,_that.updatedAt);case _:
@@ -200,7 +200,7 @@ return $default(_that.id,_that.userId,_that.ticketTypeId,_that.status,_that.stri
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String userId,  String ticketTypeId,  TicketPurchaseStatus status,  String? stripePaymentIntentId,  DateTime createdAt,  DateTime updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String userId,  String ticketTypeId,  TicketPurchaseStatus status,  String? stripePaymentIntentId, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _TicketPurchases() when $default != null:
 return $default(_that.id,_that.userId,_that.ticketTypeId,_that.status,_that.stripePaymentIntentId,_that.createdAt,_that.updatedAt);case _:
@@ -215,7 +215,7 @@ return $default(_that.id,_that.userId,_that.ticketTypeId,_that.status,_that.stri
 @JsonSerializable()
 
 class _TicketPurchases implements TicketPurchases {
-  const _TicketPurchases({required this.id, required this.userId, required this.ticketTypeId, required this.status, this.stripePaymentIntentId, required this.createdAt, required this.updatedAt});
+  const _TicketPurchases({required this.id, required this.userId, required this.ticketTypeId, required this.status, this.stripePaymentIntentId, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt});
   factory _TicketPurchases.fromJson(Map<String, dynamic> json) => _$TicketPurchasesFromJson(json);
 
 @override final  String id;
@@ -223,8 +223,8 @@ class _TicketPurchases implements TicketPurchases {
 @override final  String ticketTypeId;
 @override final  TicketPurchaseStatus status;
 @override final  String? stripePaymentIntentId;
-@override final  DateTime createdAt;
-@override final  DateTime updatedAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime updatedAt;
 
 /// Create a copy of TicketPurchases
 /// with the given fields replaced by the non-null parameter values.
@@ -259,7 +259,7 @@ abstract mixin class _$TicketPurchasesCopyWith<$Res> implements $TicketPurchases
   factory _$TicketPurchasesCopyWith(_TicketPurchases value, $Res Function(_TicketPurchases) _then) = __$TicketPurchasesCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String userId, String ticketTypeId, TicketPurchaseStatus status, String? stripePaymentIntentId, DateTime createdAt, DateTime updatedAt
+ String id, String userId, String ticketTypeId, TicketPurchaseStatus status, String? stripePaymentIntentId,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -296,7 +296,7 @@ as DateTime,
 /// @nodoc
 mixin _$TicketPurchaseOptions {
 
- String get id; String get ticketPurchaseId; String get ticketOptionId; String? get optionValue; DateTime get createdAt; DateTime get updatedAt;
+ String get id; String get ticketPurchaseId; String get ticketOptionId; String? get optionValue;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;
 /// Create a copy of TicketPurchaseOptions
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -329,7 +329,7 @@ abstract mixin class $TicketPurchaseOptionsCopyWith<$Res>  {
   factory $TicketPurchaseOptionsCopyWith(TicketPurchaseOptions value, $Res Function(TicketPurchaseOptions) _then) = _$TicketPurchaseOptionsCopyWithImpl;
 @useResult
 $Res call({
- String id, String ticketPurchaseId, String ticketOptionId, String? optionValue, DateTime createdAt, DateTime updatedAt
+ String id, String ticketPurchaseId, String ticketOptionId, String? optionValue,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -439,7 +439,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String ticketPurchaseId,  String ticketOptionId,  String? optionValue,  DateTime createdAt,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String ticketPurchaseId,  String ticketOptionId,  String? optionValue, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _TicketPurchaseOptions() when $default != null:
 return $default(_that.id,_that.ticketPurchaseId,_that.ticketOptionId,_that.optionValue,_that.createdAt,_that.updatedAt);case _:
@@ -460,7 +460,7 @@ return $default(_that.id,_that.ticketPurchaseId,_that.ticketOptionId,_that.optio
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String ticketPurchaseId,  String ticketOptionId,  String? optionValue,  DateTime createdAt,  DateTime updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String ticketPurchaseId,  String ticketOptionId,  String? optionValue, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _TicketPurchaseOptions():
 return $default(_that.id,_that.ticketPurchaseId,_that.ticketOptionId,_that.optionValue,_that.createdAt,_that.updatedAt);case _:
@@ -480,7 +480,7 @@ return $default(_that.id,_that.ticketPurchaseId,_that.ticketOptionId,_that.optio
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String ticketPurchaseId,  String ticketOptionId,  String? optionValue,  DateTime createdAt,  DateTime updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String ticketPurchaseId,  String ticketOptionId,  String? optionValue, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _TicketPurchaseOptions() when $default != null:
 return $default(_that.id,_that.ticketPurchaseId,_that.ticketOptionId,_that.optionValue,_that.createdAt,_that.updatedAt);case _:
@@ -495,15 +495,15 @@ return $default(_that.id,_that.ticketPurchaseId,_that.ticketOptionId,_that.optio
 @JsonSerializable()
 
 class _TicketPurchaseOptions implements TicketPurchaseOptions {
-  const _TicketPurchaseOptions({required this.id, required this.ticketPurchaseId, required this.ticketOptionId, this.optionValue, required this.createdAt, required this.updatedAt});
+  const _TicketPurchaseOptions({required this.id, required this.ticketPurchaseId, required this.ticketOptionId, this.optionValue, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt});
   factory _TicketPurchaseOptions.fromJson(Map<String, dynamic> json) => _$TicketPurchaseOptionsFromJson(json);
 
 @override final  String id;
 @override final  String ticketPurchaseId;
 @override final  String ticketOptionId;
 @override final  String? optionValue;
-@override final  DateTime createdAt;
-@override final  DateTime updatedAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime updatedAt;
 
 /// Create a copy of TicketPurchaseOptions
 /// with the given fields replaced by the non-null parameter values.
@@ -538,7 +538,7 @@ abstract mixin class _$TicketPurchaseOptionsCopyWith<$Res> implements $TicketPur
   factory _$TicketPurchaseOptionsCopyWith(_TicketPurchaseOptions value, $Res Function(_TicketPurchaseOptions) _then) = __$TicketPurchaseOptionsCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String ticketPurchaseId, String ticketOptionId, String? optionValue, DateTime createdAt, DateTime updatedAt
+ String id, String ticketPurchaseId, String ticketOptionId, String? optionValue,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 

--- a/packages/db_types/lib/src/tables/ticket_purchases.g.dart
+++ b/packages/db_types/lib/src/tables/ticket_purchases.g.dart
@@ -27,11 +27,11 @@ _TicketPurchases _$TicketPurchasesFromJson(Map<String, dynamic> json) =>
           ),
           createdAt: $checkedConvert(
             'created_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
           updatedAt: $checkedConvert(
             'updated_at',
-            (v) => DateTime.parse(v as String),
+            (v) => const RequiredDateTimeConverter().fromJson(v),
           ),
         );
         return val;
@@ -45,16 +45,17 @@ _TicketPurchases _$TicketPurchasesFromJson(Map<String, dynamic> json) =>
       },
     );
 
-Map<String, dynamic> _$TicketPurchasesToJson(_TicketPurchases instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'user_id': instance.userId,
-      'ticket_type_id': instance.ticketTypeId,
-      'status': _$TicketPurchaseStatusEnumMap[instance.status]!,
-      'stripe_payment_intent_id': instance.stripePaymentIntentId,
-      'created_at': instance.createdAt.toIso8601String(),
-      'updated_at': instance.updatedAt.toIso8601String(),
-    };
+Map<String, dynamic> _$TicketPurchasesToJson(
+  _TicketPurchases instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'user_id': instance.userId,
+  'ticket_type_id': instance.ticketTypeId,
+  'status': _$TicketPurchaseStatusEnumMap[instance.status]!,
+  'stripe_payment_intent_id': instance.stripePaymentIntentId,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const RequiredDateTimeConverter().toJson(instance.updatedAt),
+};
 
 const _$TicketPurchaseStatusEnumMap = {
   TicketPurchaseStatus.completed: 'completed',
@@ -77,11 +78,11 @@ _TicketPurchaseOptions _$TicketPurchaseOptionsFromJson(
       optionValue: $checkedConvert('option_value', (v) => v as String?),
       createdAt: $checkedConvert(
         'created_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
       updatedAt: $checkedConvert(
         'updated_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
     );
     return val;
@@ -102,6 +103,6 @@ Map<String, dynamic> _$TicketPurchaseOptionsToJson(
   'ticket_purchase_id': instance.ticketPurchaseId,
   'ticket_option_id': instance.ticketOptionId,
   'option_value': instance.optionValue,
-  'created_at': instance.createdAt.toIso8601String(),
-  'updated_at': instance.updatedAt.toIso8601String(),
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const RequiredDateTimeConverter().toJson(instance.updatedAt),
 };

--- a/packages/db_types/lib/src/tables/ticket_types.dart
+++ b/packages/db_types/lib/src/tables/ticket_types.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'ticket_types.freezed.dart';
@@ -12,11 +13,11 @@ abstract class TicketTypes with _$TicketTypes {
     int? maxQuantity,
     String? description,
     required bool isActive,
-    DateTime? saleStartsAt,
-    DateTime? saleEndsAt,
+    @DateTimeConverter() DateTime? saleStartsAt,
+    @DateTimeConverter() DateTime? saleEndsAt,
     String? url,
-    required DateTime createdAt,
-    required DateTime updatedAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
   }) = _TicketTypes;
 
   factory TicketTypes.fromJson(Map<String, dynamic> json) =>

--- a/packages/db_types/lib/src/tables/ticket_types.freezed.dart
+++ b/packages/db_types/lib/src/tables/ticket_types.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$TicketTypes {
 
- String get id; String get name; int get price; int? get maxQuantity; String? get description; bool get isActive; DateTime? get saleStartsAt; DateTime? get saleEndsAt; String? get url; DateTime get createdAt; DateTime get updatedAt;
+ String get id; String get name; int get price; int? get maxQuantity; String? get description; bool get isActive;@DateTimeConverter() DateTime? get saleStartsAt;@DateTimeConverter() DateTime? get saleEndsAt; String? get url;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;
 /// Create a copy of TicketTypes
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $TicketTypesCopyWith<$Res>  {
   factory $TicketTypesCopyWith(TicketTypes value, $Res Function(TicketTypes) _then) = _$TicketTypesCopyWithImpl;
 @useResult
 $Res call({
- String id, String name, int price, int? maxQuantity, String? description, bool isActive, DateTime? saleStartsAt, DateTime? saleEndsAt, String? url, DateTime createdAt, DateTime updatedAt
+ String id, String name, int price, int? maxQuantity, String? description, bool isActive,@DateTimeConverter() DateTime? saleStartsAt,@DateTimeConverter() DateTime? saleEndsAt, String? url,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -163,7 +163,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  int price,  int? maxQuantity,  String? description,  bool isActive,  DateTime? saleStartsAt,  DateTime? saleEndsAt,  String? url,  DateTime createdAt,  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  int price,  int? maxQuantity,  String? description,  bool isActive, @DateTimeConverter()  DateTime? saleStartsAt, @DateTimeConverter()  DateTime? saleEndsAt,  String? url, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _TicketTypes() when $default != null:
 return $default(_that.id,_that.name,_that.price,_that.maxQuantity,_that.description,_that.isActive,_that.saleStartsAt,_that.saleEndsAt,_that.url,_that.createdAt,_that.updatedAt);case _:
@@ -184,7 +184,7 @@ return $default(_that.id,_that.name,_that.price,_that.maxQuantity,_that.descript
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  int price,  int? maxQuantity,  String? description,  bool isActive,  DateTime? saleStartsAt,  DateTime? saleEndsAt,  String? url,  DateTime createdAt,  DateTime updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  int price,  int? maxQuantity,  String? description,  bool isActive, @DateTimeConverter()  DateTime? saleStartsAt, @DateTimeConverter()  DateTime? saleEndsAt,  String? url, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _TicketTypes():
 return $default(_that.id,_that.name,_that.price,_that.maxQuantity,_that.description,_that.isActive,_that.saleStartsAt,_that.saleEndsAt,_that.url,_that.createdAt,_that.updatedAt);case _:
@@ -204,7 +204,7 @@ return $default(_that.id,_that.name,_that.price,_that.maxQuantity,_that.descript
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  int price,  int? maxQuantity,  String? description,  bool isActive,  DateTime? saleStartsAt,  DateTime? saleEndsAt,  String? url,  DateTime createdAt,  DateTime updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  int price,  int? maxQuantity,  String? description,  bool isActive, @DateTimeConverter()  DateTime? saleStartsAt, @DateTimeConverter()  DateTime? saleEndsAt,  String? url, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _TicketTypes() when $default != null:
 return $default(_that.id,_that.name,_that.price,_that.maxQuantity,_that.description,_that.isActive,_that.saleStartsAt,_that.saleEndsAt,_that.url,_that.createdAt,_that.updatedAt);case _:
@@ -219,7 +219,7 @@ return $default(_that.id,_that.name,_that.price,_that.maxQuantity,_that.descript
 @JsonSerializable()
 
 class _TicketTypes implements TicketTypes {
-  const _TicketTypes({required this.id, required this.name, required this.price, this.maxQuantity, this.description, required this.isActive, this.saleStartsAt, this.saleEndsAt, this.url, required this.createdAt, required this.updatedAt});
+  const _TicketTypes({required this.id, required this.name, required this.price, this.maxQuantity, this.description, required this.isActive, @DateTimeConverter() this.saleStartsAt, @DateTimeConverter() this.saleEndsAt, this.url, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt});
   factory _TicketTypes.fromJson(Map<String, dynamic> json) => _$TicketTypesFromJson(json);
 
 @override final  String id;
@@ -228,11 +228,11 @@ class _TicketTypes implements TicketTypes {
 @override final  int? maxQuantity;
 @override final  String? description;
 @override final  bool isActive;
-@override final  DateTime? saleStartsAt;
-@override final  DateTime? saleEndsAt;
+@override@DateTimeConverter() final  DateTime? saleStartsAt;
+@override@DateTimeConverter() final  DateTime? saleEndsAt;
 @override final  String? url;
-@override final  DateTime createdAt;
-@override final  DateTime updatedAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime updatedAt;
 
 /// Create a copy of TicketTypes
 /// with the given fields replaced by the non-null parameter values.
@@ -267,7 +267,7 @@ abstract mixin class _$TicketTypesCopyWith<$Res> implements $TicketTypesCopyWith
   factory _$TicketTypesCopyWith(_TicketTypes value, $Res Function(_TicketTypes) _then) = __$TicketTypesCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name, int price, int? maxQuantity, String? description, bool isActive, DateTime? saleStartsAt, DateTime? saleEndsAt, String? url, DateTime createdAt, DateTime updatedAt
+ String id, String name, int price, int? maxQuantity, String? description, bool isActive,@DateTimeConverter() DateTime? saleStartsAt,@DateTimeConverter() DateTime? saleEndsAt, String? url,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 

--- a/packages/db_types/lib/src/tables/ticket_types.g.dart
+++ b/packages/db_types/lib/src/tables/ticket_types.g.dart
@@ -21,20 +21,20 @@ _TicketTypes _$TicketTypesFromJson(Map<String, dynamic> json) => $checkedCreate(
       isActive: $checkedConvert('is_active', (v) => v as bool),
       saleStartsAt: $checkedConvert(
         'sale_starts_at',
-        (v) => v == null ? null : DateTime.parse(v as String),
+        (v) => const DateTimeConverter().fromJson(v),
       ),
       saleEndsAt: $checkedConvert(
         'sale_ends_at',
-        (v) => v == null ? null : DateTime.parse(v as String),
+        (v) => const DateTimeConverter().fromJson(v),
       ),
       url: $checkedConvert('url', (v) => v as String?),
       createdAt: $checkedConvert(
         'created_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
       updatedAt: $checkedConvert(
         'updated_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
     );
     return val;
@@ -49,17 +49,18 @@ _TicketTypes _$TicketTypesFromJson(Map<String, dynamic> json) => $checkedCreate(
   },
 );
 
-Map<String, dynamic> _$TicketTypesToJson(_TicketTypes instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'name': instance.name,
-      'price': instance.price,
-      'max_quantity': instance.maxQuantity,
-      'description': instance.description,
-      'is_active': instance.isActive,
-      'sale_starts_at': instance.saleStartsAt?.toIso8601String(),
-      'sale_ends_at': instance.saleEndsAt?.toIso8601String(),
-      'url': instance.url,
-      'created_at': instance.createdAt.toIso8601String(),
-      'updated_at': instance.updatedAt.toIso8601String(),
-    };
+Map<String, dynamic> _$TicketTypesToJson(
+  _TicketTypes instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'name': instance.name,
+  'price': instance.price,
+  'max_quantity': instance.maxQuantity,
+  'description': instance.description,
+  'is_active': instance.isActive,
+  'sale_starts_at': const DateTimeConverter().toJson(instance.saleStartsAt),
+  'sale_ends_at': const DateTimeConverter().toJson(instance.saleEndsAt),
+  'url': instance.url,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+  'updated_at': const RequiredDateTimeConverter().toJson(instance.updatedAt),
+};

--- a/packages/db_types/lib/src/tables/user_roles.dart
+++ b/packages/db_types/lib/src/tables/user_roles.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'user_roles.freezed.dart';
@@ -8,7 +9,7 @@ abstract class UserRoles with _$UserRoles {
   const factory UserRoles({
     required String userId,
     required Role role,
-    required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime createdAt,
   }) = _UserRoles;
 
   factory UserRoles.fromJson(Map<String, dynamic> json) =>

--- a/packages/db_types/lib/src/tables/user_roles.freezed.dart
+++ b/packages/db_types/lib/src/tables/user_roles.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$UserRoles {
 
- String get userId; Role get role; DateTime get createdAt;
+ String get userId; Role get role;@RequiredDateTimeConverter() DateTime get createdAt;
 /// Create a copy of UserRoles
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $UserRolesCopyWith<$Res>  {
   factory $UserRolesCopyWith(UserRoles value, $Res Function(UserRoles) _then) = _$UserRolesCopyWithImpl;
 @useResult
 $Res call({
- String userId, Role role, DateTime createdAt
+ String userId, Role role,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -155,7 +155,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String userId,  Role role,  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String userId,  Role role, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _UserRoles() when $default != null:
 return $default(_that.userId,_that.role,_that.createdAt);case _:
@@ -176,7 +176,7 @@ return $default(_that.userId,_that.role,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String userId,  Role role,  DateTime createdAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String userId,  Role role, @RequiredDateTimeConverter()  DateTime createdAt)  $default,) {final _that = this;
 switch (_that) {
 case _UserRoles():
 return $default(_that.userId,_that.role,_that.createdAt);case _:
@@ -196,7 +196,7 @@ return $default(_that.userId,_that.role,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String userId,  Role role,  DateTime createdAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String userId,  Role role, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,) {final _that = this;
 switch (_that) {
 case _UserRoles() when $default != null:
 return $default(_that.userId,_that.role,_that.createdAt);case _:
@@ -211,12 +211,12 @@ return $default(_that.userId,_that.role,_that.createdAt);case _:
 @JsonSerializable()
 
 class _UserRoles implements UserRoles {
-  const _UserRoles({required this.userId, required this.role, required this.createdAt});
+  const _UserRoles({required this.userId, required this.role, @RequiredDateTimeConverter() required this.createdAt});
   factory _UserRoles.fromJson(Map<String, dynamic> json) => _$UserRolesFromJson(json);
 
 @override final  String userId;
 @override final  Role role;
-@override final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
 
 /// Create a copy of UserRoles
 /// with the given fields replaced by the non-null parameter values.
@@ -251,7 +251,7 @@ abstract mixin class _$UserRolesCopyWith<$Res> implements $UserRolesCopyWith<$Re
   factory _$UserRolesCopyWith(_UserRoles value, $Res Function(_UserRoles) _then) = __$UserRolesCopyWithImpl;
 @override @useResult
 $Res call({
- String userId, Role role, DateTime createdAt
+ String userId, Role role,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 

--- a/packages/db_types/lib/src/tables/user_roles.g.dart
+++ b/packages/db_types/lib/src/tables/user_roles.g.dart
@@ -17,7 +17,7 @@ _UserRoles _$UserRolesFromJson(Map<String, dynamic> json) => $checkedCreate(
       role: $checkedConvert('role', (v) => $enumDecode(_$RoleEnumMap, v)),
       createdAt: $checkedConvert(
         'created_at',
-        (v) => DateTime.parse(v as String),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
     );
     return val;
@@ -25,12 +25,13 @@ _UserRoles _$UserRolesFromJson(Map<String, dynamic> json) => $checkedCreate(
   fieldKeyMap: const {'userId': 'user_id', 'createdAt': 'created_at'},
 );
 
-Map<String, dynamic> _$UserRolesToJson(_UserRoles instance) =>
-    <String, dynamic>{
-      'user_id': instance.userId,
-      'role': _$RoleEnumMap[instance.role]!,
-      'created_at': instance.createdAt.toIso8601String(),
-    };
+Map<String, dynamic> _$UserRolesToJson(
+  _UserRoles instance,
+) => <String, dynamic>{
+  'user_id': instance.userId,
+  'role': _$RoleEnumMap[instance.role]!,
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
+};
 
 const _$RoleEnumMap = {
   Role.admin: 'admin',

--- a/packages/db_types/lib/src/tables/users.dart
+++ b/packages/db_types/lib/src/tables/users.dart
@@ -1,3 +1,4 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'users.freezed.dart';
@@ -5,8 +6,10 @@ part 'users.g.dart';
 
 @freezed
 abstract class Users with _$Users {
-  const factory Users({required String id, required DateTime createdAt}) =
-      _Users;
+  const factory Users({
+    required String id,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+  }) = _Users;
 
   factory Users.fromJson(Map<String, dynamic> json) => _$UsersFromJson(json);
 }

--- a/packages/db_types/lib/src/tables/users.freezed.dart
+++ b/packages/db_types/lib/src/tables/users.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Users {
 
- String get id; DateTime get createdAt;
+ String get id;@RequiredDateTimeConverter() DateTime get createdAt;
 /// Create a copy of Users
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $UsersCopyWith<$Res>  {
   factory $UsersCopyWith(Users value, $Res Function(Users) _then) = _$UsersCopyWithImpl;
 @useResult
 $Res call({
- String id, DateTime createdAt
+ String id,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 
@@ -154,7 +154,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Users() when $default != null:
 return $default(_that.id,_that.createdAt);case _:
@@ -175,7 +175,7 @@ return $default(_that.id,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  DateTime createdAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @RequiredDateTimeConverter()  DateTime createdAt)  $default,) {final _that = this;
 switch (_that) {
 case _Users():
 return $default(_that.id,_that.createdAt);case _:
@@ -195,7 +195,7 @@ return $default(_that.id,_that.createdAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  DateTime createdAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @RequiredDateTimeConverter()  DateTime createdAt)?  $default,) {final _that = this;
 switch (_that) {
 case _Users() when $default != null:
 return $default(_that.id,_that.createdAt);case _:
@@ -210,11 +210,11 @@ return $default(_that.id,_that.createdAt);case _:
 @JsonSerializable()
 
 class _Users implements Users {
-  const _Users({required this.id, required this.createdAt});
+  const _Users({required this.id, @RequiredDateTimeConverter() required this.createdAt});
   factory _Users.fromJson(Map<String, dynamic> json) => _$UsersFromJson(json);
 
 @override final  String id;
-@override final  DateTime createdAt;
+@override@RequiredDateTimeConverter() final  DateTime createdAt;
 
 /// Create a copy of Users
 /// with the given fields replaced by the non-null parameter values.
@@ -249,7 +249,7 @@ abstract mixin class _$UsersCopyWith<$Res> implements $UsersCopyWith<$Res> {
   factory _$UsersCopyWith(_Users value, $Res Function(_Users) _then) = __$UsersCopyWithImpl;
 @override @useResult
 $Res call({
- String id, DateTime createdAt
+ String id,@RequiredDateTimeConverter() DateTime createdAt
 });
 
 

--- a/packages/db_types/lib/src/tables/users.g.dart
+++ b/packages/db_types/lib/src/tables/users.g.dart
@@ -14,7 +14,7 @@ _Users _$UsersFromJson(Map<String, dynamic> json) =>
         id: $checkedConvert('id', (v) => v as String),
         createdAt: $checkedConvert(
           'created_at',
-          (v) => DateTime.parse(v as String),
+          (v) => const RequiredDateTimeConverter().fromJson(v),
         ),
       );
       return val;
@@ -22,5 +22,5 @@ _Users _$UsersFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$UsersToJson(_Users instance) => <String, dynamic>{
   'id': instance.id,
-  'created_at': instance.createdAt.toIso8601String(),
+  'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
 };


### PR DESCRIPTION
## Issue

なし

## 概要

BFFのAPIで発生していたDateTime型の型キャストエラーを修正しました。

## 詳細

### 問題
BFFのAPI実行時に以下のエラーが発生していました：
```
JSONのデコード中にエラーが発生しました: starts_at, type 'DateTime' is not a subtype of type 'String' in type cast
```

### 原因
- PostgreSQLから返されるDateTimeフィールドが、Dartコードでは文字列として処理されることを期待していた
- `DateTimeConverter`が文字列からの変換のみを想定していたため、既にDateTimeオブジェクトとして返される場合に対応していなかった
- さらに、`null`値が渡された際にもエラーが発生していた

### 解決策
1. **共通コンバーターの作成**
   - `packages/db_types/lib/src/converters/date_time_converter.dart`に共通のコンバーターを定義
   - `DateTimeConverter`：nullableなDateTimeフィールド用（`null`値を許可）
   - `RequiredDateTimeConverter`：必須DateTimeフィールド用（`null`値を拒否）

2. **全テーブルファイルの修正**
   - 全てのDateTimeフィールドに適切なコンバーターを追加
   - 修正したファイル：14ファイル（news.dart, ticket_types.dart, ticket_options.dart, ticket_checkout_sessions.dart, sponsors.dart, users.dart, individual_drafts.dart, companies.dart, individuals.dart, ticket_purchases.dart, stripe_webhook_logs.dart, user_roles.dart, company_drafts.dart, company_invitation.dart）

### 対応したケース
- PostgreSQLから`null`値が返される場合
- PostgreSQLから文字列が返される場合
- PostgreSQLからDateTimeオブジェクトが返される場合

## 画像・動画

なし

## その他

- 修正後、`melos run gen:build`を実行してコード生成を正常に完了
- 43ファイルが変更され、450行の追加、405行の削除
- `supabase/seeds/005_news.sql`が新規作成