### PR TITLE
feat(ticket): 自分の購入済みチケット一覧を取得するAPIを追加

### DIFF
--- a/bff/engine/lib/routes/ticket_api_service.dart
+++ b/bff/engine/lib/routes/ticket_api_service.dart
@@ -233,5 +233,26 @@ class TicketApiService {
     },
   );
 
+  /// 自分の購入済みチケット一覧を取得
+  @Route.get('/me')
+  Future<Response> _getUserTickets(Request request) async => jsonResponse(
+    () async {
+      final supabaseUtil = container.read(supabaseUtilProvider);
+      final userResult = await supabaseUtil.extractUser(request);
+      final (_, user, _) = userResult.unwrap;
+
+      final database = await container.read(dbClientProvider.future);
+      final response = await (
+        database.ticketPurchase.getUserAllTickets(user.id),
+        database.ticketCheckout.getUserSessionHistory(user.id),
+      ).wait;
+
+      return UserTicketsResponse(
+        tickets: response.$1,
+        ticketCheckouts: response.$2,
+      ).toJson();
+    },
+  );
+
   Router get router => _$TicketApiServiceRouter(this);
 }

--- a/bff/engine/lib/routes/ticket_api_service.g.dart
+++ b/bff/engine/lib/routes/ticket_api_service.g.dart
@@ -18,5 +18,6 @@ Router _$TicketApiServiceRouter(TicketApiService service) {
   );
   router.add('POST', r'/checkout', service._createCheckout);
   router.add('GET', r'/checkout/<sessionId>', service._getCheckoutSession);
+  router.add('GET', r'/me', service._getUserTickets);
   return router;
 }

--- a/packages/bff_client/lib/src/api/v1/news_api_client.g.dart
+++ b/packages/bff_client/lib/src/api/v1/news_api_client.g.dart
@@ -8,7 +8,7 @@ part of 'news_api_client.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter
 
 class _NewsApiClient implements NewsApiClient {
   _NewsApiClient(this._dio, {this.baseUrl, this.errorLogger});

--- a/packages/bff_client/lib/src/api/v1/tickets_api_client.dart
+++ b/packages/bff_client/lib/src/api/v1/tickets_api_client.dart
@@ -29,4 +29,8 @@ abstract class TicketsApiClient {
   Future<TicketCheckoutSessionResponse> getCheckoutSession(
     @Path('sessionId') String sessionId,
   );
+
+  /// 自分の購入済みチケット一覧を取得
+  @GET('/v1/tickets/me')
+  Future<UserTicketsResponse> getUserTickets();
 }

--- a/packages/bff_client/lib/src/api/v1/tickets_api_client.g.dart
+++ b/packages/bff_client/lib/src/api/v1/tickets_api_client.g.dart
@@ -8,7 +8,7 @@ part of 'tickets_api_client.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter
 
 class _TicketsApiClient implements TicketsApiClient {
   _TicketsApiClient(this._dio, {this.baseUrl, this.errorLogger});
@@ -126,6 +126,33 @@ class _TicketsApiClient implements TicketsApiClient {
     late TicketCheckoutSessionResponse _value;
     try {
       _value = TicketCheckoutSessionResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<UserTicketsResponse> getUserTickets() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<UserTicketsResponse>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/v1/tickets/me',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late UserTicketsResponse _value;
+    try {
+      _value = UserTicketsResponse.fromJson(_result.data!);
     } on Object catch (e, s) {
       errorLogger?.logError(e, s, _options);
       rethrow;

--- a/packages/bff_client/lib/src/api/v1/users_api_client.g.dart
+++ b/packages/bff_client/lib/src/api/v1/users_api_client.g.dart
@@ -8,7 +8,7 @@ part of 'users_api_client.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter
 
 class _UsersApiClient implements UsersApiClient {
   _UsersApiClient(this._dio, {this.baseUrl, this.errorLogger});

--- a/packages/bff_client/lib/src/model/v1/tickets/user_tickets_response.dart
+++ b/packages/bff_client/lib/src/model/v1/tickets/user_tickets_response.dart
@@ -1,0 +1,16 @@
+import 'package:db_types/db_types.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user_tickets_response.freezed.dart';
+part 'user_tickets_response.g.dart';
+
+@freezed
+abstract class UserTicketsResponse with _$UserTicketsResponse {
+  const factory UserTicketsResponse({
+    required List<TicketPurchases> tickets,
+    required List<TicketCheckoutSessions> ticketCheckouts,
+  }) = _UserTicketsResponse;
+
+  factory UserTicketsResponse.fromJson(Map<String, dynamic> json) =>
+      _$UserTicketsResponseFromJson(json);
+}

--- a/packages/bff_client/lib/src/model/v1/tickets/user_tickets_response.freezed.dart
+++ b/packages/bff_client/lib/src/model/v1/tickets/user_tickets_response.freezed.dart
@@ -1,0 +1,292 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_tickets_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$UserTicketsResponse {
+
+ List<TicketPurchases> get tickets; List<TicketCheckoutSessions> get ticketCheckouts;
+/// Create a copy of UserTicketsResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UserTicketsResponseCopyWith<UserTicketsResponse> get copyWith => _$UserTicketsResponseCopyWithImpl<UserTicketsResponse>(this as UserTicketsResponse, _$identity);
+
+  /// Serializes this UserTicketsResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserTicketsResponse&&const DeepCollectionEquality().equals(other.tickets, tickets)&&const DeepCollectionEquality().equals(other.ticketCheckouts, ticketCheckouts));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(tickets),const DeepCollectionEquality().hash(ticketCheckouts));
+
+@override
+String toString() {
+  return 'UserTicketsResponse(tickets: $tickets, ticketCheckouts: $ticketCheckouts)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $UserTicketsResponseCopyWith<$Res>  {
+  factory $UserTicketsResponseCopyWith(UserTicketsResponse value, $Res Function(UserTicketsResponse) _then) = _$UserTicketsResponseCopyWithImpl;
+@useResult
+$Res call({
+ List<TicketPurchases> tickets, List<TicketCheckoutSessions> ticketCheckouts
+});
+
+
+
+
+}
+/// @nodoc
+class _$UserTicketsResponseCopyWithImpl<$Res>
+    implements $UserTicketsResponseCopyWith<$Res> {
+  _$UserTicketsResponseCopyWithImpl(this._self, this._then);
+
+  final UserTicketsResponse _self;
+  final $Res Function(UserTicketsResponse) _then;
+
+/// Create a copy of UserTicketsResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? tickets = null,Object? ticketCheckouts = null,}) {
+  return _then(_self.copyWith(
+tickets: null == tickets ? _self.tickets : tickets // ignore: cast_nullable_to_non_nullable
+as List<TicketPurchases>,ticketCheckouts: null == ticketCheckouts ? _self.ticketCheckouts : ticketCheckouts // ignore: cast_nullable_to_non_nullable
+as List<TicketCheckoutSessions>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [UserTicketsResponse].
+extension UserTicketsResponsePatterns on UserTicketsResponse {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UserTicketsResponse value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UserTicketsResponse() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UserTicketsResponse value)  $default,){
+final _that = this;
+switch (_that) {
+case _UserTicketsResponse():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UserTicketsResponse value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UserTicketsResponse() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<TicketPurchases> tickets,  List<TicketCheckoutSessions> ticketCheckouts)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UserTicketsResponse() when $default != null:
+return $default(_that.tickets,_that.ticketCheckouts);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<TicketPurchases> tickets,  List<TicketCheckoutSessions> ticketCheckouts)  $default,) {final _that = this;
+switch (_that) {
+case _UserTicketsResponse():
+return $default(_that.tickets,_that.ticketCheckouts);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<TicketPurchases> tickets,  List<TicketCheckoutSessions> ticketCheckouts)?  $default,) {final _that = this;
+switch (_that) {
+case _UserTicketsResponse() when $default != null:
+return $default(_that.tickets,_that.ticketCheckouts);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _UserTicketsResponse implements UserTicketsResponse {
+  const _UserTicketsResponse({required final  List<TicketPurchases> tickets, required final  List<TicketCheckoutSessions> ticketCheckouts}): _tickets = tickets,_ticketCheckouts = ticketCheckouts;
+  factory _UserTicketsResponse.fromJson(Map<String, dynamic> json) => _$UserTicketsResponseFromJson(json);
+
+ final  List<TicketPurchases> _tickets;
+@override List<TicketPurchases> get tickets {
+  if (_tickets is EqualUnmodifiableListView) return _tickets;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_tickets);
+}
+
+ final  List<TicketCheckoutSessions> _ticketCheckouts;
+@override List<TicketCheckoutSessions> get ticketCheckouts {
+  if (_ticketCheckouts is EqualUnmodifiableListView) return _ticketCheckouts;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_ticketCheckouts);
+}
+
+
+/// Create a copy of UserTicketsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UserTicketsResponseCopyWith<_UserTicketsResponse> get copyWith => __$UserTicketsResponseCopyWithImpl<_UserTicketsResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$UserTicketsResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserTicketsResponse&&const DeepCollectionEquality().equals(other._tickets, _tickets)&&const DeepCollectionEquality().equals(other._ticketCheckouts, _ticketCheckouts));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_tickets),const DeepCollectionEquality().hash(_ticketCheckouts));
+
+@override
+String toString() {
+  return 'UserTicketsResponse(tickets: $tickets, ticketCheckouts: $ticketCheckouts)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$UserTicketsResponseCopyWith<$Res> implements $UserTicketsResponseCopyWith<$Res> {
+  factory _$UserTicketsResponseCopyWith(_UserTicketsResponse value, $Res Function(_UserTicketsResponse) _then) = __$UserTicketsResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ List<TicketPurchases> tickets, List<TicketCheckoutSessions> ticketCheckouts
+});
+
+
+
+
+}
+/// @nodoc
+class __$UserTicketsResponseCopyWithImpl<$Res>
+    implements _$UserTicketsResponseCopyWith<$Res> {
+  __$UserTicketsResponseCopyWithImpl(this._self, this._then);
+
+  final _UserTicketsResponse _self;
+  final $Res Function(_UserTicketsResponse) _then;
+
+/// Create a copy of UserTicketsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? tickets = null,Object? ticketCheckouts = null,}) {
+  return _then(_UserTicketsResponse(
+tickets: null == tickets ? _self._tickets : tickets // ignore: cast_nullable_to_non_nullable
+as List<TicketPurchases>,ticketCheckouts: null == ticketCheckouts ? _self._ticketCheckouts : ticketCheckouts // ignore: cast_nullable_to_non_nullable
+as List<TicketCheckoutSessions>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/bff_client/lib/src/model/v1/tickets/user_tickets_response.g.dart
+++ b/packages/bff_client/lib/src/model/v1/tickets/user_tickets_response.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint
+
+part of 'user_tickets_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_UserTicketsResponse _$UserTicketsResponseFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      '_UserTicketsResponse',
+      json,
+      ($checkedConvert) {
+        final val = _UserTicketsResponse(
+          tickets: $checkedConvert(
+            'tickets',
+            (v) => (v as List<dynamic>)
+                .map((e) => TicketPurchases.fromJson(e as Map<String, dynamic>))
+                .toList(),
+          ),
+          ticketCheckouts: $checkedConvert(
+            'ticket_checkouts',
+            (v) => (v as List<dynamic>)
+                .map(
+                  (e) => TicketCheckoutSessions.fromJson(
+                    e as Map<String, dynamic>,
+                  ),
+                )
+                .toList(),
+          ),
+        );
+        return val;
+      },
+      fieldKeyMap: const {'ticketCheckouts': 'ticket_checkouts'},
+    );
+
+Map<String, dynamic> _$UserTicketsResponseToJson(
+  _UserTicketsResponse instance,
+) => <String, dynamic>{
+  'tickets': instance.tickets,
+  'ticket_checkouts': instance.ticketCheckouts,
+};

--- a/packages/bff_client/lib/src/src.dart
+++ b/packages/bff_client/lib/src/src.dart
@@ -12,6 +12,7 @@ export 'model/v1/tickets/ticket_checkout_session_response.dart';
 export 'model/v1/tickets/ticket_type_with_options_response.dart';
 export 'model/v1/tickets/ticket_types_response.dart';
 export 'model/v1/tickets/ticket_types_with_options_response.dart';
+export 'model/v1/tickets/user_tickets_response.dart';
 export 'model/v1/users/user_role_put_request.dart';
 export 'model/v1/users/users_list_request.dart';
 export 'model/v1/users/users_list_response.dart';

--- a/packages/db_client/lib/src/client/ticket/ticket_purchase_db_client.dart
+++ b/packages/db_client/lib/src/client/ticket/ticket_purchase_db_client.dart
@@ -30,4 +30,26 @@ class TicketPurchaseDbClient {
         .map((row) => TicketPurchases.fromJson(row.toColumnMap()))
         .toList();
   }
+
+  /// ユーザーのすべてのチケット購入情報を取得
+  /// ステータスに関係なくすべて返す（作成日時の降順）
+  Future<List<TicketPurchases>> getUserAllTickets(
+    String userId,
+  ) async {
+    final result = await _connection.execute(
+      Sql.named('''
+        SELECT *
+        FROM ticket_purchases
+        WHERE user_id = @userId
+        ORDER BY created_at DESC
+      '''),
+      parameters: {
+        'userId': userId,
+      },
+    );
+
+    return result
+        .map((row) => TicketPurchases.fromJson(row.toColumnMap()))
+        .toList();
+  }
 }


### PR DESCRIPTION
- ユーザーの購入済みチケットとチェックアウト履歴を取得する新しいエンドポイント `/me` を追加しました。
- `UserTicketsResponse` モデルをエクスポートするように `src.dart` を更新しました。
- チケット購入情報を取得するメソッド `getUserAllTickets` を `TicketPurchaseDbClient` に追加しました。

## Issue

Closes #{issue_number}

## 概要

<!--
必ず書いてください。
やったことをわかりやすく短く書いてください。
-->

## 詳細

<!--
可能であれば、変更した内容と変更した理由や背景を書いてください。
-->

## 画像・動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

| Before | After | Design |
| ------ | ----- | ------ |
|        |       |        |

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
