### PR TITLE
[BFF] Internal API ProxyのDart Clientを実装

### DIFF
--- a/packages/internal_api_client/README.md
+++ b/packages/internal_api_client/README.md
@@ -1,4 +1,228 @@
-# Base Package
+# Internal API Client
 
-FlutterKaigi 2025のDartベースパッケージ
-パッケージを作成する時はこのディレクトリをコピー&リネームして作業を進めましょう!
+Payment Workflow Internal API用のDartクライアントライブラリです。
+
+## 概要
+
+このパッケージは、FlutterKaigi 2025プロジェクトの決済ワークフロー用内部APIとの通信を簡素化し、型安全性を提供します。
+
+## 機能
+
+- **チケットチェックアウトワークフロー**: チケット購入プロセスの開始と監視
+- **支払い完了ワークフロー**: 支払い処理の完了と検証
+- **型安全性**: Freezedを使用した厳密な型定義
+- **非同期処理**: Future/awaitパターンによる非同期API呼び出し
+
+## セットアップ
+
+`pubspec.yaml`に依存関係を追加：
+
+```yaml
+dependencies:
+  internal_api_client:
+    path: ../packages/internal_api_client
+```
+
+## 使用例
+
+### 基本的なセットアップ
+
+```dart
+import 'package:dio/dio.dart';
+import 'package:internal_api_client/internal_api_client.dart';
+
+// Dioクライアントを設定
+final dio = Dio();
+dio.options.baseUrl = 'https://your-api-domain.com';
+
+// Internal API クライアントを初期化
+final apiClient = InternalApiClient(
+  dio: dio,
+  baseUrl: 'https://your-api-domain.com',
+);
+```
+
+### チケットチェックアウトワークフロー
+
+```dart
+// チケットチェックアウトワークフローを開始
+try {
+  final response = await apiClient.ticketCheckout
+      .startTicketCheckoutWorkflow(
+    ticketCheckoutSessionId: 'session_123',
+  );
+  
+  final status = response.data;
+  print('ワークフロー開始: ${status.status}');
+} catch (e) {
+  print('エラー: $e');
+}
+
+// ワークフローステータスを確認
+try {
+  final response = await apiClient.ticketCheckout
+      .getTicketCheckoutWorkflowStatus(
+    ticketCheckoutSessionId: 'session_123',
+  );
+  
+  final status = response.data;
+  switch (status.status) {
+    case ContainerInstanceStatusEnum.queued:
+      print('処理待ち中');
+      break;
+    case ContainerInstanceStatusEnum.running:
+      print('処理中');
+      break;
+    case ContainerInstanceStatusEnum.complete:
+      print('完了');
+      break;
+    case ContainerInstanceStatusEnum.errored:
+      print('エラー: ${status.error}');
+      break;
+    default:
+      print('ステータス: ${status.status}');
+  }
+} catch (e) {
+  print('エラー: $e');
+}
+```
+
+### 支払い完了ワークフロー
+
+```dart
+// PaymentIntentを作成
+final paymentIntent = PaymentIntent(
+  id: 'pi_123456',
+  clientSecret: 'pi_123456_secret_abc',
+  amount: 5000,
+  currency: 'jpy',
+  status: 'succeeded',
+  customerId: 'cus_123',
+  metadata: {
+    'order_id': 'order_789',
+    'event_id': 'flutterkaigi_2025',
+  },
+);
+
+// 支払い完了ワークフローを開始
+try {
+  final response = await apiClient.paymentCompletion
+      .startPaymentCompletionWorkflow(
+    userId: 'user_123',
+    ticketCheckoutId: 'checkout_456',
+    paymentIntent: paymentIntent,
+  );
+  
+  final status = response.data;
+  print('支払い完了ワークフロー開始: ${status.status}');
+} catch (e) {
+  print('エラー: $e');
+}
+
+// 支払い完了ワークフローのステータスを確認
+try {
+  final response = await apiClient.paymentCompletion
+      .getPaymentCompletionWorkflowStatus(
+    ticketCheckoutId: 'checkout_456',
+  );
+  
+  final status = response.data;
+  if (status.status == ContainerInstanceStatusEnum.complete) {
+    print('支払い処理が完了しました');
+    if (status.output != null) {
+      print('結果: ${status.output}');
+    }
+  }
+} catch (e) {
+  print('エラー: $e');
+}
+```
+
+### エラーハンドリング
+
+```dart
+import 'package:dio/dio.dart';
+
+try {
+  final response = await apiClient.ticketCheckout
+      .startTicketCheckoutWorkflow(
+    ticketCheckoutSessionId: 'session_123',
+  );
+  // 成功時の処理
+} on DioException catch (e) {
+  switch (e.type) {
+    case DioExceptionType.connectionTimeout:
+      print('接続タイムアウト');
+      break;
+    case DioExceptionType.receiveTimeout:
+      print('受信タイムアウト');
+      break;
+    case DioExceptionType.badResponse:
+      print('HTTPエラー: ${e.response?.statusCode}');
+      break;
+    default:
+      print('通信エラー: ${e.message}');
+  }
+} catch (e) {
+  print('予期しないエラー: $e');
+}
+```
+
+## データモデル
+
+### ContainerInstanceStatus
+
+ワークフローの実行状態を表します：
+
+```dart
+enum ContainerInstanceStatusEnum {
+  queued,      // 処理待ち
+  running,     // 実行中
+  paused,      // 一時停止
+  errored,     // エラー
+  terminated,  // 終了
+  complete,    // 完了
+  waiting,     // 待機
+  waitingForPause,  // 一時停止待ち
+  unknown,     // 不明
+}
+```
+
+### PaymentIntent
+
+支払い情報を表します：
+
+```dart
+class PaymentIntent {
+  final String id;              // PaymentIntent ID
+  final String clientSecret;    // クライアントシークレット
+  final int amount;            // 金額（最小単位）
+  final String currency;       // 通貨コード
+  final String status;         // 支払いステータス
+  final String? customerId;    // 顧客ID（オプション）
+  final Map<String, dynamic>? metadata;  // メタデータ（オプション）
+}
+```
+
+## 開発
+
+### コード生成
+
+モデルクラスやAPIクライアントの変更後は、以下のコマンドでコード生成を実行してください：
+
+```bash
+cd packages/internal_api_client
+dart run build_runner build --delete-conflicting-outputs
+```
+
+### 分析
+
+コードの品質を確認：
+
+```bash
+flutter analyze
+```
+
+## ライセンス
+
+このプロジェクトはFlutterKaigi 2025の一部です。

--- a/packages/internal_api_client/build.yaml
+++ b/packages/internal_api_client/build.yaml
@@ -1,0 +1,19 @@
+targets:
+  $default:
+    builders:
+      # https://github.com/google/json_serializable.dart/tree/master/json_serializable#build-configuration
+      json_serializable:
+        options:
+          field_rename: snake
+          # json のデシリアライズ時に発生する Exception を CheckedFromJsonException にまとめる
+          checked: true
+      # https://github.com/dart-lang/source_gen#ignore_for_file
+      source_gen:combining_builder:
+        options:
+          ignore_for_file:
+            - type=lint
+            - duplicate_ignore
+      # https://github.com/trevorwang/retrofit.dart#configuration
+      retrofit_generator:
+        options:
+          convert_snake_case: true

--- a/packages/internal_api_client/lib/hello.dart
+++ b/packages/internal_api_client/lib/hello.dart
@@ -1,2 +1,0 @@
-// ignore: avoid_print
-void main() => print('Hello, World!');

--- a/packages/internal_api_client/lib/internal_api_client.dart
+++ b/packages/internal_api_client/lib/internal_api_client.dart
@@ -1,0 +1,6 @@
+// Payment Workflow Internal API Client Library
+export 'src/api/payment_completion_api_client.dart';
+export 'src/api/ticket_checkout_api_client.dart';
+export 'src/internal_api_client.dart';
+export 'src/model/container_instance_status.dart';
+export 'src/model/payment_intent.dart';

--- a/packages/internal_api_client/lib/src/api/payment_completion_api_client.dart
+++ b/packages/internal_api_client/lib/src/api/payment_completion_api_client.dart
@@ -1,0 +1,27 @@
+import 'package:dio/dio.dart';
+import 'package:internal_api_client/src/model/container_instance_status.dart';
+import 'package:internal_api_client/src/model/payment_intent.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'payment_completion_api_client.g.dart';
+
+@RestApi()
+abstract class PaymentCompletionApiClient {
+  factory PaymentCompletionApiClient(Dio dio, {String? baseUrl}) =
+      _PaymentCompletionApiClient;
+
+  /// 支払い完了ワークフローを開始します
+  @PUT('/payment-completion/{userId}/{ticketCheckoutId}')
+  Future<HttpResponse<ContainerInstanceStatus>> startPaymentCompletionWorkflow({
+    @Path() required String userId,
+    @Path() required String ticketCheckoutId,
+    @Body() required PaymentIntent paymentIntent,
+  });
+
+  /// 支払い完了ワークフローのステータスを取得します
+  @GET('/payment-completion/{ticketCheckoutId}')
+  Future<HttpResponse<ContainerInstanceStatus>>
+      getPaymentCompletionWorkflowStatus({
+    @Path() required String ticketCheckoutId,
+  });
+}

--- a/packages/internal_api_client/lib/src/api/payment_completion_api_client.g.dart
+++ b/packages/internal_api_client/lib/src/api/payment_completion_api_client.g.dart
@@ -1,0 +1,109 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'payment_completion_api_client.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
+
+class _PaymentCompletionApiClient implements PaymentCompletionApiClient {
+  _PaymentCompletionApiClient(this._dio, {this.baseUrl, this.errorLogger});
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<HttpResponse<ContainerInstanceStatus>> startPaymentCompletionWorkflow({
+    required String userId,
+    required String ticketCheckoutId,
+    required PaymentIntent paymentIntent,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = paymentIntent;
+    final _options = _setStreamType<HttpResponse<ContainerInstanceStatus>>(
+      Options(method: 'PUT', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/payment-completion/${userId}/${ticketCheckoutId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ContainerInstanceStatus _value;
+    try {
+      _value = ContainerInstanceStatus.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<ContainerInstanceStatus>>
+  getPaymentCompletionWorkflowStatus({required String ticketCheckoutId}) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<ContainerInstanceStatus>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/payment-completion/${ticketCheckoutId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ContainerInstanceStatus _value;
+    try {
+      _value = ContainerInstanceStatus.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}

--- a/packages/internal_api_client/lib/src/api/ticket_checkout_api_client.dart
+++ b/packages/internal_api_client/lib/src/api/ticket_checkout_api_client.dart
@@ -1,0 +1,24 @@
+import 'package:dio/dio.dart';
+import 'package:internal_api_client/src/model/container_instance_status.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'ticket_checkout_api_client.g.dart';
+
+@RestApi()
+abstract class TicketCheckoutApiClient {
+  factory TicketCheckoutApiClient(Dio dio, {String? baseUrl}) =
+      _TicketCheckoutApiClient;
+
+  /// チケットチェックアウトワークフローを開始します
+  @PUT('/ticket-checkout/{ticketCheckoutSessionId}')
+  Future<HttpResponse<ContainerInstanceStatus>> startTicketCheckoutWorkflow({
+    @Path() required String ticketCheckoutSessionId,
+  });
+
+  /// チケットチェックアウトワークフローのステータスを取得します
+  @GET('/ticket-checkout/{ticketCheckoutSessionId}')
+  Future<HttpResponse<ContainerInstanceStatus>>
+      getTicketCheckoutWorkflowStatus({
+    @Path() required String ticketCheckoutSessionId,
+  });
+}

--- a/packages/internal_api_client/lib/src/api/ticket_checkout_api_client.g.dart
+++ b/packages/internal_api_client/lib/src/api/ticket_checkout_api_client.g.dart
@@ -1,0 +1,109 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'ticket_checkout_api_client.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
+
+class _TicketCheckoutApiClient implements TicketCheckoutApiClient {
+  _TicketCheckoutApiClient(this._dio, {this.baseUrl, this.errorLogger});
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<HttpResponse<ContainerInstanceStatus>> startTicketCheckoutWorkflow({
+    required String ticketCheckoutSessionId,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<ContainerInstanceStatus>>(
+      Options(method: 'PUT', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/ticket-checkout/${ticketCheckoutSessionId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ContainerInstanceStatus _value;
+    try {
+      _value = ContainerInstanceStatus.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<HttpResponse<ContainerInstanceStatus>>
+  getTicketCheckoutWorkflowStatus({
+    required String ticketCheckoutSessionId,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<ContainerInstanceStatus>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/ticket-checkout/${ticketCheckoutSessionId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late ContainerInstanceStatus _value;
+    try {
+      _value = ContainerInstanceStatus.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}

--- a/packages/internal_api_client/lib/src/internal_api_client.dart
+++ b/packages/internal_api_client/lib/src/internal_api_client.dart
@@ -1,0 +1,23 @@
+import 'package:dio/dio.dart';
+import 'package:internal_api_client/src/api/payment_completion_api_client.dart';
+import 'package:internal_api_client/src/api/ticket_checkout_api_client.dart';
+
+/// Payment Workflow Internal APIクライアント
+class InternalApiClient {
+  InternalApiClient({required Dio dio, String? baseUrl})
+      : _dio = dio,
+        _baseUrl = baseUrl;
+
+  final Dio _dio;
+  final String? _baseUrl;
+
+  /// チケットチェックアウトAPIクライアント
+  TicketCheckoutApiClient get ticketCheckout => _baseUrl != null
+      ? TicketCheckoutApiClient(_dio, baseUrl: _baseUrl)
+      : TicketCheckoutApiClient(_dio);
+
+  /// 支払い完了APIクライアント  
+  PaymentCompletionApiClient get paymentCompletion => _baseUrl != null
+      ? PaymentCompletionApiClient(_dio, baseUrl: _baseUrl)
+      : PaymentCompletionApiClient(_dio);
+}

--- a/packages/internal_api_client/lib/src/model/container_instance_status.dart
+++ b/packages/internal_api_client/lib/src/model/container_instance_status.dart
@@ -1,0 +1,38 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'container_instance_status.freezed.dart';
+part 'container_instance_status.g.dart';
+
+@freezed
+abstract class ContainerInstanceStatus with _$ContainerInstanceStatus {
+  const factory ContainerInstanceStatus({
+    required ContainerInstanceStatusEnum status,
+    String? error,
+    Map<String, dynamic>? output,
+  }) = _ContainerInstanceStatus;
+
+  factory ContainerInstanceStatus.fromJson(Map<String, dynamic> json) =>
+      _$ContainerInstanceStatusFromJson(json);
+}
+
+@JsonEnum()
+enum ContainerInstanceStatusEnum {
+  @JsonValue('queued')
+  queued,
+  @JsonValue('running')
+  running,
+  @JsonValue('paused')
+  paused,
+  @JsonValue('errored')
+  errored,
+  @JsonValue('terminated')
+  terminated,
+  @JsonValue('complete')
+  complete,
+  @JsonValue('waiting')
+  waiting,
+  @JsonValue('waitingForPause')
+  waitingForPause,
+  @JsonValue('unknown')
+  unknown,
+}

--- a/packages/internal_api_client/lib/src/model/container_instance_status.freezed.dart
+++ b/packages/internal_api_client/lib/src/model/container_instance_status.freezed.dart
@@ -1,0 +1,291 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'container_instance_status.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ContainerInstanceStatus {
+
+ ContainerInstanceStatusEnum get status; String? get error; Map<String, dynamic>? get output;
+/// Create a copy of ContainerInstanceStatus
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ContainerInstanceStatusCopyWith<ContainerInstanceStatus> get copyWith => _$ContainerInstanceStatusCopyWithImpl<ContainerInstanceStatus>(this as ContainerInstanceStatus, _$identity);
+
+  /// Serializes this ContainerInstanceStatus to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ContainerInstanceStatus&&(identical(other.status, status) || other.status == status)&&(identical(other.error, error) || other.error == error)&&const DeepCollectionEquality().equals(other.output, output));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status,error,const DeepCollectionEquality().hash(output));
+
+@override
+String toString() {
+  return 'ContainerInstanceStatus(status: $status, error: $error, output: $output)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ContainerInstanceStatusCopyWith<$Res>  {
+  factory $ContainerInstanceStatusCopyWith(ContainerInstanceStatus value, $Res Function(ContainerInstanceStatus) _then) = _$ContainerInstanceStatusCopyWithImpl;
+@useResult
+$Res call({
+ ContainerInstanceStatusEnum status, String? error, Map<String, dynamic>? output
+});
+
+
+
+
+}
+/// @nodoc
+class _$ContainerInstanceStatusCopyWithImpl<$Res>
+    implements $ContainerInstanceStatusCopyWith<$Res> {
+  _$ContainerInstanceStatusCopyWithImpl(this._self, this._then);
+
+  final ContainerInstanceStatus _self;
+  final $Res Function(ContainerInstanceStatus) _then;
+
+/// Create a copy of ContainerInstanceStatus
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,Object? error = freezed,Object? output = freezed,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as ContainerInstanceStatusEnum,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as String?,output: freezed == output ? _self.output : output // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ContainerInstanceStatus].
+extension ContainerInstanceStatusPatterns on ContainerInstanceStatus {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ContainerInstanceStatus value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ContainerInstanceStatus() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ContainerInstanceStatus value)  $default,){
+final _that = this;
+switch (_that) {
+case _ContainerInstanceStatus():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ContainerInstanceStatus value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ContainerInstanceStatus() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( ContainerInstanceStatusEnum status,  String? error,  Map<String, dynamic>? output)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ContainerInstanceStatus() when $default != null:
+return $default(_that.status,_that.error,_that.output);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( ContainerInstanceStatusEnum status,  String? error,  Map<String, dynamic>? output)  $default,) {final _that = this;
+switch (_that) {
+case _ContainerInstanceStatus():
+return $default(_that.status,_that.error,_that.output);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( ContainerInstanceStatusEnum status,  String? error,  Map<String, dynamic>? output)?  $default,) {final _that = this;
+switch (_that) {
+case _ContainerInstanceStatus() when $default != null:
+return $default(_that.status,_that.error,_that.output);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ContainerInstanceStatus implements ContainerInstanceStatus {
+  const _ContainerInstanceStatus({required this.status, this.error, final  Map<String, dynamic>? output}): _output = output;
+  factory _ContainerInstanceStatus.fromJson(Map<String, dynamic> json) => _$ContainerInstanceStatusFromJson(json);
+
+@override final  ContainerInstanceStatusEnum status;
+@override final  String? error;
+ final  Map<String, dynamic>? _output;
+@override Map<String, dynamic>? get output {
+  final value = _output;
+  if (value == null) return null;
+  if (_output is EqualUnmodifiableMapView) return _output;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+
+/// Create a copy of ContainerInstanceStatus
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ContainerInstanceStatusCopyWith<_ContainerInstanceStatus> get copyWith => __$ContainerInstanceStatusCopyWithImpl<_ContainerInstanceStatus>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ContainerInstanceStatusToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ContainerInstanceStatus&&(identical(other.status, status) || other.status == status)&&(identical(other.error, error) || other.error == error)&&const DeepCollectionEquality().equals(other._output, _output));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status,error,const DeepCollectionEquality().hash(_output));
+
+@override
+String toString() {
+  return 'ContainerInstanceStatus(status: $status, error: $error, output: $output)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ContainerInstanceStatusCopyWith<$Res> implements $ContainerInstanceStatusCopyWith<$Res> {
+  factory _$ContainerInstanceStatusCopyWith(_ContainerInstanceStatus value, $Res Function(_ContainerInstanceStatus) _then) = __$ContainerInstanceStatusCopyWithImpl;
+@override @useResult
+$Res call({
+ ContainerInstanceStatusEnum status, String? error, Map<String, dynamic>? output
+});
+
+
+
+
+}
+/// @nodoc
+class __$ContainerInstanceStatusCopyWithImpl<$Res>
+    implements _$ContainerInstanceStatusCopyWith<$Res> {
+  __$ContainerInstanceStatusCopyWithImpl(this._self, this._then);
+
+  final _ContainerInstanceStatus _self;
+  final $Res Function(_ContainerInstanceStatus) _then;
+
+/// Create a copy of ContainerInstanceStatus
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,Object? error = freezed,Object? output = freezed,}) {
+  return _then(_ContainerInstanceStatus(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as ContainerInstanceStatusEnum,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as String?,output: freezed == output ? _self._output : output // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/internal_api_client/lib/src/model/container_instance_status.g.dart
+++ b/packages/internal_api_client/lib/src/model/container_instance_status.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'container_instance_status.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ContainerInstanceStatus _$ContainerInstanceStatusFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('_ContainerInstanceStatus', json, ($checkedConvert) {
+  final val = _ContainerInstanceStatus(
+    status: $checkedConvert(
+      'status',
+      (v) => $enumDecode(_$ContainerInstanceStatusEnumEnumMap, v),
+    ),
+    error: $checkedConvert('error', (v) => v as String?),
+    output: $checkedConvert('output', (v) => v as Map<String, dynamic>?),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$ContainerInstanceStatusToJson(
+  _ContainerInstanceStatus instance,
+) => <String, dynamic>{
+  'status': _$ContainerInstanceStatusEnumEnumMap[instance.status]!,
+  'error': instance.error,
+  'output': instance.output,
+};
+
+const _$ContainerInstanceStatusEnumEnumMap = {
+  ContainerInstanceStatusEnum.queued: 'queued',
+  ContainerInstanceStatusEnum.running: 'running',
+  ContainerInstanceStatusEnum.paused: 'paused',
+  ContainerInstanceStatusEnum.errored: 'errored',
+  ContainerInstanceStatusEnum.terminated: 'terminated',
+  ContainerInstanceStatusEnum.complete: 'complete',
+  ContainerInstanceStatusEnum.waiting: 'waiting',
+  ContainerInstanceStatusEnum.waitingForPause: 'waitingForPause',
+  ContainerInstanceStatusEnum.unknown: 'unknown',
+};

--- a/packages/internal_api_client/lib/src/model/payment_intent.dart
+++ b/packages/internal_api_client/lib/src/model/payment_intent.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'payment_intent.freezed.dart';
+part 'payment_intent.g.dart';
+
+@freezed
+abstract class PaymentIntent with _$PaymentIntent {
+  const factory PaymentIntent({
+    required String id,
+    required String clientSecret,
+    required int amount,
+    required String currency,
+    required String status,
+    String? customerId,
+    Map<String, dynamic>? metadata,
+  }) = _PaymentIntent;
+
+  factory PaymentIntent.fromJson(Map<String, dynamic> json) =>
+      _$PaymentIntentFromJson(json);
+}

--- a/packages/internal_api_client/lib/src/model/payment_intent.freezed.dart
+++ b/packages/internal_api_client/lib/src/model/payment_intent.freezed.dart
@@ -1,0 +1,303 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'payment_intent.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PaymentIntent {
+
+ String get id; String get clientSecret; int get amount; String get currency; String get status; String? get customerId; Map<String, dynamic>? get metadata;
+/// Create a copy of PaymentIntent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PaymentIntentCopyWith<PaymentIntent> get copyWith => _$PaymentIntentCopyWithImpl<PaymentIntent>(this as PaymentIntent, _$identity);
+
+  /// Serializes this PaymentIntent to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PaymentIntent&&(identical(other.id, id) || other.id == id)&&(identical(other.clientSecret, clientSecret) || other.clientSecret == clientSecret)&&(identical(other.amount, amount) || other.amount == amount)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.status, status) || other.status == status)&&(identical(other.customerId, customerId) || other.customerId == customerId)&&const DeepCollectionEquality().equals(other.metadata, metadata));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,clientSecret,amount,currency,status,customerId,const DeepCollectionEquality().hash(metadata));
+
+@override
+String toString() {
+  return 'PaymentIntent(id: $id, clientSecret: $clientSecret, amount: $amount, currency: $currency, status: $status, customerId: $customerId, metadata: $metadata)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PaymentIntentCopyWith<$Res>  {
+  factory $PaymentIntentCopyWith(PaymentIntent value, $Res Function(PaymentIntent) _then) = _$PaymentIntentCopyWithImpl;
+@useResult
+$Res call({
+ String id, String clientSecret, int amount, String currency, String status, String? customerId, Map<String, dynamic>? metadata
+});
+
+
+
+
+}
+/// @nodoc
+class _$PaymentIntentCopyWithImpl<$Res>
+    implements $PaymentIntentCopyWith<$Res> {
+  _$PaymentIntentCopyWithImpl(this._self, this._then);
+
+  final PaymentIntent _self;
+  final $Res Function(PaymentIntent) _then;
+
+/// Create a copy of PaymentIntent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? clientSecret = null,Object? amount = null,Object? currency = null,Object? status = null,Object? customerId = freezed,Object? metadata = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,clientSecret: null == clientSecret ? _self.clientSecret : clientSecret // ignore: cast_nullable_to_non_nullable
+as String,amount: null == amount ? _self.amount : amount // ignore: cast_nullable_to_non_nullable
+as int,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,customerId: freezed == customerId ? _self.customerId : customerId // ignore: cast_nullable_to_non_nullable
+as String?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PaymentIntent].
+extension PaymentIntentPatterns on PaymentIntent {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PaymentIntent value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PaymentIntent() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PaymentIntent value)  $default,){
+final _that = this;
+switch (_that) {
+case _PaymentIntent():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PaymentIntent value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PaymentIntent() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String clientSecret,  int amount,  String currency,  String status,  String? customerId,  Map<String, dynamic>? metadata)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PaymentIntent() when $default != null:
+return $default(_that.id,_that.clientSecret,_that.amount,_that.currency,_that.status,_that.customerId,_that.metadata);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String clientSecret,  int amount,  String currency,  String status,  String? customerId,  Map<String, dynamic>? metadata)  $default,) {final _that = this;
+switch (_that) {
+case _PaymentIntent():
+return $default(_that.id,_that.clientSecret,_that.amount,_that.currency,_that.status,_that.customerId,_that.metadata);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String clientSecret,  int amount,  String currency,  String status,  String? customerId,  Map<String, dynamic>? metadata)?  $default,) {final _that = this;
+switch (_that) {
+case _PaymentIntent() when $default != null:
+return $default(_that.id,_that.clientSecret,_that.amount,_that.currency,_that.status,_that.customerId,_that.metadata);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PaymentIntent implements PaymentIntent {
+  const _PaymentIntent({required this.id, required this.clientSecret, required this.amount, required this.currency, required this.status, this.customerId, final  Map<String, dynamic>? metadata}): _metadata = metadata;
+  factory _PaymentIntent.fromJson(Map<String, dynamic> json) => _$PaymentIntentFromJson(json);
+
+@override final  String id;
+@override final  String clientSecret;
+@override final  int amount;
+@override final  String currency;
+@override final  String status;
+@override final  String? customerId;
+ final  Map<String, dynamic>? _metadata;
+@override Map<String, dynamic>? get metadata {
+  final value = _metadata;
+  if (value == null) return null;
+  if (_metadata is EqualUnmodifiableMapView) return _metadata;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+
+/// Create a copy of PaymentIntent
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PaymentIntentCopyWith<_PaymentIntent> get copyWith => __$PaymentIntentCopyWithImpl<_PaymentIntent>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PaymentIntentToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PaymentIntent&&(identical(other.id, id) || other.id == id)&&(identical(other.clientSecret, clientSecret) || other.clientSecret == clientSecret)&&(identical(other.amount, amount) || other.amount == amount)&&(identical(other.currency, currency) || other.currency == currency)&&(identical(other.status, status) || other.status == status)&&(identical(other.customerId, customerId) || other.customerId == customerId)&&const DeepCollectionEquality().equals(other._metadata, _metadata));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,clientSecret,amount,currency,status,customerId,const DeepCollectionEquality().hash(_metadata));
+
+@override
+String toString() {
+  return 'PaymentIntent(id: $id, clientSecret: $clientSecret, amount: $amount, currency: $currency, status: $status, customerId: $customerId, metadata: $metadata)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PaymentIntentCopyWith<$Res> implements $PaymentIntentCopyWith<$Res> {
+  factory _$PaymentIntentCopyWith(_PaymentIntent value, $Res Function(_PaymentIntent) _then) = __$PaymentIntentCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String clientSecret, int amount, String currency, String status, String? customerId, Map<String, dynamic>? metadata
+});
+
+
+
+
+}
+/// @nodoc
+class __$PaymentIntentCopyWithImpl<$Res>
+    implements _$PaymentIntentCopyWith<$Res> {
+  __$PaymentIntentCopyWithImpl(this._self, this._then);
+
+  final _PaymentIntent _self;
+  final $Res Function(_PaymentIntent) _then;
+
+/// Create a copy of PaymentIntent
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? clientSecret = null,Object? amount = null,Object? currency = null,Object? status = null,Object? customerId = freezed,Object? metadata = freezed,}) {
+  return _then(_PaymentIntent(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,clientSecret: null == clientSecret ? _self.clientSecret : clientSecret // ignore: cast_nullable_to_non_nullable
+as String,amount: null == amount ? _self.amount : amount // ignore: cast_nullable_to_non_nullable
+as int,currency: null == currency ? _self.currency : currency // ignore: cast_nullable_to_non_nullable
+as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,customerId: freezed == customerId ? _self.customerId : customerId // ignore: cast_nullable_to_non_nullable
+as String?,metadata: freezed == metadata ? _self._metadata : metadata // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/internal_api_client/lib/src/model/payment_intent.g.dart
+++ b/packages/internal_api_client/lib/src/model/payment_intent.g.dart
@@ -1,0 +1,45 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'payment_intent.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PaymentIntent _$PaymentIntentFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      '_PaymentIntent',
+      json,
+      ($checkedConvert) {
+        final val = _PaymentIntent(
+          id: $checkedConvert('id', (v) => v as String),
+          clientSecret: $checkedConvert('client_secret', (v) => v as String),
+          amount: $checkedConvert('amount', (v) => (v as num).toInt()),
+          currency: $checkedConvert('currency', (v) => v as String),
+          status: $checkedConvert('status', (v) => v as String),
+          customerId: $checkedConvert('customer_id', (v) => v as String?),
+          metadata: $checkedConvert(
+            'metadata',
+            (v) => v as Map<String, dynamic>?,
+          ),
+        );
+        return val;
+      },
+      fieldKeyMap: const {
+        'clientSecret': 'client_secret',
+        'customerId': 'customer_id',
+      },
+    );
+
+Map<String, dynamic> _$PaymentIntentToJson(_PaymentIntent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'client_secret': instance.clientSecret,
+      'amount': instance.amount,
+      'currency': instance.currency,
+      'status': instance.status,
+      'customer_id': instance.customerId,
+      'metadata': instance.metadata,
+    };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1486,26 +1486,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.15"
+    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.11"
   time:
     dependency: transitive
     description:
@@ -1638,10 +1638,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ workspace:
   - packages/db_types
   - packages/auth_client
   - packages/db_client
+  - packages/internal_api_client
   - packages/_base
   # bff
   - bff/engine


### PR DESCRIPTION
```
## Issue

Closes #{issue_number}

## 概要

Payment Workflow Internal APIのDartクライアントを新規パッケージとして実装しました。

## 詳細

`bff/payment-workflow-internal-api/src/index.ts`で定義されているAPIエンドポイントとデータ構造に基づき、Dartで型安全なクライアントライブラリを構築しました。

-   **目的**: FlutterアプリケーションからPayment Workflow Internal APIへの型安全かつ効率的なアクセスを可能にします。
-   **実装内容**:
    -   `packages/internal_api_client` パッケージの追加。
    -   `TicketCheckoutApiClient` と `PaymentCompletionApiClient` の定義。
    -   `ContainerInstanceStatus` と `PaymentIntent` モデルのFreezed/JSON Serializableによる型安全な実装。
    -   Retrofitを用いたHTTP通信の抽象化。
-   **利用方法**: `packages/internal_api_client/README.md` に詳細な使用例とセットアップ手順を記載しています。

## 画像・動画

| Before | After | Design |
| ------ | ----- | ------ |
|        |       |        |

## その他

-   `dart run build_runner build` によりコード生成済み。
-   `flutter analyze` にて静的解析エラーがないことを確認済み。
```

---

[Open in Web](https://cursor.com/agents?id=bc-c40d7073-de41-4154-add7-a181a2876710) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c40d7073-de41-4154-add7-a181a2876710) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)