### PR TITLE
[Infra] fix: Update .env.example for local development

### DIFF
--- a/bff/engine/.env.example
+++ b/bff/engine/.env.example
@@ -1,5 +1,5 @@
 # Supabase Configuration
-SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_URL=http://127.0.0.1:54321
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 CF_VERSION_METADATA_ID=local
 CF_VERSION_METADATA_TAG=local

--- a/bff/engine/.env.example
+++ b/bff/engine/.env.example
@@ -5,3 +5,5 @@ CF_VERSION_METADATA_ID=local
 CF_VERSION_METADATA_TAG=local
 CF_VERSION_METADATA_TIMESTAMP=2025-01-01T00:00:00Z
 POSTGRES_URL=postgresql://postgres:postgres@host.docker.internal:54322/postgres
+INTERNAL_API_URL=http://localhost:8787
+X_API_KEY=xxx


### PR DESCRIPTION
## 概要

ローカル開発環境用の設定を`.env.example`に追加・更新しました。

## 詳細

`bff/engine/.env.example`ファイルに以下の変更を行いました：

- `INTERNAL_API_URL=http://localhost:8787`を追加
- `X_API_KEY=xxx`を追加  
- `SUPABASE_URL`を`https://your-project.supabase.co`から`http://127.0.0.1:54321`に変更（ローカル開発用）

これらの変更により、開発者がローカル環境でアプリケーションを実行する際の設定がより明確になり、開発効率が向上します。