### PR TITLE
[Infra]: ニュースデータの追加

### DIFF
--- a/supabase/seeds/005_news.sql
+++ b/supabase/seeds/005_news.sql
@@ -1,0 +1,15 @@
+INSERT INTO
+    public.news (title, url, starts_at, ends_at)
+VALUES
+    (
+        'FlutterKaigi mini #4 @Kyoto を開催',
+        'https://medium.com/flutterkaigi/flutterkaigi-mini-4-kyoto-%E3%82%92%E9%96%8B%E5%82%AC%E3%81%97%E3%81%BE%E3%81%99-85facf0ec6b2',
+        '2025-04-16 09:00:00+00'::timestamp,
+        '2025-06-30 09:00:00+00'::timestamp
+    ),
+    (
+        'FlutterKaigi 2025 スポンサー募集を開始',
+        'https://medium.com/flutterkaigi/flutterkaigi-2025-%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B5%E3%83%BC%E5%8B%9F%E9%9B%86%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6-034330881a94',
+        '2025-04-23 09:00:00+00'::timestamp,
+        NULL
+    );


### PR DESCRIPTION
## Issue

Closes #190

## 概要

ニューステーブルにサンプルデータを追加しました。

## 詳細

`supabase/seeds/005_news.sql` に以下のニュースデータを追加しました：

- FlutterKaigi mini #4 @Kyoto 開催のお知らせ
- FlutterKaigi 2025 スポンサー募集開始のお知らせ

これらのデータは、アプリケーションでのニュース機能のテストに使用されます。

## 画像・動画

<img width="320" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-26 at 16 12 37" src="https://github.com/user-attachments/assets/fadcda46-ea17-4ec3-8885-af94e548b6e0" />


## その他

なし