### PR TITLE
Create profile API and manage user data

### DIFF
--- a/apps/dashboard/lib/features/account/provider/profile_provider.dart
+++ b/apps/dashboard/lib/features/account/provider/profile_provider.dart
@@ -1,0 +1,196 @@
+import 'package:bff_client/bff_client.dart';
+import 'package:db_types/db_types.dart';
+import 'package:dashboard/core/provider/bff_api_client_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'profile_provider.g.dart';
+
+@riverpod
+class ProfileNotifier extends _$ProfileNotifier {
+  @override
+  Future<ProfileResponse?> build() async {
+    return null;
+  }
+
+  /// プロファイル情報を取得する
+  Future<void> fetchProfile() async {
+    state = const AsyncLoading();
+    
+    try {
+      final client = ref.read(bffApiClientProvider);
+      final response = await client.v1.profile.getMyProfile();
+      state = AsyncData(response.data);
+    } catch (e) {
+      state = AsyncError(e, StackTrace.current);
+    }
+  }
+
+  /// プロファイル情報を更新する
+  Future<void> updateProfile(ProfileUpdateRequest request) async {
+    state = const AsyncLoading();
+    
+    try {
+      final client = ref.read(bffApiClientProvider);
+      await client.v1.profile.updateMyProfile(request: request);
+      // 更新後に最新情報を取得
+      await fetchProfile();
+    } catch (e) {
+      state = AsyncError(e, StackTrace.current);
+    }
+  }
+
+  /// アバターを削除する
+  Future<void> deleteAvatar() async {
+    try {
+      final client = ref.read(bffApiClientProvider);
+      await client.v1.profile.deleteMyAvatar();
+      // 削除後に最新情報を取得
+      await fetchProfile();
+    } catch (e) {
+      state = AsyncError(e, StackTrace.current);
+    }
+  }
+
+  /// アバターアップロード用URLを取得する
+  Future<AvatarUploadUrlResponse?> getAvatarUploadUrl({
+    required String fileName,
+    required String contentType,
+  }) async {
+    try {
+      final client = ref.read(bffApiClientProvider);
+      final response = await client.v1.profile.getAvatarUploadUrl(
+        request: AvatarUploadUrlRequest(
+          fileName: fileName,
+          contentType: contentType,
+        ),
+      );
+      return response.data;
+    } catch (e) {
+      state = AsyncError(e, StackTrace.current);
+      return null;
+    }
+  }
+}
+
+/// プロファイル編集フォームの状態管理
+@riverpod
+class ProfileFormNotifier extends _$ProfileFormNotifier {
+  @override
+  ProfileFormState build() {
+    return const ProfileFormState();
+  }
+
+  void updateName(String name) {
+    state = state.copyWith(name: name);
+  }
+
+  void updateComment(String comment) {
+    state = state.copyWith(comment: comment);
+  }
+
+  void updateIsAdult(bool isAdult) {
+    state = state.copyWith(isAdult: isAdult);
+  }
+
+  void updateSnsLinks(List<SnsLinkFormState> snsLinks) {
+    state = state.copyWith(snsLinks: snsLinks);
+  }
+
+  void addSnsLink() {
+    final newLinks = List<SnsLinkFormState>.from(state.snsLinks)
+      ..add(const SnsLinkFormState());
+    state = state.copyWith(snsLinks: newLinks);
+  }
+
+  void removeSnsLink(int index) {
+    final newLinks = List<SnsLinkFormState>.from(state.snsLinks)
+      ..removeAt(index);
+    state = state.copyWith(snsLinks: newLinks);
+  }
+
+  void updateSnsLink(int index, SnsLinkFormState linkState) {
+    final newLinks = List<SnsLinkFormState>.from(state.snsLinks);
+    newLinks[index] = linkState;
+    state = state.copyWith(snsLinks: newLinks);
+  }
+
+  void loadFromProfile(ProfileResponse profile) {
+    state = ProfileFormState(
+      name: profile.profile.name,
+      comment: profile.profile.comment,
+      isAdult: profile.profile.isAdult,
+      snsLinks: profile.snsLinks
+          .map((link) => SnsLinkFormState(
+                snsType: link.snsType,
+                value: link.value,
+              ))
+          .toList(),
+    );
+  }
+
+  ProfileUpdateRequest toRequest() {
+    return ProfileUpdateRequest(
+      name: state.name.isEmpty ? null : state.name,
+      comment: state.comment.isEmpty ? null : state.comment,
+      isAdult: state.isAdult,
+      snsLinks: state.snsLinks
+          .where((link) => link.snsType != null && link.value.isNotEmpty)
+          .map((link) => SnsLinkRequest(
+                snsType: link.snsType!,
+                value: link.value,
+              ))
+          .toList(),
+    );
+  }
+}
+
+/// プロファイル編集フォームの状態
+class ProfileFormState {
+  const ProfileFormState({
+    this.name = '',
+    this.comment = '',
+    this.isAdult = false,
+    this.snsLinks = const [],
+  });
+
+  final String name;
+  final String comment;
+  final bool isAdult;
+  final List<SnsLinkFormState> snsLinks;
+
+  ProfileFormState copyWith({
+    String? name,
+    String? comment,
+    bool? isAdult,
+    List<SnsLinkFormState>? snsLinks,
+  }) {
+    return ProfileFormState(
+      name: name ?? this.name,
+      comment: comment ?? this.comment,
+      isAdult: isAdult ?? this.isAdult,
+      snsLinks: snsLinks ?? this.snsLinks,
+    );
+  }
+}
+
+/// SNSリンクフォームの状態
+class SnsLinkFormState {
+  const SnsLinkFormState({
+    this.snsType,
+    this.value = '',
+  });
+
+  final SnsType? snsType;
+  final String value;
+
+  SnsLinkFormState copyWith({
+    SnsType? snsType,
+    String? value,
+  }) {
+    return SnsLinkFormState(
+      snsType: snsType ?? this.snsType,
+      value: value ?? this.value,
+    );
+  }
+}

--- a/apps/dashboard/lib/features/account/ui/component/sns_link_card.dart
+++ b/apps/dashboard/lib/features/account/ui/component/sns_link_card.dart
@@ -1,0 +1,135 @@
+import 'package:db_types/db_types.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// SNSリンクを表示するカードコンポーネント
+class SnsLinkCard extends StatelessWidget {
+  const SnsLinkCard({
+    required this.snsAccount,
+    super.key,
+  });
+
+  final SnsAccount snsAccount;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    
+    return Card(
+      child: ListTile(
+        leading: Icon(
+          _getSnsIcon(snsAccount.type),
+          color: _getSnsColor(snsAccount.type, colorScheme),
+        ),
+        title: Text(_getSnsTypeDisplayName(snsAccount.type)),
+        subtitle: Text(
+          snsAccount.link.toString(),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: const Icon(Icons.open_in_new),
+        onTap: () => _launchUrl(snsAccount.link),
+      ),
+    );
+  }
+
+  Future<void> _launchUrl(Uri url) async {
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  IconData _getSnsIcon(SnsType type) {
+    switch (type) {
+      case SnsType.github:
+        return Icons.code;
+      case SnsType.x:
+        return Icons.alternate_email;
+      case SnsType.discord:
+        return Icons.chat;
+      case SnsType.medium:
+        return Icons.article;
+      case SnsType.qiita:
+        return Icons.lightbulb_outline;
+      case SnsType.zenn:
+        return Icons.menu_book;
+      case SnsType.note:
+        return Icons.edit_note;
+      case SnsType.other:
+        return Icons.link;
+    }
+  }
+
+  Color _getSnsColor(SnsType type, ColorScheme colorScheme) {
+    // Material Design カラーを使用
+    switch (type) {
+      case SnsType.github:
+        return const Color(0xFF24292e);
+      case SnsType.x:
+        return const Color(0xFF1DA1F2);
+      case SnsType.discord:
+        return const Color(0xFF7289DA);
+      case SnsType.medium:
+        return const Color(0xFF00AB6C);
+      case SnsType.qiita:
+        return const Color(0xFF55C500);
+      case SnsType.zenn:
+        return const Color(0xFF3EA8FF);
+      case SnsType.note:
+        return const Color(0xFF41C9B4);
+      case SnsType.other:
+        return colorScheme.primary;
+    }
+  }
+
+  String _getSnsTypeDisplayName(SnsType type) {
+    switch (type) {
+      case SnsType.github:
+        return 'GitHub';
+      case SnsType.x:
+        return 'X (Twitter)';
+      case SnsType.discord:
+        return 'Discord';
+      case SnsType.medium:
+        return 'Medium';
+      case SnsType.qiita:
+        return 'Qiita';
+      case SnsType.zenn:
+        return 'Zenn';
+      case SnsType.note:
+        return 'note';
+      case SnsType.other:
+        return 'その他';
+    }
+  }
+}
+
+/// SNSリンクリスト表示用ウィジェット
+class SnsLinksList extends StatelessWidget {
+  const SnsLinksList({
+    required this.snsLinks,
+    super.key,
+  });
+
+  final List<UserSnsLinks> snsLinks;
+
+  @override
+  Widget build(BuildContext context) {
+    if (snsLinks.isEmpty) {
+      return const Card(
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: Center(
+            child: Text('SNSリンクが登録されていません'),
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      children: snsLinks
+          .map((link) => SnsLinkCard(snsAccount: link.toSnsAccount()))
+          .toList(),
+    );
+  }
+}

--- a/apps/dashboard/lib/features/account/ui/profile_edit_screen.dart
+++ b/apps/dashboard/lib/features/account/ui/profile_edit_screen.dart
@@ -372,16 +372,32 @@ class _SnsLinkFormState extends State<_SnsLinkForm> {
               ],
             ),
             const SizedBox(height: 12),
-            TextFormField(
-              controller: _controller,
-              decoration: const InputDecoration(
-                labelText: 'URL/ユーザーID',
-                border: OutlineInputBorder(),
-              ),
-              onChanged: (value) {
-                widget.onChanged(widget.snsLink.copyWith(value: value));
-              },
-            ),
+                         TextFormField(
+               controller: _controller,
+               decoration: InputDecoration(
+                 labelText: 'URL/ユーザーID',
+                 border: const OutlineInputBorder(),
+                 helperText: _getHelperText(widget.snsLink.snsType),
+               ),
+               validator: (value) {
+                 if (value == null || value.trim().isEmpty) {
+                   return 'URL/ユーザーIDを入力してください';
+                 }
+                 
+                 final snsType = widget.snsLink.snsType;
+                 if (snsType != null) {
+                   final validationError = _validateSnsValue(snsType, value.trim());
+                   if (validationError != null) {
+                     return validationError;
+                   }
+                 }
+                 
+                 return null;
+               },
+               onChanged: (value) {
+                 widget.onChanged(widget.snsLink.copyWith(value: value));
+               },
+             ),
           ],
         ),
       ),
@@ -390,22 +406,83 @@ class _SnsLinkFormState extends State<_SnsLinkForm> {
 
   String _getSnsTypeDisplayName(SnsType type) {
     switch (type) {
-      case SnsType.x:
-        return 'X (Twitter)';
       case SnsType.github:
         return 'GitHub';
-      case SnsType.facebook:
-        return 'Facebook';
-      case SnsType.instagram:
-        return 'Instagram';
-      case SnsType.linkedin:
-        return 'LinkedIn';
-      case SnsType.youtube:
-        return 'YouTube';
-      case SnsType.tiktok:
-        return 'TikTok';
-      case SnsType.website:
-        return 'ウェブサイト';
+      case SnsType.x:
+        return 'X (Twitter)';
+      case SnsType.discord:
+        return 'Discord';
+      case SnsType.medium:
+        return 'Medium';
+      case SnsType.qiita:
+        return 'Qiita';
+      case SnsType.zenn:
+        return 'Zenn';
+      case SnsType.note:
+        return 'note';
+      case SnsType.other:
+        return 'その他';
     }
+  }
+
+  String? _getHelperText(SnsType? type) {
+    if (type == null) return null;
+    
+    switch (type) {
+      case SnsType.github:
+        return '例: octocat または https://github.com/octocat';
+      case SnsType.x:
+        return '例: twitter または https://x.com/twitter';
+      case SnsType.discord:
+        return '例: 123456789012345678 (ユーザーID)';
+      case SnsType.medium:
+        return '例: username または https://medium.com/@username';
+      case SnsType.qiita:
+        return '例: username または https://qiita.com/username';
+      case SnsType.zenn:
+        return '例: username または https://zenn.dev/username';
+      case SnsType.note:
+        return '例: username または https://note.com/username';
+      case SnsType.other:
+        return '完全なURLを入力してください';
+    }
+  }
+
+  String? _validateSnsValue(SnsType type, String value) {
+    // URLが入力された場合はそのまま通す
+    if (value.startsWith('http://') || value.startsWith('https://')) {
+      try {
+        Uri.parse(value);
+        return null;
+      } catch (e) {
+        return '有効なURLを入力してください';
+      }
+    }
+
+    // ユーザーIDの形式チェック
+    switch (type) {
+      case SnsType.github:
+      case SnsType.x:
+      case SnsType.medium:
+      case SnsType.qiita:
+      case SnsType.zenn:
+      case SnsType.note:
+        // 英数字、アンダースコア、ハイフンのみ許可
+        if (!RegExp(r'^[a-zA-Z0-9_-]+$').hasMatch(value)) {
+          return '英数字、アンダースコア、ハイフンのみ使用可能です';
+        }
+        break;
+      case SnsType.discord:
+        // DiscordユーザーIDは数字のみ（通常18桁）
+        if (!RegExp(r'^\d{17,19}$').hasMatch(value)) {
+          return 'DiscordユーザーIDは17-19桁の数字である必要があります';
+        }
+        break;
+      case SnsType.other:
+        // その他の場合はURLである必要がある
+        return 'その他の場合は完全なURLを入力してください';
+    }
+
+    return null;
   }
 }

--- a/apps/dashboard/lib/features/account/ui/profile_edit_screen.dart
+++ b/apps/dashboard/lib/features/account/ui/profile_edit_screen.dart
@@ -1,4 +1,9 @@
+import 'package:bff_client/bff_client.dart';
+import 'package:db_types/db_types.dart';
+import 'package:dashboard/features/account/provider/profile_provider.dart';
+import 'package:dashboard/features/account/ui/component/account_circle_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// プロフィール編集画面
 ///
@@ -8,16 +13,399 @@ import 'package:flutter/material.dart';
 ///
 /// 参考:
 /// - [SCREENS.md](https://github.com/FlutterKaigi/2025/blob/main/docs/dashboard/SCREENS.md)
-class ProfileEditScreen extends StatelessWidget {
+class ProfileEditScreen extends ConsumerStatefulWidget {
   const ProfileEditScreen({super.key});
 
   @override
+  ConsumerState<ProfileEditScreen> createState() => _ProfileEditScreenState();
+}
+
+class _ProfileEditScreenState extends ConsumerState<ProfileEditScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _commentController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    // 画面表示時にプロファイル情報を取得
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(profileNotifierProvider.notifier).fetchProfile();
+    });
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _commentController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final profileAsync = ref.watch(profileNotifierProvider);
+    final formState = ref.watch(profileFormNotifierProvider);
+    final formNotifier = ref.read(profileFormNotifierProvider.notifier);
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('ProfileEditScreen'),
+        title: const Text('プロフィール編集'),
+        actions: [
+          TextButton(
+            onPressed: () => _saveProfile(context),
+            child: const Text('保存'),
+          ),
+        ],
       ),
-      body: const Center(),
+      body: profileAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stack) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('エラーが発生しました: $error'),
+              ElevatedButton(
+                onPressed: () => ref.read(profileNotifierProvider.notifier).fetchProfile(),
+                child: const Text('再試行'),
+              ),
+            ],
+          ),
+        ),
+        data: (profile) {
+          // プロファイルデータがロードされたらフォームに反映
+          if (profile != null) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (_nameController.text.isEmpty) {
+                _nameController.text = profile.profile.name;
+                _commentController.text = profile.profile.comment;
+                formNotifier.loadFromProfile(profile);
+              }
+            });
+
+            return SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // ネームプレート注意事項
+                    if (!profile.canEditNameplate && profile.nameplateNote != null)
+                      Card(
+                        color: Theme.of(context).colorScheme.warningContainer,
+                        child: Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: Row(
+                            children: [
+                              Icon(
+                                Icons.warning,
+                                color: Theme.of(context).colorScheme.onWarningContainer,
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Text(
+                                  profile.nameplateNote!,
+                                  style: TextStyle(
+                                    color: Theme.of(context).colorScheme.onWarningContainer,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    const SizedBox(height: 16),
+
+                    // アバター画像
+                    Center(
+                      child: Column(
+                        children: [
+                          AccountCircleImage(
+                            imageUrl: profile.profile.avatarKey ?? '',
+                            imageSize: 120,
+                            circleRadius: 60,
+                          ),
+                          const SizedBox(height: 8),
+                          Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              TextButton.icon(
+                                onPressed: () => _uploadAvatar(),
+                                icon: const Icon(Icons.upload),
+                                label: const Text('アップロード'),
+                              ),
+                              if (profile.profile.avatarKey != null)
+                                TextButton.icon(
+                                  onPressed: () => _deleteAvatar(),
+                                  icon: const Icon(Icons.delete),
+                                  label: const Text('削除'),
+                                ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+
+                    // 名前
+                    TextFormField(
+                      controller: _nameController,
+                      decoration: const InputDecoration(
+                        labelText: '名前 *',
+                        border: OutlineInputBorder(),
+                      ),
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return '名前を入力してください';
+                        }
+                        return null;
+                      },
+                      onChanged: formNotifier.updateName,
+                    ),
+                    const SizedBox(height: 16),
+
+                    // ひとことコメント
+                    TextFormField(
+                      controller: _commentController,
+                      decoration: const InputDecoration(
+                        labelText: 'ひとことコメント *',
+                        border: OutlineInputBorder(),
+                        helperText: '100文字以内',
+                      ),
+                      maxLength: 100,
+                      maxLines: 3,
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return 'ひとことコメントを入力してください';
+                        }
+                        if (value.length > 100) {
+                          return 'ひとことコメントは100文字以内で入力してください';
+                        }
+                        return null;
+                      },
+                      onChanged: formNotifier.updateComment,
+                    ),
+                    const SizedBox(height: 16),
+
+                    // 成人確認
+                    CheckboxListTile(
+                      title: const Text('20歳以上です'),
+                      value: formState.isAdult,
+                      onChanged: (value) => formNotifier.updateIsAdult(value ?? false),
+                      controlAffinity: ListTileControlAffinity.leading,
+                    ),
+                    const SizedBox(height: 24),
+
+                    // SNSリンク
+                    Row(
+                      children: [
+                        const Text(
+                          'SNSリンク',
+                          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                        ),
+                        const Spacer(),
+                        TextButton.icon(
+                          onPressed: formNotifier.addSnsLink,
+                          icon: const Icon(Icons.add),
+                          label: const Text('追加'),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+
+                    // SNSリンクリスト
+                    ...formState.snsLinks.asMap().entries.map((entry) {
+                      final index = entry.key;
+                      final link = entry.value;
+                      return _SnsLinkForm(
+                        key: ValueKey(index),
+                        snsLink: link,
+                        onChanged: (newLink) => formNotifier.updateSnsLink(index, newLink),
+                        onRemove: () => formNotifier.removeSnsLink(index),
+                      );
+                    }).toList(),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          return const Center(child: Text('プロファイル情報がありません'));
+        },
+      ),
     );
+  }
+
+  Future<void> _saveProfile(BuildContext context) async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    try {
+      final formNotifier = ref.read(profileFormNotifierProvider.notifier);
+      final request = formNotifier.toRequest();
+      await ref.read(profileNotifierProvider.notifier).updateProfile(request);
+
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('プロファイルを更新しました')),
+        );
+        Navigator.of(context).pop();
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('更新に失敗しました: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _uploadAvatar() async {
+    // TODO: ファイル選択とアップロード処理を実装
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('アバターアップロード機能は準備中です')),
+    );
+  }
+
+  Future<void> _deleteAvatar() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('アバター削除'),
+        content: const Text('アバター画像を削除しますか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('削除'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      try {
+        await ref.read(profileNotifierProvider.notifier).deleteAvatar();
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('アバターを削除しました')),
+          );
+        }
+      } catch (e) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('削除に失敗しました: $e')),
+          );
+        }
+      }
+    }
+  }
+}
+
+class _SnsLinkForm extends StatefulWidget {
+  const _SnsLinkForm({
+    required this.snsLink,
+    required this.onChanged,
+    required this.onRemove,
+    super.key,
+  });
+
+  final SnsLinkFormState snsLink;
+  final ValueChanged<SnsLinkFormState> onChanged;
+  final VoidCallback onRemove;
+
+  @override
+  State<_SnsLinkForm> createState() => _SnsLinkFormState();
+}
+
+class _SnsLinkFormState extends State<_SnsLinkForm> {
+  late TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.snsLink.value);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: DropdownButtonFormField<SnsType>(
+                    value: widget.snsLink.snsType,
+                    decoration: const InputDecoration(
+                      labelText: 'SNSタイプ',
+                      border: OutlineInputBorder(),
+                    ),
+                    items: SnsType.values.map((type) {
+                      return DropdownMenuItem(
+                        value: type,
+                        child: Text(_getSnsTypeDisplayName(type)),
+                      );
+                    }).toList(),
+                    onChanged: (value) {
+                      widget.onChanged(widget.snsLink.copyWith(snsType: value));
+                    },
+                  ),
+                ),
+                const SizedBox(width: 8),
+                IconButton(
+                  onPressed: widget.onRemove,
+                  icon: const Icon(Icons.delete),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _controller,
+              decoration: const InputDecoration(
+                labelText: 'URL/ユーザーID',
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (value) {
+                widget.onChanged(widget.snsLink.copyWith(value: value));
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _getSnsTypeDisplayName(SnsType type) {
+    switch (type) {
+      case SnsType.x:
+        return 'X (Twitter)';
+      case SnsType.github:
+        return 'GitHub';
+      case SnsType.facebook:
+        return 'Facebook';
+      case SnsType.instagram:
+        return 'Instagram';
+      case SnsType.linkedin:
+        return 'LinkedIn';
+      case SnsType.youtube:
+        return 'YouTube';
+      case SnsType.tiktok:
+        return 'TikTok';
+      case SnsType.website:
+        return 'ウェブサイト';
+    }
   }
 }

--- a/apps/dashboard/lib/features/account/ui/profile_view_screen.dart
+++ b/apps/dashboard/lib/features/account/ui/profile_view_screen.dart
@@ -1,0 +1,234 @@
+import 'package:bff_client/bff_client.dart';
+import 'package:dashboard/features/account/provider/profile_provider.dart';
+import 'package:dashboard/features/account/ui/component/account_circle_image.dart';
+import 'package:dashboard/features/account/ui/component/sns_link_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// プロファイル表示画面
+/// 
+/// 主な役割:
+/// - ユーザーのプロファイル情報を表示する
+/// - SNSリンクを表示する
+/// - 編集画面への遷移を提供する
+class ProfileViewScreen extends ConsumerStatefulWidget {
+  const ProfileViewScreen({super.key});
+
+  @override
+  ConsumerState<ProfileViewScreen> createState() => _ProfileViewScreenState();
+}
+
+class _ProfileViewScreenState extends ConsumerState<ProfileViewScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // 画面表示時にプロファイル情報を取得
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(profileNotifierProvider.notifier).fetchProfile();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final profileAsync = ref.watch(profileNotifierProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('プロファイル'),
+        actions: [
+          IconButton(
+            onPressed: () => Navigator.of(context).pushNamed('/account/profile-edit'),
+            icon: const Icon(Icons.edit),
+            tooltip: '編集',
+          ),
+        ],
+      ),
+      body: profileAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stack) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.error_outline,
+                size: 64,
+                color: Theme.of(context).colorScheme.error,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'エラーが発生しました',
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 8),
+              Text('$error'),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => ref.read(profileNotifierProvider.notifier).fetchProfile(),
+                child: const Text('再試行'),
+              ),
+            ],
+          ),
+        ),
+        data: (profile) {
+          if (profile == null) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.person_outline,
+                    size: 64,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'プロファイルが見つかりません',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                  const SizedBox(height: 8),
+                  const Text('プロファイル情報を作成してください'),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => Navigator.of(context).pushNamed('/account/profile-edit'),
+                    child: const Text('プロファイルを作成'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // ネームプレート注意事項
+                if (!profile.canEditNameplate && profile.nameplateNote != null)
+                  Card(
+                    color: Theme.of(context).colorScheme.secondaryContainer,
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.info,
+                            color: Theme.of(context).colorScheme.onSecondaryContainer,
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              profile.nameplateNote!,
+                              style: TextStyle(
+                                color: Theme.of(context).colorScheme.onSecondaryContainer,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                const SizedBox(height: 16),
+
+                // プロファイル情報カード
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      children: [
+                        // アバター画像
+                        AccountCircleImage(
+                          imageUrl: profile.profile.avatarKey ?? '',
+                          imageSize: 120,
+                          circleRadius: 60,
+                        ),
+                        const SizedBox(height: 16),
+
+                        // 名前
+                        Text(
+                          profile.profile.name,
+                          style: Theme.of(context).textTheme.headlineSmall,
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 8),
+
+                        // ひとことコメント
+                        Text(
+                          profile.profile.comment,
+                          style: Theme.of(context).textTheme.bodyLarge,
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 16),
+
+                        // 成人フラグ
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              profile.profile.isAdult ? Icons.check_circle : Icons.cancel,
+                              color: profile.profile.isAdult 
+                                  ? Colors.green 
+                                  : Colors.grey,
+                              size: 20,
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              profile.profile.isAdult ? '20歳以上' : '20歳未満',
+                              style: Theme.of(context).textTheme.bodyMedium,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 24),
+
+                // SNSリンクセクション
+                Row(
+                  children: [
+                    Text(
+                      'SNSリンク',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(width: 8),
+                    if (profile.snsLinks.isNotEmpty)
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.primaryContainer,
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Text(
+                          '${profile.snsLinks.length}',
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.onPrimaryContainer,
+                            fontSize: 12,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+
+                // SNSリンクリスト
+                SnsLinksList(snsLinks: profile.snsLinks),
+                
+                const SizedBox(height: 32),
+
+                // 編集ボタン
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    onPressed: () => Navigator.of(context).pushNamed('/account/profile-edit'),
+                    icon: const Icon(Icons.edit),
+                    label: const Text('プロファイルを編集'),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/bff/engine/lib/routes/api_service.dart
+++ b/bff/engine/lib/routes/api_service.dart
@@ -4,6 +4,7 @@ import 'package:bff_client/bff_client.dart';
 import 'package:engine/main.dart';
 import 'package:engine/provider/db_client_provider.dart';
 import 'package:engine/routes/news_api_service.dart';
+import 'package:engine/routes/profile_api_service.dart';
 import 'package:engine/routes/ticket_api_service.dart';
 import 'package:engine/routes/user_api_service.dart';
 import 'package:engine/util/json_response.dart';
@@ -35,6 +36,9 @@ class ApiService {
 
   @Route.mount('/v1/users')
   Router get _userApiService => UserApiService().router;
+
+  @Route.mount('/v1/profile')
+  Router get _profileApiService => ProfileApiService().router;
 
   @Route.mount('/v1')
   Router get _newsApiService => NewsApiService().router;

--- a/bff/engine/lib/routes/profile_api_service.dart
+++ b/bff/engine/lib/routes/profile_api_service.dart
@@ -1,0 +1,200 @@
+import 'dart:convert';
+
+import 'package:bff_client/bff_client.dart';
+import 'package:db_types/db_types.dart';
+import 'package:engine/main.dart';
+import 'package:engine/provider/db_client_provider.dart';
+import 'package:engine/provider/supabase_util.dart';
+import 'package:engine/util/exception_handler.dart';
+import 'package:engine/util/json_response.dart';
+import 'package:shelf/shelf.dart';
+import 'package:shelf_router/shelf_router.dart';
+
+part 'profile_api_service.g.dart';
+
+class ProfileApiService {
+  @Route.get('/me')
+  Future<Response> _getMyProfile(Request request) async => jsonResponse(
+    () async {
+      final supabaseUtil = container.read(supabaseUtilProvider);
+      final userResult = await supabaseUtil.extractUser(request);
+      final (_, user, _) = userResult.unwrap;
+      
+      final database = await container.read(dbClientProvider.future);
+      
+      // プロファイル情報とSNSリンクを一回のクエリで取得
+      final profileWithSns = await database.from('profiles').select('''
+        id,
+        name,
+        comment,
+        is_adult,
+        avatar_key,
+        created_at,
+        updated_at,
+        user_sns_links:user_sns_links(
+          id,
+          sns_type,
+          value,
+          created_at,
+          updated_at
+        )
+      ''').eq('id', user.id).maybeSingle();
+      
+      if (profileWithSns == null) {
+        throw ErrorResponse.errorCode(
+          code: ErrorCode.notFound,
+          detail: 'プロファイルが見つかりません',
+        );
+      }
+      
+      // ネームプレート変更可能かどうかの判定
+      // 特定の日付（例：2025年2月1日）以前に作成されたユーザーは変更不可
+      final profileCreatedAt = DateTime.parse(profileWithSns['created_at'] as String);
+      const nameplateDeadline = '2025-02-01T00:00:00Z';
+      final deadline = DateTime.parse(nameplateDeadline);
+      final canEditNameplate = profileCreatedAt.isAfter(deadline);
+      
+      final profile = Profiles.fromJson(profileWithSns);
+      final snsLinks = (profileWithSns['user_sns_links'] as List? ?? [])
+          .map((link) => UserSnsLinks.fromJson(link as Map<String, dynamic>))
+          .toList();
+      
+      return {
+        'profile': profile.toJson(),
+        'snsLinks': snsLinks.map((link) => link.toJson()).toList(),
+        'canEditNameplate': canEditNameplate,
+        'nameplateNote': canEditNameplate 
+            ? null 
+            : 'このアカウントは$nameplateDeadline以前に作成されたため、ネームプレートに印刷済みの情報は変更できません。',
+      };
+    },
+  );
+
+  @Route.put('/me')
+  Future<Response> _updateMyProfile(Request request) async => jsonResponse(
+    () async {
+      final supabaseUtil = container.read(supabaseUtilProvider);
+      final userResult = await supabaseUtil.extractUser(request);
+      final (_, user, _) = userResult.unwrap;
+      
+      final body = jsonDecode(await request.readAsString()) as Map<String, dynamic>;
+      final database = await container.read(dbClientProvider.future);
+      
+      // プロファイル更新
+      final profileData = <String, dynamic>{
+        'updated_at': DateTime.now().toIso8601String(),
+      };
+      
+      if (body.containsKey('name')) {
+        profileData['name'] = body['name'] as String;
+      }
+      if (body.containsKey('comment')) {
+        final comment = body['comment'] as String;
+        if (comment.length > 100) {
+          throw ErrorResponse.errorCode(
+            code: ErrorCode.badRequest,
+            detail: 'コメントは100文字以内で入力してください',
+          );
+        }
+        profileData['comment'] = comment;
+      }
+      if (body.containsKey('isAdult')) {
+        profileData['is_adult'] = body['isAdult'] as bool;
+      }
+      
+      // プロファイルを更新
+      final updatedProfile = await database
+          .from('profiles')
+          .update(profileData)
+          .eq('id', user.id)
+          .select()
+          .single();
+      
+      // SNSリンクを更新
+      if (body.containsKey('snsLinks')) {
+        final snsLinksData = body['snsLinks'] as List;
+        
+        // 既存のSNSリンクを削除
+        await database
+            .from('user_sns_links')
+            .delete()
+            .eq('user_id', user.id);
+        
+        // 新しいSNSリンクを挿入
+        if (snsLinksData.isNotEmpty) {
+          final linksToInsert = snsLinksData.map((link) => {
+            'user_id': user.id,
+            'sns_type': link['snsType'] as String,
+            'value': (link['value'] as String).trim(),
+            'created_at': DateTime.now().toIso8601String(),
+            'updated_at': DateTime.now().toIso8601String(),
+          }).toList();
+          
+          await database.from('user_sns_links').insert(linksToInsert);
+        }
+      }
+      
+      return Profiles.fromJson(updatedProfile).toJson();
+    },
+  );
+
+  @Route.delete('/me/avatar')
+  Future<Response> _deleteMyAvatar(Request request) async => jsonResponse(
+    () async {
+      final supabaseUtil = container.read(supabaseUtilProvider);
+      final userResult = await supabaseUtil.extractUser(request);
+      final (_, user, _) = userResult.unwrap;
+      
+      final database = await container.read(dbClientProvider.future);
+      
+      // アバターキーをnullに設定
+      await database
+          .from('profiles')
+          .update({
+            'avatar_key': null,
+            'updated_at': DateTime.now().toIso8601String(),
+          })
+          .eq('id', user.id);
+      
+      // TODO: 実際のファイル削除処理を実装
+      // R2からファイル削除のロジックをここに追加
+      
+      return {'success': true, 'message': 'アバターを削除しました'};
+    },
+  );
+
+  @Route.post('/me/avatar/upload-url')
+  Future<Response> _getAvatarUploadUrl(Request request) async => jsonResponse(
+    () async {
+      final supabaseUtil = container.read(supabaseUtilProvider);
+      final userResult = await supabaseUtil.extractUser(request);
+      final (_, user, _) = userResult.unwrap;
+      
+      final body = jsonDecode(await request.readAsString()) as Map<String, dynamic>;
+      final fileName = body['fileName'] as String?;
+      final contentType = body['contentType'] as String?;
+      
+      if (fileName == null || contentType == null) {
+        throw ErrorResponse.errorCode(
+          code: ErrorCode.badRequest,
+          detail: 'ファイル名とコンテンツタイプが必要です',
+        );
+      }
+      
+      // TODO: 実際の署名付きURL生成処理を実装
+      // R2への署名付きURL生成のロジックをここに追加
+      
+      // Mockレスポンス
+      final avatarKey = 'avatars/${user.id}/${DateTime.now().millisecondsSinceEpoch}_$fileName';
+      final uploadUrl = 'https://mock-upload-url.example.com/$avatarKey';
+      
+      return {
+        'uploadUrl': uploadUrl,
+        'avatarKey': avatarKey,
+        'expiresIn': 3600, // 1時間
+      };
+    },
+  );
+
+  Router get router => _$ProfileApiServiceRouter(this);
+}

--- a/packages/bff_client/lib/src/api/bff_api_client.dart
+++ b/packages/bff_client/lib/src/api/bff_api_client.dart
@@ -1,3 +1,4 @@
+import 'package:bff_client/src/api/v1/profile_api_client.dart';
 import 'package:bff_client/src/api/v1/tickets_api_client.dart';
 import 'package:bff_client/src/api/v1/users_api_client.dart';
 import 'package:dio/dio.dart';
@@ -15,6 +16,7 @@ class BffApiClientV1 {
 
   final Dio _dio;
 
+  ProfileApiClient get profile => ProfileApiClient(_dio);
   TicketsApiClient get tickets => TicketsApiClient(_dio);
   UsersApiClient get users => UsersApiClient(_dio);
 }

--- a/packages/bff_client/lib/src/api/v1/profile_api_client.dart
+++ b/packages/bff_client/lib/src/api/v1/profile_api_client.dart
@@ -1,0 +1,35 @@
+import 'package:bff_client/bff_client.dart';
+import 'package:db_types/db_types.dart';
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'profile_api_client.g.dart';
+
+@RestApi()
+abstract class ProfileApiClient {
+  factory ProfileApiClient(Dio dio, {String baseUrl}) = _ProfileApiClient;
+
+  /// 自分のプロファイル情報を取得します
+  /// Authorization Headerが必須
+  @GET('/profile/me')
+  Future<HttpResponse<ProfileResponse>> getMyProfile();
+
+  /// 自分のプロファイル情報を更新します
+  /// Authorization Headerが必須
+  @PUT('/profile/me')
+  Future<HttpResponse<Profiles>> updateMyProfile({
+    @Body() required ProfileUpdateRequest request,
+  });
+
+  /// 自分のアバターを削除します
+  /// Authorization Headerが必須
+  @DELETE('/profile/me/avatar')
+  Future<HttpResponse<Map<String, dynamic>>> deleteMyAvatar();
+
+  /// アバターアップロード用の署名付きURLを取得します
+  /// Authorization Headerが必須
+  @POST('/profile/me/avatar/upload-url')
+  Future<HttpResponse<AvatarUploadUrlResponse>> getAvatarUploadUrl({
+    @Body() required AvatarUploadUrlRequest request,
+  });
+}

--- a/packages/bff_client/lib/src/model/v1/profile/avatar_upload_url_request.dart
+++ b/packages/bff_client/lib/src/model/v1/profile/avatar_upload_url_request.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'avatar_upload_url_request.freezed.dart';
+part 'avatar_upload_url_request.g.dart';
+
+@freezed
+abstract class AvatarUploadUrlRequest with _$AvatarUploadUrlRequest {
+  const factory AvatarUploadUrlRequest({
+    required String fileName,
+    required String contentType,
+  }) = _AvatarUploadUrlRequest;
+
+  factory AvatarUploadUrlRequest.fromJson(Map<String, dynamic> json) =>
+      _$AvatarUploadUrlRequestFromJson(json);
+}

--- a/packages/bff_client/lib/src/model/v1/profile/avatar_upload_url_response.dart
+++ b/packages/bff_client/lib/src/model/v1/profile/avatar_upload_url_response.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'avatar_upload_url_response.freezed.dart';
+part 'avatar_upload_url_response.g.dart';
+
+@freezed
+abstract class AvatarUploadUrlResponse with _$AvatarUploadUrlResponse {
+  const factory AvatarUploadUrlResponse({
+    required String uploadUrl,
+    required String avatarKey,
+    required int expiresIn,
+  }) = _AvatarUploadUrlResponse;
+
+  factory AvatarUploadUrlResponse.fromJson(Map<String, dynamic> json) =>
+      _$AvatarUploadUrlResponseFromJson(json);
+}

--- a/packages/bff_client/lib/src/model/v1/profile/profile_response.dart
+++ b/packages/bff_client/lib/src/model/v1/profile/profile_response.dart
@@ -1,0 +1,18 @@
+import 'package:db_types/db_types.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'profile_response.freezed.dart';
+part 'profile_response.g.dart';
+
+@freezed
+abstract class ProfileResponse with _$ProfileResponse {
+  const factory ProfileResponse({
+    required Profiles profile,
+    required List<UserSnsLinks> snsLinks,
+    required bool canEditNameplate,
+    String? nameplateNote,
+  }) = _ProfileResponse;
+
+  factory ProfileResponse.fromJson(Map<String, dynamic> json) =>
+      _$ProfileResponseFromJson(json);
+}

--- a/packages/bff_client/lib/src/model/v1/profile/profile_update_request.dart
+++ b/packages/bff_client/lib/src/model/v1/profile/profile_update_request.dart
@@ -1,0 +1,29 @@
+import 'package:db_types/db_types.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'profile_update_request.freezed.dart';
+part 'profile_update_request.g.dart';
+
+@freezed
+abstract class SnsLinkRequest with _$SnsLinkRequest {
+  const factory SnsLinkRequest({
+    required SnsType snsType,
+    required String value,
+  }) = _SnsLinkRequest;
+
+  factory SnsLinkRequest.fromJson(Map<String, dynamic> json) =>
+      _$SnsLinkRequestFromJson(json);
+}
+
+@freezed
+abstract class ProfileUpdateRequest with _$ProfileUpdateRequest {
+  const factory ProfileUpdateRequest({
+    String? name,
+    String? comment,
+    bool? isAdult,
+    List<SnsLinkRequest>? snsLinks,
+  }) = _ProfileUpdateRequest;
+
+  factory ProfileUpdateRequest.fromJson(Map<String, dynamic> json) =>
+      _$ProfileUpdateRequestFromJson(json);
+}

--- a/packages/bff_client/lib/src/src.dart
+++ b/packages/bff_client/lib/src/src.dart
@@ -1,5 +1,6 @@
 export 'api/bff_api_client.dart';
 export 'api/v1/news_api_client.dart';
+export 'api/v1/profile_api_client.dart';
 export 'api/v1/tickets_api_client.dart';
 export 'api/v1/users_api_client.dart';
 export 'model/error/error_response.dart';
@@ -13,6 +14,10 @@ export 'model/v1/tickets/ticket_type_with_options_response.dart';
 export 'model/v1/tickets/ticket_types_response.dart';
 export 'model/v1/tickets/ticket_types_with_options_response.dart';
 export 'model/v1/tickets/user_tickets_response.dart';
+export 'model/v1/profile/avatar_upload_url_request.dart';
+export 'model/v1/profile/avatar_upload_url_response.dart';
+export 'model/v1/profile/profile_response.dart';
+export 'model/v1/profile/profile_update_request.dart';
 export 'model/v1/users/user_role_put_request.dart';
 export 'model/v1/users/users_list_request.dart';
 export 'model/v1/users/users_list_response.dart';

--- a/packages/db_types/lib/src/src.dart
+++ b/packages/db_types/lib/src/src.dart
@@ -17,4 +17,6 @@ export 'tables/ticket_options.dart';
 export 'tables/ticket_purchases.dart';
 export 'tables/ticket_types.dart';
 export 'tables/user_roles.dart';
+export 'tables/user_sns_links.dart';
 export 'tables/users.dart';
+export 'tables/profiles.dart';

--- a/packages/db_types/lib/src/tables/profiles.dart
+++ b/packages/db_types/lib/src/tables/profiles.dart
@@ -1,0 +1,23 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'profiles.freezed.dart';
+part 'profiles.g.dart';
+
+@freezed
+abstract class Profiles with _$Profiles {
+  const factory Profiles({
+    required String id,
+    required String name,
+    required String comment,
+    required bool isAdult,
+    String? avatarKey,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
+  }) = _Profiles;
+
+  factory Profiles.fromJson(Map<String, dynamic> json) =>
+      _$ProfilesFromJson(json);
+}
+
+enum SnsType { x, github, facebook, instagram, linkedin, youtube, tiktok, website }

--- a/packages/db_types/lib/src/tables/profiles.dart
+++ b/packages/db_types/lib/src/tables/profiles.dart
@@ -20,4 +20,39 @@ abstract class Profiles with _$Profiles {
       _$ProfilesFromJson(json);
 }
 
-enum SnsType { x, github, facebook, instagram, linkedin, youtube, tiktok, website }
+enum SnsType {
+  github,
+  x,
+  discord,
+  medium,
+  qiita,
+  zenn,
+  note,
+  other,
+  ;
+
+  Uri toUri(String value) {
+    final url = switch (this) {
+      SnsType.github => 'https://github.com/$value',
+      SnsType.x => 'https://x.com/$value',
+      SnsType.discord => 'https://discord.com/users/$value',
+      SnsType.medium => 'https://medium.com/@$value',
+      SnsType.qiita => 'https://qiita.com/$value',
+      SnsType.zenn => 'https://zenn.dev/$value',
+      SnsType.note => 'https://note.com/$value',
+      SnsType.other => value,
+    };
+    return Uri.parse(url);
+  }
+}
+
+@freezed
+class SnsAccount with _$SnsAccount {
+  const factory SnsAccount({
+    required SnsType type,
+    required Uri link,
+  }) = _SnsAccount;
+
+  factory SnsAccount.fromJson(Map<String, dynamic> json) =>
+      _$SnsAccountFromJson(json);
+}

--- a/packages/db_types/lib/src/tables/user_sns_links.dart
+++ b/packages/db_types/lib/src/tables/user_sns_links.dart
@@ -19,3 +19,13 @@ abstract class UserSnsLinks with _$UserSnsLinks {
   factory UserSnsLinks.fromJson(Map<String, dynamic> json) =>
       _$UserSnsLinksFromJson(json);
 }
+
+extension UserSnsLinksExtension on UserSnsLinks {
+  /// UserSnsLinksからSnsAccountに変換
+  SnsAccount toSnsAccount() {
+    return SnsAccount(
+      type: snsType,
+      link: snsType.toUri(value),
+    );
+  }
+}

--- a/packages/db_types/lib/src/tables/user_sns_links.dart
+++ b/packages/db_types/lib/src/tables/user_sns_links.dart
@@ -1,0 +1,21 @@
+import 'package:db_types/src/converters/date_time_converter.dart';
+import 'package:db_types/src/tables/profiles.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user_sns_links.freezed.dart';
+part 'user_sns_links.g.dart';
+
+@freezed
+abstract class UserSnsLinks with _$UserSnsLinks {
+  const factory UserSnsLinks({
+    required String id,
+    required String userId,
+    required SnsType snsType,
+    required String value,
+    @RequiredDateTimeConverter() required DateTime createdAt,
+    @RequiredDateTimeConverter() required DateTime updatedAt,
+  }) = _UserSnsLinks;
+
+  factory UserSnsLinks.fromJson(Map<String, dynamic> json) =>
+      _$UserSnsLinksFromJson(json);
+}

--- a/supabase/schemas/006_profile_tables.sql
+++ b/supabase/schemas/006_profile_tables.sql
@@ -1,0 +1,49 @@
+-- SNSの種類を定義するenum
+CREATE TYPE public.sns_type AS enum('x', 'github', 'facebook', 'instagram', 'linkedin', 'youtube', 'tiktok', 'website');
+
+-- プロファイルテーブル
+CREATE TABLE public.profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users (id) ON DELETE CASCADE,
+  name text NOT NULL,
+  comment text NOT NULL CHECK (char_length(comment) <= 100),
+  is_adult boolean NOT NULL DEFAULT false,
+  avatar_key text,
+  created_at timestamp DEFAULT current_timestamp NOT NULL,
+  updated_at timestamp DEFAULT current_timestamp NOT NULL
+);
+
+ALTER TABLE public.profiles enable ROW level security;
+
+-- ユーザのSNSリンクテーブル
+CREATE TABLE public.user_sns_links (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v7(),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  sns_type public.sns_type NOT NULL,
+  value text NOT NULL CHECK (char_length(trim(value)) > 0),
+  created_at timestamp DEFAULT current_timestamp NOT NULL,
+  updated_at timestamp DEFAULT current_timestamp NOT NULL,
+  UNIQUE (user_id, sns_type)
+);
+
+ALTER TABLE public.user_sns_links enable ROW level security;
+
+-- updated_atを自動更新するトリガー関数
+CREATE OR REPLACE FUNCTION public.update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = current_timestamp;
+  RETURN NEW;
+END;
+$$ language plpgsql;
+
+-- profilesテーブルのupdated_atトリガー
+CREATE TRIGGER update_profiles_updated_at 
+  BEFORE UPDATE ON public.profiles 
+  FOR EACH ROW 
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- user_sns_linksテーブルのupdated_atトリガー
+CREATE TRIGGER update_user_sns_links_updated_at 
+  BEFORE UPDATE ON public.user_sns_links 
+  FOR EACH ROW 
+  EXECUTE FUNCTION public.update_updated_at_column();

--- a/supabase/schemas/006_profile_tables.sql
+++ b/supabase/schemas/006_profile_tables.sql
@@ -1,5 +1,5 @@
 -- SNSの種類を定義するenum
-CREATE TYPE public.sns_type AS enum('x', 'github', 'facebook', 'instagram', 'linkedin', 'youtube', 'tiktok', 'website');
+CREATE TYPE public.sns_type AS enum('github', 'x', 'discord', 'medium', 'qiita', 'zenn', 'note', 'other');
 
 -- プロファイルテーブル
 CREATE TABLE public.profiles (


### PR DESCRIPTION
## Issue

Closes #{issue_number}

## 概要

Profile APIのバックエンド（Supabaseテーブル、BFFエンドポイント）とフロントエンド（Flutter UI）を実装しました。

## 詳細

### データベース
- `profiles` テーブル: ユーザーの基本プロフィール情報（名前、コメント、成人フラグ、アバターキー）を格納。`auth.users(id)` を参照。
- `user_sns_links` テーブル: 各プロファイルに紐づくSNSリンクを格納。`sns_type` enum型を定義し、`user_id`と`sns_type`の複合ユニーク制約を設定。
- `updated_at` カラムの自動更新トリガーを追加。

### BFF API (`/v1/profile`)
- `GET /me`: 認証済みユーザーのプロファイルとSNSリンクを取得。ネームプレートの編集可否情報（`canEditNameplate`）と注意事項（`nameplateNote`）を付与。N+1問題を避けるためJOINで一括取得。
- `PUT /me`: 認証済みユーザーのプロファイル情報とSNSリンクを更新。コメントの文字数バリデーションを含む。
- `DELETE /me/avatar`: アバターキーをnullに設定（R2からのファイル削除は将来実装）。
- `POST /me/avatar/upload-url`: アバターアップロード用の署名付きURLを返却（現在Mock）。

### Flutter UI (`ProfileEditScreen`)
- プロファイル情報の表示・編集フォームを実装。
- 名前、コメント、成人フラグ、SNSリンクの追加・編集・削除に対応。
- ネームプレートの編集制限に関する警告表示。
- アバターのアップロード（Mock）と削除機能。
- Riverpodによる状態管理とフォームバリデーション。

## 画像・動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

| Before | After | Design |
| ------ | ----- | ------ |
|        |       |        |

## その他

- アバターのアップロード/削除機能は、R2連携が未実装のため、BFF側でMockレスポンスを返しています。
- ネームプレートの編集可否判定は、`2025-02-01T00:00:00Z` を基準にしています。

---
<a href="https://cursor.com/background-agent?bcId=bc-23f5486d-905c-4689-8231-b77ee5dff93c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23f5486d-905c-4689-8231-b77ee5dff93c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

