### PR TITLE
refactor: スポンサーのdescriptionフィールドをprTextに変更

### DIFF
--- a/apps/dashboard/lib/core/gen/l10n/l10n.dart
+++ b/apps/dashboard/lib/core/gen/l10n/l10n.dart
@@ -153,11 +153,11 @@ abstract class L10n {
   /// **'東京都千代田区大手町二丁目3番1号'**
   String get eventAddress;
 
-  /// No description provided for @sponsorDescription.
+  /// No description provided for @sponsorPrText.
   ///
   /// In ja, this message translates to:
   /// **'PR 文章'**
-  String get sponsorDescription;
+  String get sponsorPrText;
 
   /// No description provided for @sponsorEnthusiasm.
   ///

--- a/apps/dashboard/lib/core/gen/l10n/l10n.dart
+++ b/apps/dashboard/lib/core/gen/l10n/l10n.dart
@@ -156,7 +156,7 @@ abstract class L10n {
   /// No description provided for @sponsorDescription.
   ///
   /// In ja, this message translates to:
-  /// **'会社概要'**
+  /// **'PR 文章'**
   String get sponsorDescription;
 
   /// No description provided for @sponsorEnthusiasm.

--- a/apps/dashboard/lib/core/gen/l10n/l10n_ja.dart
+++ b/apps/dashboard/lib/core/gen/l10n/l10n_ja.dart
@@ -40,7 +40,7 @@ class L10nJa extends L10n {
   String get eventAddress => '東京都千代田区大手町二丁目3番1号';
 
   @override
-  String get sponsorDescription => '会社概要';
+  String get sponsorDescription => 'PR 文章';
 
   @override
   String get sponsorEnthusiasm => '意気込み';

--- a/apps/dashboard/lib/core/gen/l10n/l10n_ja.dart
+++ b/apps/dashboard/lib/core/gen/l10n/l10n_ja.dart
@@ -40,7 +40,7 @@ class L10nJa extends L10n {
   String get eventAddress => '東京都千代田区大手町二丁目3番1号';
 
   @override
-  String get sponsorDescription => 'PR 文章';
+  String get sponsorPrText => 'PR 文章';
 
   @override
   String get sponsorEnthusiasm => '意気込み';

--- a/apps/dashboard/lib/features/sponsor/data/sponsor.dart
+++ b/apps/dashboard/lib/features/sponsor/data/sponsor.dart
@@ -37,12 +37,12 @@ sealed class CompanySponsor extends Sponsor {
     required super.name,
     required super.slug,
     required super.logoUrl,
-    required this.description,
+    required this.prText,
     required this.websiteUrl,
     this.scholarship = false,
   });
 
-  final String description;
+  final String prText;
   final Uri websiteUrl;
   final bool scholarship;
 
@@ -56,7 +56,7 @@ sealed class CompanySponsor extends Sponsor {
         name == other.name &&
         slug == other.slug &&
         logoUrl == other.logoUrl &&
-        description == other.description &&
+        prText == other.prText &&
         websiteUrl == other.websiteUrl &&
         scholarship == other.scholarship;
   }
@@ -67,7 +67,7 @@ sealed class CompanySponsor extends Sponsor {
     name,
     slug,
     logoUrl,
-    description,
+    prText,
     websiteUrl,
     scholarship,
   );
@@ -168,7 +168,7 @@ sealed class BasicSponsor extends CompanySponsor {
     required super.name,
     required super.slug,
     required super.logoUrl,
-    required super.description,
+    required super.prText,
     required super.websiteUrl,
     super.scholarship,
   });
@@ -183,7 +183,7 @@ sealed class BasicSponsor extends CompanySponsor {
         name == other.name &&
         slug == other.slug &&
         logoUrl == other.logoUrl &&
-        description == other.description &&
+        prText == other.prText &&
         websiteUrl == other.websiteUrl &&
         scholarship == other.scholarship;
   }
@@ -194,7 +194,7 @@ sealed class BasicSponsor extends CompanySponsor {
     name,
     slug,
     logoUrl,
-    description,
+    prText,
     websiteUrl,
     scholarship,
   );
@@ -207,7 +207,7 @@ final class PlatinumSponsor extends BasicSponsor {
     required super.name,
     required super.slug,
     required super.logoUrl,
-    required super.description,
+    required super.prText,
     required super.websiteUrl,
     super.scholarship,
     this.namingRight = const NotAppliedNamingRight(),
@@ -227,7 +227,7 @@ final class PlatinumSponsor extends BasicSponsor {
         name == other.name &&
         slug == other.slug &&
         logoUrl == other.logoUrl &&
-        description == other.description &&
+        prText == other.prText &&
         websiteUrl == other.websiteUrl &&
         namingRight == other.namingRight &&
         namePlate == other.namePlate &&
@@ -240,7 +240,7 @@ final class PlatinumSponsor extends BasicSponsor {
     name,
     slug,
     logoUrl,
-    description,
+    prText,
     websiteUrl,
     namingRight,
     namePlate,
@@ -255,7 +255,7 @@ final class GoldSponsor extends BasicSponsor {
     required super.name,
     required super.slug,
     required super.logoUrl,
-    required super.description,
+    required super.prText,
     required super.websiteUrl,
     super.scholarship,
     this.namingRight = const NotAppliedNamingRight(),
@@ -275,7 +275,7 @@ final class GoldSponsor extends BasicSponsor {
         name == other.name &&
         slug == other.slug &&
         logoUrl == other.logoUrl &&
-        description == other.description &&
+        prText == other.prText &&
         websiteUrl == other.websiteUrl &&
         namingRight == other.namingRight &&
         namePlate == other.namePlate &&
@@ -288,7 +288,7 @@ final class GoldSponsor extends BasicSponsor {
     name,
     slug,
     logoUrl,
-    description,
+    prText,
     websiteUrl,
     namingRight,
     namePlate,
@@ -303,7 +303,7 @@ final class SilverSponsor extends BasicSponsor {
     required super.name,
     required super.slug,
     required super.logoUrl,
-    required super.description,
+    required super.prText,
     required super.websiteUrl,
     super.scholarship,
     this.namingRight = const NotAppliedNamingRight(),
@@ -325,7 +325,7 @@ final class SilverSponsor extends BasicSponsor {
         name == other.name &&
         slug == other.slug &&
         logoUrl == other.logoUrl &&
-        description == other.description &&
+        prText == other.prText &&
         websiteUrl == other.websiteUrl &&
         namingRight == other.namingRight &&
         namePlate == other.namePlate &&
@@ -339,7 +339,7 @@ final class SilverSponsor extends BasicSponsor {
     name,
     slug,
     logoUrl,
-    description,
+    prText,
     websiteUrl,
     namingRight,
     namePlate,
@@ -355,7 +355,7 @@ final class BronzeSponsor extends BasicSponsor {
     required super.name,
     required super.slug,
     required super.logoUrl,
-    required super.description,
+    required super.prText,
     required super.websiteUrl,
     super.scholarship,
     this.namePlate = false,
@@ -375,7 +375,7 @@ final class BronzeSponsor extends BasicSponsor {
         name == other.name &&
         slug == other.slug &&
         logoUrl == other.logoUrl &&
-        description == other.description &&
+        prText == other.prText &&
         websiteUrl == other.websiteUrl &&
         namePlate == other.namePlate &&
         lunchSponsor == other.lunchSponsor &&
@@ -388,7 +388,7 @@ final class BronzeSponsor extends BasicSponsor {
     name,
     slug,
     logoUrl,
-    description,
+    prText,
     websiteUrl,
     namePlate,
     lunchSponsor,
@@ -403,7 +403,7 @@ final class ToolSponsor extends CompanySponsor {
     required super.name,
     required super.slug,
     required super.logoUrl,
-    required super.description,
+    required super.prText,
     required super.websiteUrl,
     super.scholarship,
   });
@@ -418,7 +418,7 @@ final class ToolSponsor extends CompanySponsor {
         name == other.name &&
         slug == other.slug &&
         logoUrl == other.logoUrl &&
-        description == other.description &&
+        prText == other.prText &&
         websiteUrl == other.websiteUrl &&
         scholarship == other.scholarship;
   }
@@ -429,7 +429,7 @@ final class ToolSponsor extends CompanySponsor {
     name,
     slug,
     logoUrl,
-    description,
+    prText,
     websiteUrl,
     scholarship,
   );
@@ -442,7 +442,7 @@ final class OtherSponsor extends CompanySponsor {
     required super.name,
     required super.slug,
     required super.logoUrl,
-    required super.description,
+    required super.prText,
     required super.websiteUrl,
     super.scholarship,
   });
@@ -457,7 +457,7 @@ final class OtherSponsor extends CompanySponsor {
         name == other.name &&
         slug == other.slug &&
         logoUrl == other.logoUrl &&
-        description == other.description &&
+        prText == other.prText &&
         websiteUrl == other.websiteUrl &&
         scholarship == other.scholarship;
   }
@@ -468,7 +468,7 @@ final class OtherSponsor extends CompanySponsor {
     name,
     slug,
     logoUrl,
-    description,
+    prText,
     websiteUrl,
     scholarship,
   );

--- a/apps/dashboard/lib/features/sponsor/data/sponsor_provider.dart
+++ b/apps/dashboard/lib/features/sponsor/data/sponsor_provider.dart
@@ -55,7 +55,7 @@ PlatinumSponsor _convertPlatinumSponsor(CompanySponsorDetail companySponsor) {
     name: companySponsor.name,
     slug: companySponsor.slug,
     logoUrl: Uri.parse('https://placehold.co/400/png'),
-    description: companySponsor.description,
+    prText: companySponsor.prText,
     websiteUrl: Uri.parse(companySponsor.websiteUrl),
     scholarship: companySponsor.isScholarship,
     namingRight: companySponsor.namingRight,
@@ -70,7 +70,7 @@ GoldSponsor _convertGoldSponsor(CompanySponsorDetail companySponsor) {
     name: companySponsor.name,
     slug: companySponsor.slug,
     logoUrl: Uri.parse('https://placehold.co/400/png'),
-    description: companySponsor.description,
+    prText: companySponsor.prText,
     websiteUrl: Uri.parse(companySponsor.websiteUrl),
     scholarship: companySponsor.isScholarship,
     namingRight: companySponsor.namingRight,
@@ -85,7 +85,7 @@ SilverSponsor _convertSilverSponsor(CompanySponsorDetail companySponsor) {
     name: companySponsor.name,
     slug: companySponsor.slug,
     logoUrl: Uri.parse('https://placehold.co/400/png'),
-    description: companySponsor.description,
+    prText: companySponsor.prText,
     websiteUrl: Uri.parse(companySponsor.websiteUrl),
     scholarship: companySponsor.isScholarship,
     namingRight: companySponsor.namingRight,
@@ -101,7 +101,7 @@ BronzeSponsor _convertBronzeSponsor(CompanySponsorDetail companySponsor) {
     name: companySponsor.name,
     slug: companySponsor.slug,
     logoUrl: Uri.parse('https://placehold.co/400/png'),
-    description: companySponsor.description,
+    prText: companySponsor.prText,
     websiteUrl: Uri.parse(companySponsor.websiteUrl),
     scholarship: companySponsor.isScholarship,
     namePlate: companySponsor.isNamePlate,
@@ -116,7 +116,7 @@ ToolSponsor _convertToolSponsor(CompanySponsorDetail companySponsor) {
     name: companySponsor.name,
     slug: companySponsor.slug,
     logoUrl: Uri.parse('https://placehold.co/400/png'),
-    description: companySponsor.description,
+    prText: companySponsor.prText,
     websiteUrl: Uri.parse(companySponsor.websiteUrl),
   );
 }
@@ -128,7 +128,7 @@ OtherSponsor _convertOtherSponsor(CompanySponsorDetail companySponsor) {
     name: companySponsor.name,
     slug: companySponsor.slug,
     logoUrl: Uri.parse('https://placehold.co/400/png'),
-    description: companySponsor.description,
+    prText: companySponsor.prText,
     websiteUrl: Uri.parse(companySponsor.websiteUrl),
   );
 }

--- a/apps/dashboard/lib/features/sponsor/ui/sponsor_detail_screen.dart
+++ b/apps/dashboard/lib/features/sponsor/ui/sponsor_detail_screen.dart
@@ -77,7 +77,7 @@ class _SponsorDetail extends ConsumerWidget {
 
     final bodyContent = switch (sponsor) {
       final CompanySponsor company => [
-        // 会社概要
+        // PR 文章
         const SizedBox(height: 8),
         Text(
           l10n.sponsorDescription,

--- a/apps/dashboard/lib/features/sponsor/ui/sponsor_detail_screen.dart
+++ b/apps/dashboard/lib/features/sponsor/ui/sponsor_detail_screen.dart
@@ -80,12 +80,12 @@ class _SponsorDetail extends ConsumerWidget {
         // PR 文章
         const SizedBox(height: 8),
         Text(
-          l10n.sponsorDescription,
+          l10n.sponsorPrText,
           style: titleStyle,
         ),
         const SizedBox(height: 8),
         Text(
-          company.description,
+          company.prText,
           style: bodyTextStyle,
         ),
         const SizedBox(height: 8),

--- a/apps/dashboard/lib/features/sponsor/ui/sponsor_edit_screen.dart
+++ b/apps/dashboard/lib/features/sponsor/ui/sponsor_edit_screen.dart
@@ -72,7 +72,7 @@ class _SponsorEditForm extends HookConsumerWidget {
       nameController.text = sponsor.name;
       switch (sponsor) {
         case final CompanySponsor company:
-          descriptionController.text = company.description;
+          descriptionController.text = company.prText;
           websiteController.text = company.websiteUrl.toString();
         case final IndividualSponsor individual:
           descriptionController.text = individual.enthusiasm;
@@ -107,7 +107,7 @@ class _SponsorEditForm extends HookConsumerWidget {
             _SponsorEditField(
               controller: descriptionController,
               label: switch (sponsor) {
-                CompanySponsor() => l10n.sponsorDescription,
+                CompanySponsor() => l10n.sponsorPrText,
                 IndividualSponsor() => l10n.sponsorEnthusiasm,
               },
               maxLines: 3,

--- a/apps/dashboard/res/l10n/app_ja.arb
+++ b/apps/dashboard/res/l10n/app_ja.arb
@@ -20,7 +20,7 @@
   "@eventVenue": {},
   "eventAddress": "東京都千代田区大手町二丁目3番1号",
   "@eventAddress": {},
-  "sponsorDescription": "PR 文章",
+  "sponsorPrText": "PR 文章",
   "@sponsorDescription": {},
   "sponsorEnthusiasm": "意気込み",
   "@sponsorEnthusiasm": {},

--- a/apps/dashboard/res/l10n/app_ja.arb
+++ b/apps/dashboard/res/l10n/app_ja.arb
@@ -20,7 +20,7 @@
   "@eventVenue": {},
   "eventAddress": "東京都千代田区大手町二丁目3番1号",
   "@eventAddress": {},
-  "sponsorDescription": "会社概要",
+  "sponsorDescription": "PR 文章",
   "@sponsorDescription": {},
   "sponsorEnthusiasm": "意気込み",
   "@sponsorEnthusiasm": {},

--- a/packages/db_client/lib/src/client/sponsor/sponsor_db_client.dart
+++ b/packages/db_client/lib/src/client/sponsor/sponsor_db_client.dart
@@ -20,7 +20,7 @@ class SponsorDbClient {
           c.name,
           c.logo_name,
           cd.slug,
-          cd.description,
+          cd.pr_text,
           cd.website_url,
           sc.sponsor_type,
           bsc.basic_plan_type,
@@ -36,14 +36,14 @@ class SponsorDbClient {
         LEFT JOIN sponsor_company_options sco ON sc.id = sco.sponsor_company_id
         WHERE cda.id IS NOT NULL
           AND cd.slug IS NOT NULL
-          AND cd.description IS NOT NULL
+          AND cd.pr_text IS NOT NULL
           AND cd.website_url IS NOT NULL
         GROUP BY 
           c.id,
           c.name,
           c.logo_name,
           cd.slug,
-          cd.description,
+          cd.pr_text,
           cd.website_url,
           sc.sponsor_type,
           bsc.basic_plan_type

--- a/packages/db_types/lib/src/models/sponsors.dart
+++ b/packages/db_types/lib/src/models/sponsors.dart
@@ -12,7 +12,7 @@ abstract class CompanySponsorDetail with _$CompanySponsorDetail {
     required String name,
     required String logoName,
     required String slug,
-    required String description,
+    required String prText,
     required String websiteUrl,
     required CompanySponsorType sponsorType,
     BasicPlanType? basicPlanType,

--- a/packages/db_types/lib/src/models/sponsors.freezed.dart
+++ b/packages/db_types/lib/src/models/sponsors.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CompanySponsorDetail {
 
- int get id; String get name; String get logoName; String get slug; String get description; String get websiteUrl; CompanySponsorType get sponsorType; BasicPlanType? get basicPlanType; List<OptionPlanType> get optionPlanTypes;
+ int get id; String get name; String get logoName; String get slug; String get prText; String get websiteUrl; CompanySponsorType get sponsorType; BasicPlanType? get basicPlanType; List<OptionPlanType> get optionPlanTypes;
 /// Create a copy of CompanySponsorDetail
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $CompanySponsorDetailCopyWith<CompanySponsorDetail> get copyWith => _$CompanySpo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CompanySponsorDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.logoName, logoName) || other.logoName == logoName)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.description, description) || other.description == description)&&(identical(other.websiteUrl, websiteUrl) || other.websiteUrl == websiteUrl)&&(identical(other.sponsorType, sponsorType) || other.sponsorType == sponsorType)&&(identical(other.basicPlanType, basicPlanType) || other.basicPlanType == basicPlanType)&&const DeepCollectionEquality().equals(other.optionPlanTypes, optionPlanTypes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CompanySponsorDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.logoName, logoName) || other.logoName == logoName)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.prText, prText) || other.prText == prText)&&(identical(other.websiteUrl, websiteUrl) || other.websiteUrl == websiteUrl)&&(identical(other.sponsorType, sponsorType) || other.sponsorType == sponsorType)&&(identical(other.basicPlanType, basicPlanType) || other.basicPlanType == basicPlanType)&&const DeepCollectionEquality().equals(other.optionPlanTypes, optionPlanTypes));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,logoName,slug,description,websiteUrl,sponsorType,basicPlanType,const DeepCollectionEquality().hash(optionPlanTypes));
+int get hashCode => Object.hash(runtimeType,id,name,logoName,slug,prText,websiteUrl,sponsorType,basicPlanType,const DeepCollectionEquality().hash(optionPlanTypes));
 
 @override
 String toString() {
-  return 'CompanySponsorDetail(id: $id, name: $name, logoName: $logoName, slug: $slug, description: $description, websiteUrl: $websiteUrl, sponsorType: $sponsorType, basicPlanType: $basicPlanType, optionPlanTypes: $optionPlanTypes)';
+  return 'CompanySponsorDetail(id: $id, name: $name, logoName: $logoName, slug: $slug, prText: $prText, websiteUrl: $websiteUrl, sponsorType: $sponsorType, basicPlanType: $basicPlanType, optionPlanTypes: $optionPlanTypes)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $CompanySponsorDetailCopyWith<$Res>  {
   factory $CompanySponsorDetailCopyWith(CompanySponsorDetail value, $Res Function(CompanySponsorDetail) _then) = _$CompanySponsorDetailCopyWithImpl;
 @useResult
 $Res call({
- int id, String name, String logoName, String slug, String description, String websiteUrl, CompanySponsorType sponsorType, BasicPlanType? basicPlanType, List<OptionPlanType> optionPlanTypes
+ int id, String name, String logoName, String slug, String prText, String websiteUrl, CompanySponsorType sponsorType, BasicPlanType? basicPlanType, List<OptionPlanType> optionPlanTypes
 });
 
 
@@ -65,13 +65,13 @@ class _$CompanySponsorDetailCopyWithImpl<$Res>
 
 /// Create a copy of CompanySponsorDetail
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? logoName = null,Object? slug = null,Object? description = null,Object? websiteUrl = null,Object? sponsorType = null,Object? basicPlanType = freezed,Object? optionPlanTypes = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? logoName = null,Object? slug = null,Object? prText = null,Object? websiteUrl = null,Object? sponsorType = null,Object? basicPlanType = freezed,Object? optionPlanTypes = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,logoName: null == logoName ? _self.logoName : logoName // ignore: cast_nullable_to_non_nullable
 as String,slug: null == slug ? _self.slug : slug // ignore: cast_nullable_to_non_nullable
-as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String,prText: null == prText ? _self.prText : prText // ignore: cast_nullable_to_non_nullable
 as String,websiteUrl: null == websiteUrl ? _self.websiteUrl : websiteUrl // ignore: cast_nullable_to_non_nullable
 as String,sponsorType: null == sponsorType ? _self.sponsorType : sponsorType // ignore: cast_nullable_to_non_nullable
 as CompanySponsorType,basicPlanType: freezed == basicPlanType ? _self.basicPlanType : basicPlanType // ignore: cast_nullable_to_non_nullable
@@ -161,10 +161,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String name,  String logoName,  String slug,  String description,  String websiteUrl,  CompanySponsorType sponsorType,  BasicPlanType? basicPlanType,  List<OptionPlanType> optionPlanTypes)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String name,  String logoName,  String slug,  String prText,  String websiteUrl,  CompanySponsorType sponsorType,  BasicPlanType? basicPlanType,  List<OptionPlanType> optionPlanTypes)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _CompanySponsorDetail() when $default != null:
-return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.description,_that.websiteUrl,_that.sponsorType,_that.basicPlanType,_that.optionPlanTypes);case _:
+return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.prText,_that.websiteUrl,_that.sponsorType,_that.basicPlanType,_that.optionPlanTypes);case _:
   return orElse();
 
 }
@@ -182,10 +182,10 @@ return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.description,
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String name,  String logoName,  String slug,  String description,  String websiteUrl,  CompanySponsorType sponsorType,  BasicPlanType? basicPlanType,  List<OptionPlanType> optionPlanTypes)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String name,  String logoName,  String slug,  String prText,  String websiteUrl,  CompanySponsorType sponsorType,  BasicPlanType? basicPlanType,  List<OptionPlanType> optionPlanTypes)  $default,) {final _that = this;
 switch (_that) {
 case _CompanySponsorDetail():
-return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.description,_that.websiteUrl,_that.sponsorType,_that.basicPlanType,_that.optionPlanTypes);case _:
+return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.prText,_that.websiteUrl,_that.sponsorType,_that.basicPlanType,_that.optionPlanTypes);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -202,10 +202,10 @@ return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.description,
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String name,  String logoName,  String slug,  String description,  String websiteUrl,  CompanySponsorType sponsorType,  BasicPlanType? basicPlanType,  List<OptionPlanType> optionPlanTypes)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String name,  String logoName,  String slug,  String prText,  String websiteUrl,  CompanySponsorType sponsorType,  BasicPlanType? basicPlanType,  List<OptionPlanType> optionPlanTypes)?  $default,) {final _that = this;
 switch (_that) {
 case _CompanySponsorDetail() when $default != null:
-return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.description,_that.websiteUrl,_that.sponsorType,_that.basicPlanType,_that.optionPlanTypes);case _:
+return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.prText,_that.websiteUrl,_that.sponsorType,_that.basicPlanType,_that.optionPlanTypes);case _:
   return null;
 
 }
@@ -217,14 +217,14 @@ return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.description,
 @JsonSerializable()
 
 class _CompanySponsorDetail implements CompanySponsorDetail {
-  const _CompanySponsorDetail({required this.id, required this.name, required this.logoName, required this.slug, required this.description, required this.websiteUrl, required this.sponsorType, this.basicPlanType, final  List<OptionPlanType> optionPlanTypes = const []}): _optionPlanTypes = optionPlanTypes;
+  const _CompanySponsorDetail({required this.id, required this.name, required this.logoName, required this.slug, required this.prText, required this.websiteUrl, required this.sponsorType, this.basicPlanType, final  List<OptionPlanType> optionPlanTypes = const []}): _optionPlanTypes = optionPlanTypes;
   factory _CompanySponsorDetail.fromJson(Map<String, dynamic> json) => _$CompanySponsorDetailFromJson(json);
 
 @override final  int id;
 @override final  String name;
 @override final  String logoName;
 @override final  String slug;
-@override final  String description;
+@override final  String prText;
 @override final  String websiteUrl;
 @override final  CompanySponsorType sponsorType;
 @override final  BasicPlanType? basicPlanType;
@@ -249,16 +249,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CompanySponsorDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.logoName, logoName) || other.logoName == logoName)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.description, description) || other.description == description)&&(identical(other.websiteUrl, websiteUrl) || other.websiteUrl == websiteUrl)&&(identical(other.sponsorType, sponsorType) || other.sponsorType == sponsorType)&&(identical(other.basicPlanType, basicPlanType) || other.basicPlanType == basicPlanType)&&const DeepCollectionEquality().equals(other._optionPlanTypes, _optionPlanTypes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CompanySponsorDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.logoName, logoName) || other.logoName == logoName)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.prText, prText) || other.prText == prText)&&(identical(other.websiteUrl, websiteUrl) || other.websiteUrl == websiteUrl)&&(identical(other.sponsorType, sponsorType) || other.sponsorType == sponsorType)&&(identical(other.basicPlanType, basicPlanType) || other.basicPlanType == basicPlanType)&&const DeepCollectionEquality().equals(other._optionPlanTypes, _optionPlanTypes));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,logoName,slug,description,websiteUrl,sponsorType,basicPlanType,const DeepCollectionEquality().hash(_optionPlanTypes));
+int get hashCode => Object.hash(runtimeType,id,name,logoName,slug,prText,websiteUrl,sponsorType,basicPlanType,const DeepCollectionEquality().hash(_optionPlanTypes));
 
 @override
 String toString() {
-  return 'CompanySponsorDetail(id: $id, name: $name, logoName: $logoName, slug: $slug, description: $description, websiteUrl: $websiteUrl, sponsorType: $sponsorType, basicPlanType: $basicPlanType, optionPlanTypes: $optionPlanTypes)';
+  return 'CompanySponsorDetail(id: $id, name: $name, logoName: $logoName, slug: $slug, prText: $prText, websiteUrl: $websiteUrl, sponsorType: $sponsorType, basicPlanType: $basicPlanType, optionPlanTypes: $optionPlanTypes)';
 }
 
 
@@ -269,7 +269,7 @@ abstract mixin class _$CompanySponsorDetailCopyWith<$Res> implements $CompanySpo
   factory _$CompanySponsorDetailCopyWith(_CompanySponsorDetail value, $Res Function(_CompanySponsorDetail) _then) = __$CompanySponsorDetailCopyWithImpl;
 @override @useResult
 $Res call({
- int id, String name, String logoName, String slug, String description, String websiteUrl, CompanySponsorType sponsorType, BasicPlanType? basicPlanType, List<OptionPlanType> optionPlanTypes
+ int id, String name, String logoName, String slug, String prText, String websiteUrl, CompanySponsorType sponsorType, BasicPlanType? basicPlanType, List<OptionPlanType> optionPlanTypes
 });
 
 
@@ -286,13 +286,13 @@ class __$CompanySponsorDetailCopyWithImpl<$Res>
 
 /// Create a copy of CompanySponsorDetail
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? logoName = null,Object? slug = null,Object? description = null,Object? websiteUrl = null,Object? sponsorType = null,Object? basicPlanType = freezed,Object? optionPlanTypes = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? logoName = null,Object? slug = null,Object? prText = null,Object? websiteUrl = null,Object? sponsorType = null,Object? basicPlanType = freezed,Object? optionPlanTypes = null,}) {
   return _then(_CompanySponsorDetail(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,logoName: null == logoName ? _self.logoName : logoName // ignore: cast_nullable_to_non_nullable
 as String,slug: null == slug ? _self.slug : slug // ignore: cast_nullable_to_non_nullable
-as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String,prText: null == prText ? _self.prText : prText // ignore: cast_nullable_to_non_nullable
 as String,websiteUrl: null == websiteUrl ? _self.websiteUrl : websiteUrl // ignore: cast_nullable_to_non_nullable
 as String,sponsorType: null == sponsorType ? _self.sponsorType : sponsorType // ignore: cast_nullable_to_non_nullable
 as CompanySponsorType,basicPlanType: freezed == basicPlanType ? _self.basicPlanType : basicPlanType // ignore: cast_nullable_to_non_nullable

--- a/packages/db_types/lib/src/models/sponsors.g.dart
+++ b/packages/db_types/lib/src/models/sponsors.g.dart
@@ -19,7 +19,7 @@ _CompanySponsorDetail _$CompanySponsorDetailFromJson(
       name: $checkedConvert('name', (v) => v as String),
       logoName: $checkedConvert('logo_name', (v) => v as String),
       slug: $checkedConvert('slug', (v) => v as String),
-      description: $checkedConvert('description', (v) => v as String),
+      prText: $checkedConvert('pr_text', (v) => v as String),
       websiteUrl: $checkedConvert('website_url', (v) => v as String),
       sponsorType: $checkedConvert(
         'sponsor_type',
@@ -42,6 +42,7 @@ _CompanySponsorDetail _$CompanySponsorDetailFromJson(
   },
   fieldKeyMap: const {
     'logoName': 'logo_name',
+    'prText': 'pr_text',
     'websiteUrl': 'website_url',
     'sponsorType': 'sponsor_type',
     'basicPlanType': 'basic_plan_type',
@@ -56,7 +57,7 @@ Map<String, dynamic> _$CompanySponsorDetailToJson(
   'name': instance.name,
   'logo_name': instance.logoName,
   'slug': instance.slug,
-  'description': instance.description,
+  'pr_text': instance.prText,
   'website_url': instance.websiteUrl,
   'sponsor_type': _$CompanySponsorTypeEnumMap[instance.sponsorType]!,
   'basic_plan_type': _$BasicPlanTypeEnumMap[instance.basicPlanType],

--- a/supabase/migrations/20250816110128_rename_description_to_pr_text.sql
+++ b/supabase/migrations/20250816110128_rename_description_to_pr_text.sql
@@ -1,0 +1,11 @@
+alter table "public"."company_drafts" drop constraint "company_drafts_description_check";
+
+alter table "public"."company_drafts" drop column "description";
+
+alter table "public"."company_drafts" add column "pr_text" text not null;
+
+alter table "public"."company_drafts" add constraint "company_drafts_pr_text_check" CHECK ((pr_text <> ''::text)) not valid;
+
+alter table "public"."company_drafts" validate constraint "company_drafts_pr_text_check";
+
+

--- a/supabase/schemas/003_company_drafts.sql
+++ b/supabase/schemas/003_company_drafts.sql
@@ -3,7 +3,7 @@ CREATE TABLE public.company_drafts (
   id smallint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
   company_id smallint REFERENCES public.companies (id) ON DELETE CASCADE NULL,
   slug text NOT NULL UNIQUE CHECK (slug <> ''),
-  description text NOT NULL CHECK (description <> ''),
+  pr_text text NOT NULL CHECK (pr_text <> ''),
   website_url text NOT NULL CHECK (website_url <> ''),
   x_account text CHECK (x_account <> ''),
   created_at timestamp DEFAULT now() NOT NULL,

--- a/supabase/seeds/003_company_drafts.sql
+++ b/supabase/seeds/003_company_drafts.sql
@@ -4,11 +4,11 @@ WITH
             '2025-06-01 00:00:00'::timestamp AS ts
     )
 INSERT INTO
-    public.company_drafts (company_id, slug, description, website_url, x_account, created_at, updated_at)
+    public.company_drafts (company_id, slug, pr_text, website_url, x_account, created_at, updated_at)
 SELECT
     company_id,
     slug,
-    description,
+    pr_text,
     website_url,
     x_account,
     ts,
@@ -186,7 +186,7 @@ FROM
                 'https://kibe.la/',
                 'kibe_la'
             )
-    ) AS drafts (company_id, slug, description, website_url, x_account)
+    ) AS drafts (company_id, slug, pr_text, website_url, x_account)
     CROSS JOIN timestamp;
 
 -- company_drafts の全てのレコードを承認ユーザーで承認する


### PR DESCRIPTION
## 概要

スポンサー詳細画面の「会社概要」を「PR 文章」に変更し、関連するフィールド名を`description`から`prText`に統一しました。

## 変更内容

### アプリケーション層
- **Sponsorモデル**: `description`フィールドを`prText`に変更
- **UIコード**: 表示テキストとフィールド参照を「PR 文章」に変更
- **l10n**: `sponsorDescription`を`sponsorPrText`に変更
- **スポンサープロバイダー**: フィールド参照を`prText`に変更

### データベース層
- **スキーマ**: `company_drafts.description`を`pr_text`に変更
- **マイグレーション**: `description`カラムを`pr_text`にリネームするマイグレーションを追加
- **シードファイル**: データ挿入時のカラム名を`pr_text`に変更

### データアクセス層
- **データベースクライアント**: SQLクエリの`description`を`pr_text`に変更
- **データベース型定義**: `CompanySponsorDetail.description`を`prText`に変更

## 変更ファイル数
- 14ファイル変更
- 84行追加、72行削除

## 技術的な詳細

1. **フィールド名の統一**: アプリケーション層からデータベース層まで一貫した命名規則を適用
2. **自動マイグレーション生成**: `supabase db diff`を使用してマイグレーションファイルを自動生成
3. **コード生成の更新**: `melos run gen:build`で生成されたコードを更新

## 動画

https://github.com/user-attachments/assets/305c7262-2688-4f58-9d00-dae69659e509

## テスト

- [x] データベースのリセット（`supabase db reset`）
- [x] アプリケーションのビルド
- [x] linterエラーの解消

## 注意事項

- データベースのカラム名が変更されるため、本番環境への適用時はデータ移行の確認が必要
- 既存のデータは`pr_text`カラムに移行される