### PR TITLE
[Infra] feat: job_boardsテーブルの作成

### DIFF
--- a/supabase/migrations/20250809065606_003_create_job_boards_table.sql
+++ b/supabase/migrations/20250809065606_003_create_job_boards_table.sql
@@ -1,0 +1,77 @@
+create table "public"."job_boards" (
+    "id" smallint not null,
+    "url" text not null,
+    "alt_text" text not null,
+    "image_name" text not null
+);
+
+
+alter table "public"."job_boards" enable row level security;
+
+CREATE UNIQUE INDEX job_boards_pkey ON public.job_boards USING btree (id);
+
+CREATE UNIQUE INDEX job_boards_url_key ON public.job_boards USING btree (url);
+
+alter table "public"."job_boards" add constraint "job_boards_pkey" PRIMARY KEY using index "job_boards_pkey";
+
+alter table "public"."job_boards" add constraint "job_boards_alt_text_check" CHECK ((alt_text <> ''::text)) not valid;
+
+alter table "public"."job_boards" validate constraint "job_boards_alt_text_check";
+
+alter table "public"."job_boards" add constraint "job_boards_id_fkey" FOREIGN KEY (id) REFERENCES companies(id) ON DELETE CASCADE not valid;
+
+alter table "public"."job_boards" validate constraint "job_boards_id_fkey";
+
+alter table "public"."job_boards" add constraint "job_boards_image_name_check" CHECK ((image_name <> ''::text)) not valid;
+
+alter table "public"."job_boards" validate constraint "job_boards_image_name_check";
+
+alter table "public"."job_boards" add constraint "job_boards_url_check" CHECK ((url ~* '^https?://'::text)) not valid;
+
+alter table "public"."job_boards" validate constraint "job_boards_url_check";
+
+alter table "public"."job_boards" add constraint "job_boards_url_key" UNIQUE using index "job_boards_url_key";
+
+grant delete on table "public"."job_boards" to "anon";
+
+grant insert on table "public"."job_boards" to "anon";
+
+grant references on table "public"."job_boards" to "anon";
+
+grant select on table "public"."job_boards" to "anon";
+
+grant trigger on table "public"."job_boards" to "anon";
+
+grant truncate on table "public"."job_boards" to "anon";
+
+grant update on table "public"."job_boards" to "anon";
+
+grant delete on table "public"."job_boards" to "authenticated";
+
+grant insert on table "public"."job_boards" to "authenticated";
+
+grant references on table "public"."job_boards" to "authenticated";
+
+grant select on table "public"."job_boards" to "authenticated";
+
+grant trigger on table "public"."job_boards" to "authenticated";
+
+grant truncate on table "public"."job_boards" to "authenticated";
+
+grant update on table "public"."job_boards" to "authenticated";
+
+grant delete on table "public"."job_boards" to "service_role";
+
+grant insert on table "public"."job_boards" to "service_role";
+
+grant references on table "public"."job_boards" to "service_role";
+
+grant select on table "public"."job_boards" to "service_role";
+
+grant trigger on table "public"."job_boards" to "service_role";
+
+grant truncate on table "public"."job_boards" to "service_role";
+
+grant update on table "public"."job_boards" to "service_role";
+
+

--- a/supabase/schemas/003_job_boards.sql
+++ b/supabase/schemas/003_job_boards.sql
@@ -1,0 +1,8 @@
+CREATE TABLE public.job_boards (
+    id smallint PRIMARY KEY REFERENCES public.companies (id) ON DELETE CASCADE,
+    url text NOT NULL UNIQUE CHECK (url ~* '^https?://'),
+    alt_text text NOT NULL CHECK (alt_text <> ''),
+    image_name text NOT NULL CHECK (image_name <> '')
+);
+
+ALTER TABLE public.job_boards enable ROW level security;


### PR DESCRIPTION
## Issue

Issueはありません。

## 概要

企業の求人情報を管理するためのjob_boardsテーブルを作成しました。

## 詳細

job_boardsテーブルを新規作成し、以下の要素を含みます：

- **テーブル構造**:
  - `id`: companiesテーブルへの外部キー（smallint, PRIMARY KEY）
  - `url`: 求人ページのURL（text, NOT NULL, UNIQUE）
  - `alt_text`: 画像の代替テキスト（text, NOT NULL）
  - `image_name`: 画像ファイル名（text, NOT NULL）

- **制約・バリデーション**:
  - URLは`https?://`で始まる形式のみ許可
  - alt_textとimage_nameは空文字列不可
  - companiesテーブルとの外部キー制約（CASCADE DELETE）
  - Row Level Security (RLS) を有効化

- **作成したファイル**:
  - `supabase/schemas/003_job_boards.sql`: テーブルスキーマ定義
  - `supabase/migrations/20250809065606_003_create_job_boards_table.sql`: マイグレーションファイル

Supabaseの宣言型データベーススキーマ機能を使用してテーブル定義を行い、`bunx supabase db diff`コマンドでマイグレーションファイルを生成しました。

## 画像・動画

N/A

## その他

READMEの命名規則に従い、`003_create_job_boards_table`という名前でマイグレーションファイルを作成しています。