### PR TITLE
fix: company buckets設定の削除

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -84,10 +84,6 @@ enabled = true
 # The maximum file size allowed (e.g. "5MB", "500KB").
 file_size_limit = "50MiB"
 
-[storage.buckets.companies]
-public = true
-objects_path = "seeds/storages/companies"
-
 # Image transformation API is available to Supabase Pro plan.
 # [storage.image_transformation]
 # enabled = true


### PR DESCRIPTION
## 概要
Supabase設定から不要になったcompany buckets設定を削除しました。

## 変更内容
- `supabase/config.toml`から`[storage.buckets.companies]`セクションを削除
- 関連する設定（`public = true`、`objects_path = "seeds/storages/companies"`）も削除

## 詳細
この変更により、Supabaseのストレージ設定がより簡潔になり、不要な設定が除去されます。company bucketsの設定が実際に使用されていない場合、この設定の削除は適切です。

## 確認事項
- [x] 設定ファイルの変更のみ
- [x] 既存の機能に影響なし
- [x] 設定の整理・最適化