### PR TITLE
feat: スポンサーAPIのロゴレスポンスをロゴURLに変更

### DIFF
--- a/bff/engine/.env.example
+++ b/bff/engine/.env.example
@@ -7,3 +7,4 @@ CF_VERSION_METADATA_TIMESTAMP=2025-01-01T00:00:00Z
 POSTGRES_URL=postgresql://postgres:postgres@host.docker.internal:54322/postgres
 INTERNAL_API_URL=http://localhost:8787
 X_API_KEY=xxx
+LOGO_BASE_URL=https://pub-27ad8ed93aa141a0b45f128f849914ed.r2.dev

--- a/bff/engine/lib/model/environments.dart
+++ b/bff/engine/lib/model/environments.dart
@@ -15,6 +15,7 @@ abstract class Environments with _$Environments {
     required String postgresUrl,
     required String internalApiUrl,
     required String xApiKey,
+    required String logoBaseUrl,
   }) = _Environments;
 
   const Environments._();

--- a/bff/engine/lib/model/environments.freezed.dart
+++ b/bff/engine/lib/model/environments.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Environments {
 
- String get supabaseUrl; String get supabaseServiceRoleKey; String get cfVersionMetadataId; String get cfVersionMetadataTag; String get cfVersionMetadataTimestamp; String get postgresUrl; String get internalApiUrl; String get xApiKey;
+ String get supabaseUrl; String get supabaseServiceRoleKey; String get cfVersionMetadataId; String get cfVersionMetadataTag; String get cfVersionMetadataTimestamp; String get postgresUrl; String get internalApiUrl; String get xApiKey; String get logoBaseUrl;
 /// Create a copy of Environments
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $EnvironmentsCopyWith<Environments> get copyWith => _$EnvironmentsCopyWithImpl<E
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Environments&&(identical(other.supabaseUrl, supabaseUrl) || other.supabaseUrl == supabaseUrl)&&(identical(other.supabaseServiceRoleKey, supabaseServiceRoleKey) || other.supabaseServiceRoleKey == supabaseServiceRoleKey)&&(identical(other.cfVersionMetadataId, cfVersionMetadataId) || other.cfVersionMetadataId == cfVersionMetadataId)&&(identical(other.cfVersionMetadataTag, cfVersionMetadataTag) || other.cfVersionMetadataTag == cfVersionMetadataTag)&&(identical(other.cfVersionMetadataTimestamp, cfVersionMetadataTimestamp) || other.cfVersionMetadataTimestamp == cfVersionMetadataTimestamp)&&(identical(other.postgresUrl, postgresUrl) || other.postgresUrl == postgresUrl)&&(identical(other.internalApiUrl, internalApiUrl) || other.internalApiUrl == internalApiUrl)&&(identical(other.xApiKey, xApiKey) || other.xApiKey == xApiKey));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Environments&&(identical(other.supabaseUrl, supabaseUrl) || other.supabaseUrl == supabaseUrl)&&(identical(other.supabaseServiceRoleKey, supabaseServiceRoleKey) || other.supabaseServiceRoleKey == supabaseServiceRoleKey)&&(identical(other.cfVersionMetadataId, cfVersionMetadataId) || other.cfVersionMetadataId == cfVersionMetadataId)&&(identical(other.cfVersionMetadataTag, cfVersionMetadataTag) || other.cfVersionMetadataTag == cfVersionMetadataTag)&&(identical(other.cfVersionMetadataTimestamp, cfVersionMetadataTimestamp) || other.cfVersionMetadataTimestamp == cfVersionMetadataTimestamp)&&(identical(other.postgresUrl, postgresUrl) || other.postgresUrl == postgresUrl)&&(identical(other.internalApiUrl, internalApiUrl) || other.internalApiUrl == internalApiUrl)&&(identical(other.xApiKey, xApiKey) || other.xApiKey == xApiKey)&&(identical(other.logoBaseUrl, logoBaseUrl) || other.logoBaseUrl == logoBaseUrl));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,supabaseUrl,supabaseServiceRoleKey,cfVersionMetadataId,cfVersionMetadataTag,cfVersionMetadataTimestamp,postgresUrl,internalApiUrl,xApiKey);
+int get hashCode => Object.hash(runtimeType,supabaseUrl,supabaseServiceRoleKey,cfVersionMetadataId,cfVersionMetadataTag,cfVersionMetadataTimestamp,postgresUrl,internalApiUrl,xApiKey,logoBaseUrl);
 
 @override
 String toString() {
-  return 'Environments(supabaseUrl: $supabaseUrl, supabaseServiceRoleKey: $supabaseServiceRoleKey, cfVersionMetadataId: $cfVersionMetadataId, cfVersionMetadataTag: $cfVersionMetadataTag, cfVersionMetadataTimestamp: $cfVersionMetadataTimestamp, postgresUrl: $postgresUrl, internalApiUrl: $internalApiUrl, xApiKey: $xApiKey)';
+  return 'Environments(supabaseUrl: $supabaseUrl, supabaseServiceRoleKey: $supabaseServiceRoleKey, cfVersionMetadataId: $cfVersionMetadataId, cfVersionMetadataTag: $cfVersionMetadataTag, cfVersionMetadataTimestamp: $cfVersionMetadataTimestamp, postgresUrl: $postgresUrl, internalApiUrl: $internalApiUrl, xApiKey: $xApiKey, logoBaseUrl: $logoBaseUrl)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $EnvironmentsCopyWith<$Res>  {
   factory $EnvironmentsCopyWith(Environments value, $Res Function(Environments) _then) = _$EnvironmentsCopyWithImpl;
 @useResult
 $Res call({
- String supabaseUrl, String supabaseServiceRoleKey, String cfVersionMetadataId, String cfVersionMetadataTag, String cfVersionMetadataTimestamp, String postgresUrl, String internalApiUrl, String xApiKey
+ String supabaseUrl, String supabaseServiceRoleKey, String cfVersionMetadataId, String cfVersionMetadataTag, String cfVersionMetadataTimestamp, String postgresUrl, String internalApiUrl, String xApiKey, String logoBaseUrl
 });
 
 
@@ -65,7 +65,7 @@ class _$EnvironmentsCopyWithImpl<$Res>
 
 /// Create a copy of Environments
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? supabaseUrl = null,Object? supabaseServiceRoleKey = null,Object? cfVersionMetadataId = null,Object? cfVersionMetadataTag = null,Object? cfVersionMetadataTimestamp = null,Object? postgresUrl = null,Object? internalApiUrl = null,Object? xApiKey = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? supabaseUrl = null,Object? supabaseServiceRoleKey = null,Object? cfVersionMetadataId = null,Object? cfVersionMetadataTag = null,Object? cfVersionMetadataTimestamp = null,Object? postgresUrl = null,Object? internalApiUrl = null,Object? xApiKey = null,Object? logoBaseUrl = null,}) {
   return _then(_self.copyWith(
 supabaseUrl: null == supabaseUrl ? _self.supabaseUrl : supabaseUrl // ignore: cast_nullable_to_non_nullable
 as String,supabaseServiceRoleKey: null == supabaseServiceRoleKey ? _self.supabaseServiceRoleKey : supabaseServiceRoleKey // ignore: cast_nullable_to_non_nullable
@@ -75,6 +75,7 @@ as String,cfVersionMetadataTimestamp: null == cfVersionMetadataTimestamp ? _self
 as String,postgresUrl: null == postgresUrl ? _self.postgresUrl : postgresUrl // ignore: cast_nullable_to_non_nullable
 as String,internalApiUrl: null == internalApiUrl ? _self.internalApiUrl : internalApiUrl // ignore: cast_nullable_to_non_nullable
 as String,xApiKey: null == xApiKey ? _self.xApiKey : xApiKey // ignore: cast_nullable_to_non_nullable
+as String,logoBaseUrl: null == logoBaseUrl ? _self.logoBaseUrl : logoBaseUrl // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }
@@ -160,10 +161,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String supabaseUrl,  String supabaseServiceRoleKey,  String cfVersionMetadataId,  String cfVersionMetadataTag,  String cfVersionMetadataTimestamp,  String postgresUrl,  String internalApiUrl,  String xApiKey)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String supabaseUrl,  String supabaseServiceRoleKey,  String cfVersionMetadataId,  String cfVersionMetadataTag,  String cfVersionMetadataTimestamp,  String postgresUrl,  String internalApiUrl,  String xApiKey,  String logoBaseUrl)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Environments() when $default != null:
-return $default(_that.supabaseUrl,_that.supabaseServiceRoleKey,_that.cfVersionMetadataId,_that.cfVersionMetadataTag,_that.cfVersionMetadataTimestamp,_that.postgresUrl,_that.internalApiUrl,_that.xApiKey);case _:
+return $default(_that.supabaseUrl,_that.supabaseServiceRoleKey,_that.cfVersionMetadataId,_that.cfVersionMetadataTag,_that.cfVersionMetadataTimestamp,_that.postgresUrl,_that.internalApiUrl,_that.xApiKey,_that.logoBaseUrl);case _:
   return orElse();
 
 }
@@ -181,10 +182,10 @@ return $default(_that.supabaseUrl,_that.supabaseServiceRoleKey,_that.cfVersionMe
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String supabaseUrl,  String supabaseServiceRoleKey,  String cfVersionMetadataId,  String cfVersionMetadataTag,  String cfVersionMetadataTimestamp,  String postgresUrl,  String internalApiUrl,  String xApiKey)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String supabaseUrl,  String supabaseServiceRoleKey,  String cfVersionMetadataId,  String cfVersionMetadataTag,  String cfVersionMetadataTimestamp,  String postgresUrl,  String internalApiUrl,  String xApiKey,  String logoBaseUrl)  $default,) {final _that = this;
 switch (_that) {
 case _Environments():
-return $default(_that.supabaseUrl,_that.supabaseServiceRoleKey,_that.cfVersionMetadataId,_that.cfVersionMetadataTag,_that.cfVersionMetadataTimestamp,_that.postgresUrl,_that.internalApiUrl,_that.xApiKey);case _:
+return $default(_that.supabaseUrl,_that.supabaseServiceRoleKey,_that.cfVersionMetadataId,_that.cfVersionMetadataTag,_that.cfVersionMetadataTimestamp,_that.postgresUrl,_that.internalApiUrl,_that.xApiKey,_that.logoBaseUrl);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -201,10 +202,10 @@ return $default(_that.supabaseUrl,_that.supabaseServiceRoleKey,_that.cfVersionMe
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String supabaseUrl,  String supabaseServiceRoleKey,  String cfVersionMetadataId,  String cfVersionMetadataTag,  String cfVersionMetadataTimestamp,  String postgresUrl,  String internalApiUrl,  String xApiKey)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String supabaseUrl,  String supabaseServiceRoleKey,  String cfVersionMetadataId,  String cfVersionMetadataTag,  String cfVersionMetadataTimestamp,  String postgresUrl,  String internalApiUrl,  String xApiKey,  String logoBaseUrl)?  $default,) {final _that = this;
 switch (_that) {
 case _Environments() when $default != null:
-return $default(_that.supabaseUrl,_that.supabaseServiceRoleKey,_that.cfVersionMetadataId,_that.cfVersionMetadataTag,_that.cfVersionMetadataTimestamp,_that.postgresUrl,_that.internalApiUrl,_that.xApiKey);case _:
+return $default(_that.supabaseUrl,_that.supabaseServiceRoleKey,_that.cfVersionMetadataId,_that.cfVersionMetadataTag,_that.cfVersionMetadataTimestamp,_that.postgresUrl,_that.internalApiUrl,_that.xApiKey,_that.logoBaseUrl);case _:
   return null;
 
 }
@@ -216,7 +217,7 @@ return $default(_that.supabaseUrl,_that.supabaseServiceRoleKey,_that.cfVersionMe
 
 @JsonSerializable(fieldRename: FieldRename.screamingSnake)
 class _Environments extends Environments {
-  const _Environments({required this.supabaseUrl, required this.supabaseServiceRoleKey, required this.cfVersionMetadataId, required this.cfVersionMetadataTag, required this.cfVersionMetadataTimestamp, required this.postgresUrl, required this.internalApiUrl, required this.xApiKey}): super._();
+  const _Environments({required this.supabaseUrl, required this.supabaseServiceRoleKey, required this.cfVersionMetadataId, required this.cfVersionMetadataTag, required this.cfVersionMetadataTimestamp, required this.postgresUrl, required this.internalApiUrl, required this.xApiKey, required this.logoBaseUrl}): super._();
   factory _Environments.fromJson(Map<String, dynamic> json) => _$EnvironmentsFromJson(json);
 
 @override final  String supabaseUrl;
@@ -227,6 +228,7 @@ class _Environments extends Environments {
 @override final  String postgresUrl;
 @override final  String internalApiUrl;
 @override final  String xApiKey;
+@override final  String logoBaseUrl;
 
 /// Create a copy of Environments
 /// with the given fields replaced by the non-null parameter values.
@@ -241,16 +243,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Environments&&(identical(other.supabaseUrl, supabaseUrl) || other.supabaseUrl == supabaseUrl)&&(identical(other.supabaseServiceRoleKey, supabaseServiceRoleKey) || other.supabaseServiceRoleKey == supabaseServiceRoleKey)&&(identical(other.cfVersionMetadataId, cfVersionMetadataId) || other.cfVersionMetadataId == cfVersionMetadataId)&&(identical(other.cfVersionMetadataTag, cfVersionMetadataTag) || other.cfVersionMetadataTag == cfVersionMetadataTag)&&(identical(other.cfVersionMetadataTimestamp, cfVersionMetadataTimestamp) || other.cfVersionMetadataTimestamp == cfVersionMetadataTimestamp)&&(identical(other.postgresUrl, postgresUrl) || other.postgresUrl == postgresUrl)&&(identical(other.internalApiUrl, internalApiUrl) || other.internalApiUrl == internalApiUrl)&&(identical(other.xApiKey, xApiKey) || other.xApiKey == xApiKey));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Environments&&(identical(other.supabaseUrl, supabaseUrl) || other.supabaseUrl == supabaseUrl)&&(identical(other.supabaseServiceRoleKey, supabaseServiceRoleKey) || other.supabaseServiceRoleKey == supabaseServiceRoleKey)&&(identical(other.cfVersionMetadataId, cfVersionMetadataId) || other.cfVersionMetadataId == cfVersionMetadataId)&&(identical(other.cfVersionMetadataTag, cfVersionMetadataTag) || other.cfVersionMetadataTag == cfVersionMetadataTag)&&(identical(other.cfVersionMetadataTimestamp, cfVersionMetadataTimestamp) || other.cfVersionMetadataTimestamp == cfVersionMetadataTimestamp)&&(identical(other.postgresUrl, postgresUrl) || other.postgresUrl == postgresUrl)&&(identical(other.internalApiUrl, internalApiUrl) || other.internalApiUrl == internalApiUrl)&&(identical(other.xApiKey, xApiKey) || other.xApiKey == xApiKey)&&(identical(other.logoBaseUrl, logoBaseUrl) || other.logoBaseUrl == logoBaseUrl));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,supabaseUrl,supabaseServiceRoleKey,cfVersionMetadataId,cfVersionMetadataTag,cfVersionMetadataTimestamp,postgresUrl,internalApiUrl,xApiKey);
+int get hashCode => Object.hash(runtimeType,supabaseUrl,supabaseServiceRoleKey,cfVersionMetadataId,cfVersionMetadataTag,cfVersionMetadataTimestamp,postgresUrl,internalApiUrl,xApiKey,logoBaseUrl);
 
 @override
 String toString() {
-  return 'Environments(supabaseUrl: $supabaseUrl, supabaseServiceRoleKey: $supabaseServiceRoleKey, cfVersionMetadataId: $cfVersionMetadataId, cfVersionMetadataTag: $cfVersionMetadataTag, cfVersionMetadataTimestamp: $cfVersionMetadataTimestamp, postgresUrl: $postgresUrl, internalApiUrl: $internalApiUrl, xApiKey: $xApiKey)';
+  return 'Environments(supabaseUrl: $supabaseUrl, supabaseServiceRoleKey: $supabaseServiceRoleKey, cfVersionMetadataId: $cfVersionMetadataId, cfVersionMetadataTag: $cfVersionMetadataTag, cfVersionMetadataTimestamp: $cfVersionMetadataTimestamp, postgresUrl: $postgresUrl, internalApiUrl: $internalApiUrl, xApiKey: $xApiKey, logoBaseUrl: $logoBaseUrl)';
 }
 
 
@@ -261,7 +263,7 @@ abstract mixin class _$EnvironmentsCopyWith<$Res> implements $EnvironmentsCopyWi
   factory _$EnvironmentsCopyWith(_Environments value, $Res Function(_Environments) _then) = __$EnvironmentsCopyWithImpl;
 @override @useResult
 $Res call({
- String supabaseUrl, String supabaseServiceRoleKey, String cfVersionMetadataId, String cfVersionMetadataTag, String cfVersionMetadataTimestamp, String postgresUrl, String internalApiUrl, String xApiKey
+ String supabaseUrl, String supabaseServiceRoleKey, String cfVersionMetadataId, String cfVersionMetadataTag, String cfVersionMetadataTimestamp, String postgresUrl, String internalApiUrl, String xApiKey, String logoBaseUrl
 });
 
 
@@ -278,7 +280,7 @@ class __$EnvironmentsCopyWithImpl<$Res>
 
 /// Create a copy of Environments
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? supabaseUrl = null,Object? supabaseServiceRoleKey = null,Object? cfVersionMetadataId = null,Object? cfVersionMetadataTag = null,Object? cfVersionMetadataTimestamp = null,Object? postgresUrl = null,Object? internalApiUrl = null,Object? xApiKey = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? supabaseUrl = null,Object? supabaseServiceRoleKey = null,Object? cfVersionMetadataId = null,Object? cfVersionMetadataTag = null,Object? cfVersionMetadataTimestamp = null,Object? postgresUrl = null,Object? internalApiUrl = null,Object? xApiKey = null,Object? logoBaseUrl = null,}) {
   return _then(_Environments(
 supabaseUrl: null == supabaseUrl ? _self.supabaseUrl : supabaseUrl // ignore: cast_nullable_to_non_nullable
 as String,supabaseServiceRoleKey: null == supabaseServiceRoleKey ? _self.supabaseServiceRoleKey : supabaseServiceRoleKey // ignore: cast_nullable_to_non_nullable
@@ -288,6 +290,7 @@ as String,cfVersionMetadataTimestamp: null == cfVersionMetadataTimestamp ? _self
 as String,postgresUrl: null == postgresUrl ? _self.postgresUrl : postgresUrl // ignore: cast_nullable_to_non_nullable
 as String,internalApiUrl: null == internalApiUrl ? _self.internalApiUrl : internalApiUrl // ignore: cast_nullable_to_non_nullable
 as String,xApiKey: null == xApiKey ? _self.xApiKey : xApiKey // ignore: cast_nullable_to_non_nullable
+as String,logoBaseUrl: null == logoBaseUrl ? _self.logoBaseUrl : logoBaseUrl // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }

--- a/bff/engine/lib/model/environments.g.dart
+++ b/bff/engine/lib/model/environments.g.dart
@@ -37,6 +37,7 @@ _Environments _$EnvironmentsFromJson(Map<String, dynamic> json) =>
             (v) => v as String,
           ),
           xApiKey: $checkedConvert('X_API_KEY', (v) => v as String),
+          logoBaseUrl: $checkedConvert('LOGO_BASE_URL', (v) => v as String),
         );
         return val;
       },
@@ -49,6 +50,7 @@ _Environments _$EnvironmentsFromJson(Map<String, dynamic> json) =>
         'postgresUrl': 'POSTGRES_URL',
         'internalApiUrl': 'INTERNAL_API_URL',
         'xApiKey': 'X_API_KEY',
+        'logoBaseUrl': 'LOGO_BASE_URL',
       },
     );
 
@@ -62,4 +64,5 @@ Map<String, dynamic> _$EnvironmentsToJson(_Environments instance) =>
       'POSTGRES_URL': instance.postgresUrl,
       'INTERNAL_API_URL': instance.internalApiUrl,
       'X_API_KEY': instance.xApiKey,
+      'LOGO_BASE_URL': instance.logoBaseUrl,
     };

--- a/bff/engine/lib/provider/db_client_provider.dart
+++ b/bff/engine/lib/provider/db_client_provider.dart
@@ -11,6 +11,7 @@ Future<DbClient> dbClient(Ref ref) async {
   // ローカル環境ではSSLを無効にする
   final db = await DbClient.connect(
     env.postgresUrl,
+    logoBaseUrl: env.logoBaseUrl,
     disableSsl: env.isLocal,
   );
 

--- a/bff/engine/lib/provider/internal_api_client_provider.g.dart
+++ b/bff/engine/lib/provider/internal_api_client_provider.g.dart
@@ -93,7 +93,7 @@ final class InternalApiDioProvider extends $FunctionalProvider<Dio, Dio, Dio>
   }
 }
 
-String _$internalApiDioHash() => r'40aad04a40987a302a0815abd3e0cc796a4b97a3';
+String _$internalApiDioHash() => r'c56bc408ceb637a8ce11d968dd7a5201abad44b0';
 
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/db_client/lib/src/client/db_client.dart
+++ b/packages/db_client/lib/src/client/db_client.dart
@@ -8,10 +8,15 @@ import 'package:db_client/src/client/user/user_db_client.dart';
 import 'package:postgres/postgres.dart';
 
 class DbClient {
-  DbClient({required Connection connection}) : _connection = connection;
+  DbClient({
+    required Connection connection,
+    required String logoBaseUrl,
+  }) : _connection = connection,
+       _logoBaseUrl = logoBaseUrl;
 
   static Future<DbClient> connect(
     String connectionString, {
+    required String logoBaseUrl,
     bool disableSsl = false,
   }) async {
     final connection = await Connection.open(
@@ -22,14 +27,21 @@ class DbClient {
         sslMode: disableSsl ? SslMode.disable : SslMode.require,
       ),
     );
-    return DbClient(connection: connection);
+    return DbClient(
+      connection: connection,
+      logoBaseUrl: logoBaseUrl,
+    );
   }
 
   final Connection _connection;
+  final String _logoBaseUrl;
 
   UserDbClient get user => UserDbClient(connection: _connection);
   NewsDbClient get news => NewsDbClient(connection: _connection);
-  SponsorDbClient get sponsor => SponsorDbClient(connection: _connection);
+  SponsorDbClient get sponsor => SponsorDbClient(
+    connection: _connection,
+    logoBaseUrl: _logoBaseUrl,
+  );
   TicketTypeDbClient get ticketType =>
       TicketTypeDbClient(connection: _connection);
   TicketOptionDbClient get ticketOption =>

--- a/packages/db_client/lib/src/client/sponsor/sponsor_db_client.dart
+++ b/packages/db_client/lib/src/client/sponsor/sponsor_db_client.dart
@@ -3,10 +3,14 @@ import 'package:db_types/db_types.dart';
 import 'package:postgres/postgres.dart';
 
 class SponsorDbClient {
-  const SponsorDbClient({required Connection connection})
-    : _connection = connection;
+  const SponsorDbClient({
+    required Connection connection,
+    required String logoBaseUrl,
+  }) : _connection = connection,
+       _logoBaseUrl = logoBaseUrl;
 
   final Connection _connection;
+  final String _logoBaseUrl;
 
   /// 企業スポンサーの詳細情報を取得
   Future<List<CompanySponsorDetail>> getCompanySponsors() async {
@@ -59,9 +63,13 @@ class SponsorDbClient {
       '''),
     );
 
-    return result
-        .map((e) => CompanySponsorDetail.fromJson(e.toColumnMapSafe()))
-        .toList();
+    return result.map((e) {
+      final json = e.toColumnMapSafe();
+      // ロゴ名をロゴURLに変換
+      final logoFileName = json['logo_name'] as String;
+      json['logo_url'] = '$_logoBaseUrl/companies/$logoFileName';
+      return CompanySponsorDetail.fromJson(json);
+    }).toList();
   }
 
   /// 個人スポンサーの詳細情報を取得
@@ -89,9 +97,13 @@ class SponsorDbClient {
       '''),
     );
 
-    return result
-        .map((e) => IndividualSponsorDetail.fromJson(e.toColumnMapSafe()))
-        .toList();
+    return result.map((e) {
+      final json = e.toColumnMapSafe();
+      // ロゴ名をロゴURLに変換
+      final logoFileName = json['logo_name'] as String;
+      json['logo_url'] = '$_logoBaseUrl/individuals/$logoFileName';
+      return IndividualSponsorDetail.fromJson(json);
+    }).toList();
   }
 
   /// スポンサー情報のサマリーを取得

--- a/packages/db_types/lib/src/models/sponsors.dart
+++ b/packages/db_types/lib/src/models/sponsors.dart
@@ -10,7 +10,7 @@ abstract class CompanySponsorDetail with _$CompanySponsorDetail {
   const factory CompanySponsorDetail({
     required int id,
     required String name,
-    required String logoName,
+    required String logoUrl,
     required String slug,
     required String prText,
     required String websiteUrl,
@@ -30,7 +30,7 @@ abstract class IndividualSponsorDetail with _$IndividualSponsorDetail {
     required int id,
     required String name,
     required String slug,
-    required String logoName,
+    required String logoUrl,
     String? enthusiasm,
     String? xAccount,
   }) = _IndividualSponsorDetail;

--- a/packages/db_types/lib/src/models/sponsors.freezed.dart
+++ b/packages/db_types/lib/src/models/sponsors.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CompanySponsorDetail {
 
- int get id; String get name; String get logoName; String get slug; String get prText; String get websiteUrl; CompanySponsorType get sponsorType; BasicPlanType? get basicPlanType; List<OptionPlanType> get optionPlanTypes;
+ int get id; String get name; String get logoUrl; String get slug; String get prText; String get websiteUrl; CompanySponsorType get sponsorType; BasicPlanType? get basicPlanType; List<OptionPlanType> get optionPlanTypes;
 /// Create a copy of CompanySponsorDetail
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $CompanySponsorDetailCopyWith<CompanySponsorDetail> get copyWith => _$CompanySpo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CompanySponsorDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.logoName, logoName) || other.logoName == logoName)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.prText, prText) || other.prText == prText)&&(identical(other.websiteUrl, websiteUrl) || other.websiteUrl == websiteUrl)&&(identical(other.sponsorType, sponsorType) || other.sponsorType == sponsorType)&&(identical(other.basicPlanType, basicPlanType) || other.basicPlanType == basicPlanType)&&const DeepCollectionEquality().equals(other.optionPlanTypes, optionPlanTypes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CompanySponsorDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.logoUrl, logoUrl) || other.logoUrl == logoUrl)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.prText, prText) || other.prText == prText)&&(identical(other.websiteUrl, websiteUrl) || other.websiteUrl == websiteUrl)&&(identical(other.sponsorType, sponsorType) || other.sponsorType == sponsorType)&&(identical(other.basicPlanType, basicPlanType) || other.basicPlanType == basicPlanType)&&const DeepCollectionEquality().equals(other.optionPlanTypes, optionPlanTypes));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,logoName,slug,prText,websiteUrl,sponsorType,basicPlanType,const DeepCollectionEquality().hash(optionPlanTypes));
+int get hashCode => Object.hash(runtimeType,id,name,logoUrl,slug,prText,websiteUrl,sponsorType,basicPlanType,const DeepCollectionEquality().hash(optionPlanTypes));
 
 @override
 String toString() {
-  return 'CompanySponsorDetail(id: $id, name: $name, logoName: $logoName, slug: $slug, prText: $prText, websiteUrl: $websiteUrl, sponsorType: $sponsorType, basicPlanType: $basicPlanType, optionPlanTypes: $optionPlanTypes)';
+  return 'CompanySponsorDetail(id: $id, name: $name, logoUrl: $logoUrl, slug: $slug, prText: $prText, websiteUrl: $websiteUrl, sponsorType: $sponsorType, basicPlanType: $basicPlanType, optionPlanTypes: $optionPlanTypes)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $CompanySponsorDetailCopyWith<$Res>  {
   factory $CompanySponsorDetailCopyWith(CompanySponsorDetail value, $Res Function(CompanySponsorDetail) _then) = _$CompanySponsorDetailCopyWithImpl;
 @useResult
 $Res call({
- int id, String name, String logoName, String slug, String prText, String websiteUrl, CompanySponsorType sponsorType, BasicPlanType? basicPlanType, List<OptionPlanType> optionPlanTypes
+ int id, String name, String logoUrl, String slug, String prText, String websiteUrl, CompanySponsorType sponsorType, BasicPlanType? basicPlanType, List<OptionPlanType> optionPlanTypes
 });
 
 
@@ -65,11 +65,11 @@ class _$CompanySponsorDetailCopyWithImpl<$Res>
 
 /// Create a copy of CompanySponsorDetail
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? logoName = null,Object? slug = null,Object? prText = null,Object? websiteUrl = null,Object? sponsorType = null,Object? basicPlanType = freezed,Object? optionPlanTypes = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? logoUrl = null,Object? slug = null,Object? prText = null,Object? websiteUrl = null,Object? sponsorType = null,Object? basicPlanType = freezed,Object? optionPlanTypes = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,logoName: null == logoName ? _self.logoName : logoName // ignore: cast_nullable_to_non_nullable
+as String,logoUrl: null == logoUrl ? _self.logoUrl : logoUrl // ignore: cast_nullable_to_non_nullable
 as String,slug: null == slug ? _self.slug : slug // ignore: cast_nullable_to_non_nullable
 as String,prText: null == prText ? _self.prText : prText // ignore: cast_nullable_to_non_nullable
 as String,websiteUrl: null == websiteUrl ? _self.websiteUrl : websiteUrl // ignore: cast_nullable_to_non_nullable
@@ -161,10 +161,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String name,  String logoName,  String slug,  String prText,  String websiteUrl,  CompanySponsorType sponsorType,  BasicPlanType? basicPlanType,  List<OptionPlanType> optionPlanTypes)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String name,  String logoUrl,  String slug,  String prText,  String websiteUrl,  CompanySponsorType sponsorType,  BasicPlanType? basicPlanType,  List<OptionPlanType> optionPlanTypes)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _CompanySponsorDetail() when $default != null:
-return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.prText,_that.websiteUrl,_that.sponsorType,_that.basicPlanType,_that.optionPlanTypes);case _:
+return $default(_that.id,_that.name,_that.logoUrl,_that.slug,_that.prText,_that.websiteUrl,_that.sponsorType,_that.basicPlanType,_that.optionPlanTypes);case _:
   return orElse();
 
 }
@@ -182,10 +182,10 @@ return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.prText,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String name,  String logoName,  String slug,  String prText,  String websiteUrl,  CompanySponsorType sponsorType,  BasicPlanType? basicPlanType,  List<OptionPlanType> optionPlanTypes)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String name,  String logoUrl,  String slug,  String prText,  String websiteUrl,  CompanySponsorType sponsorType,  BasicPlanType? basicPlanType,  List<OptionPlanType> optionPlanTypes)  $default,) {final _that = this;
 switch (_that) {
 case _CompanySponsorDetail():
-return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.prText,_that.websiteUrl,_that.sponsorType,_that.basicPlanType,_that.optionPlanTypes);case _:
+return $default(_that.id,_that.name,_that.logoUrl,_that.slug,_that.prText,_that.websiteUrl,_that.sponsorType,_that.basicPlanType,_that.optionPlanTypes);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -202,10 +202,10 @@ return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.prText,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String name,  String logoName,  String slug,  String prText,  String websiteUrl,  CompanySponsorType sponsorType,  BasicPlanType? basicPlanType,  List<OptionPlanType> optionPlanTypes)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String name,  String logoUrl,  String slug,  String prText,  String websiteUrl,  CompanySponsorType sponsorType,  BasicPlanType? basicPlanType,  List<OptionPlanType> optionPlanTypes)?  $default,) {final _that = this;
 switch (_that) {
 case _CompanySponsorDetail() when $default != null:
-return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.prText,_that.websiteUrl,_that.sponsorType,_that.basicPlanType,_that.optionPlanTypes);case _:
+return $default(_that.id,_that.name,_that.logoUrl,_that.slug,_that.prText,_that.websiteUrl,_that.sponsorType,_that.basicPlanType,_that.optionPlanTypes);case _:
   return null;
 
 }
@@ -217,12 +217,12 @@ return $default(_that.id,_that.name,_that.logoName,_that.slug,_that.prText,_that
 @JsonSerializable()
 
 class _CompanySponsorDetail implements CompanySponsorDetail {
-  const _CompanySponsorDetail({required this.id, required this.name, required this.logoName, required this.slug, required this.prText, required this.websiteUrl, required this.sponsorType, this.basicPlanType, final  List<OptionPlanType> optionPlanTypes = const []}): _optionPlanTypes = optionPlanTypes;
+  const _CompanySponsorDetail({required this.id, required this.name, required this.logoUrl, required this.slug, required this.prText, required this.websiteUrl, required this.sponsorType, this.basicPlanType, final  List<OptionPlanType> optionPlanTypes = const []}): _optionPlanTypes = optionPlanTypes;
   factory _CompanySponsorDetail.fromJson(Map<String, dynamic> json) => _$CompanySponsorDetailFromJson(json);
 
 @override final  int id;
 @override final  String name;
-@override final  String logoName;
+@override final  String logoUrl;
 @override final  String slug;
 @override final  String prText;
 @override final  String websiteUrl;
@@ -249,16 +249,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CompanySponsorDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.logoName, logoName) || other.logoName == logoName)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.prText, prText) || other.prText == prText)&&(identical(other.websiteUrl, websiteUrl) || other.websiteUrl == websiteUrl)&&(identical(other.sponsorType, sponsorType) || other.sponsorType == sponsorType)&&(identical(other.basicPlanType, basicPlanType) || other.basicPlanType == basicPlanType)&&const DeepCollectionEquality().equals(other._optionPlanTypes, _optionPlanTypes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CompanySponsorDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.logoUrl, logoUrl) || other.logoUrl == logoUrl)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.prText, prText) || other.prText == prText)&&(identical(other.websiteUrl, websiteUrl) || other.websiteUrl == websiteUrl)&&(identical(other.sponsorType, sponsorType) || other.sponsorType == sponsorType)&&(identical(other.basicPlanType, basicPlanType) || other.basicPlanType == basicPlanType)&&const DeepCollectionEquality().equals(other._optionPlanTypes, _optionPlanTypes));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,logoName,slug,prText,websiteUrl,sponsorType,basicPlanType,const DeepCollectionEquality().hash(_optionPlanTypes));
+int get hashCode => Object.hash(runtimeType,id,name,logoUrl,slug,prText,websiteUrl,sponsorType,basicPlanType,const DeepCollectionEquality().hash(_optionPlanTypes));
 
 @override
 String toString() {
-  return 'CompanySponsorDetail(id: $id, name: $name, logoName: $logoName, slug: $slug, prText: $prText, websiteUrl: $websiteUrl, sponsorType: $sponsorType, basicPlanType: $basicPlanType, optionPlanTypes: $optionPlanTypes)';
+  return 'CompanySponsorDetail(id: $id, name: $name, logoUrl: $logoUrl, slug: $slug, prText: $prText, websiteUrl: $websiteUrl, sponsorType: $sponsorType, basicPlanType: $basicPlanType, optionPlanTypes: $optionPlanTypes)';
 }
 
 
@@ -269,7 +269,7 @@ abstract mixin class _$CompanySponsorDetailCopyWith<$Res> implements $CompanySpo
   factory _$CompanySponsorDetailCopyWith(_CompanySponsorDetail value, $Res Function(_CompanySponsorDetail) _then) = __$CompanySponsorDetailCopyWithImpl;
 @override @useResult
 $Res call({
- int id, String name, String logoName, String slug, String prText, String websiteUrl, CompanySponsorType sponsorType, BasicPlanType? basicPlanType, List<OptionPlanType> optionPlanTypes
+ int id, String name, String logoUrl, String slug, String prText, String websiteUrl, CompanySponsorType sponsorType, BasicPlanType? basicPlanType, List<OptionPlanType> optionPlanTypes
 });
 
 
@@ -286,11 +286,11 @@ class __$CompanySponsorDetailCopyWithImpl<$Res>
 
 /// Create a copy of CompanySponsorDetail
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? logoName = null,Object? slug = null,Object? prText = null,Object? websiteUrl = null,Object? sponsorType = null,Object? basicPlanType = freezed,Object? optionPlanTypes = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? logoUrl = null,Object? slug = null,Object? prText = null,Object? websiteUrl = null,Object? sponsorType = null,Object? basicPlanType = freezed,Object? optionPlanTypes = null,}) {
   return _then(_CompanySponsorDetail(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,logoName: null == logoName ? _self.logoName : logoName // ignore: cast_nullable_to_non_nullable
+as String,logoUrl: null == logoUrl ? _self.logoUrl : logoUrl // ignore: cast_nullable_to_non_nullable
 as String,slug: null == slug ? _self.slug : slug // ignore: cast_nullable_to_non_nullable
 as String,prText: null == prText ? _self.prText : prText // ignore: cast_nullable_to_non_nullable
 as String,websiteUrl: null == websiteUrl ? _self.websiteUrl : websiteUrl // ignore: cast_nullable_to_non_nullable
@@ -308,7 +308,7 @@ as List<OptionPlanType>,
 /// @nodoc
 mixin _$IndividualSponsorDetail {
 
- int get id; String get name; String get slug; String get logoName; String? get enthusiasm; String? get xAccount;
+ int get id; String get name; String get slug; String get logoUrl; String? get enthusiasm; String? get xAccount;
 /// Create a copy of IndividualSponsorDetail
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -321,16 +321,16 @@ $IndividualSponsorDetailCopyWith<IndividualSponsorDetail> get copyWith => _$Indi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is IndividualSponsorDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.logoName, logoName) || other.logoName == logoName)&&(identical(other.enthusiasm, enthusiasm) || other.enthusiasm == enthusiasm)&&(identical(other.xAccount, xAccount) || other.xAccount == xAccount));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is IndividualSponsorDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.logoUrl, logoUrl) || other.logoUrl == logoUrl)&&(identical(other.enthusiasm, enthusiasm) || other.enthusiasm == enthusiasm)&&(identical(other.xAccount, xAccount) || other.xAccount == xAccount));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,slug,logoName,enthusiasm,xAccount);
+int get hashCode => Object.hash(runtimeType,id,name,slug,logoUrl,enthusiasm,xAccount);
 
 @override
 String toString() {
-  return 'IndividualSponsorDetail(id: $id, name: $name, slug: $slug, logoName: $logoName, enthusiasm: $enthusiasm, xAccount: $xAccount)';
+  return 'IndividualSponsorDetail(id: $id, name: $name, slug: $slug, logoUrl: $logoUrl, enthusiasm: $enthusiasm, xAccount: $xAccount)';
 }
 
 
@@ -341,7 +341,7 @@ abstract mixin class $IndividualSponsorDetailCopyWith<$Res>  {
   factory $IndividualSponsorDetailCopyWith(IndividualSponsorDetail value, $Res Function(IndividualSponsorDetail) _then) = _$IndividualSponsorDetailCopyWithImpl;
 @useResult
 $Res call({
- int id, String name, String slug, String logoName, String? enthusiasm, String? xAccount
+ int id, String name, String slug, String logoUrl, String? enthusiasm, String? xAccount
 });
 
 
@@ -358,12 +358,12 @@ class _$IndividualSponsorDetailCopyWithImpl<$Res>
 
 /// Create a copy of IndividualSponsorDetail
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? slug = null,Object? logoName = null,Object? enthusiasm = freezed,Object? xAccount = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? slug = null,Object? logoUrl = null,Object? enthusiasm = freezed,Object? xAccount = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,slug: null == slug ? _self.slug : slug // ignore: cast_nullable_to_non_nullable
-as String,logoName: null == logoName ? _self.logoName : logoName // ignore: cast_nullable_to_non_nullable
+as String,logoUrl: null == logoUrl ? _self.logoUrl : logoUrl // ignore: cast_nullable_to_non_nullable
 as String,enthusiasm: freezed == enthusiasm ? _self.enthusiasm : enthusiasm // ignore: cast_nullable_to_non_nullable
 as String?,xAccount: freezed == xAccount ? _self.xAccount : xAccount // ignore: cast_nullable_to_non_nullable
 as String?,
@@ -451,10 +451,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String name,  String slug,  String logoName,  String? enthusiasm,  String? xAccount)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String name,  String slug,  String logoUrl,  String? enthusiasm,  String? xAccount)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _IndividualSponsorDetail() when $default != null:
-return $default(_that.id,_that.name,_that.slug,_that.logoName,_that.enthusiasm,_that.xAccount);case _:
+return $default(_that.id,_that.name,_that.slug,_that.logoUrl,_that.enthusiasm,_that.xAccount);case _:
   return orElse();
 
 }
@@ -472,10 +472,10 @@ return $default(_that.id,_that.name,_that.slug,_that.logoName,_that.enthusiasm,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String name,  String slug,  String logoName,  String? enthusiasm,  String? xAccount)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String name,  String slug,  String logoUrl,  String? enthusiasm,  String? xAccount)  $default,) {final _that = this;
 switch (_that) {
 case _IndividualSponsorDetail():
-return $default(_that.id,_that.name,_that.slug,_that.logoName,_that.enthusiasm,_that.xAccount);case _:
+return $default(_that.id,_that.name,_that.slug,_that.logoUrl,_that.enthusiasm,_that.xAccount);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -492,10 +492,10 @@ return $default(_that.id,_that.name,_that.slug,_that.logoName,_that.enthusiasm,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String name,  String slug,  String logoName,  String? enthusiasm,  String? xAccount)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String name,  String slug,  String logoUrl,  String? enthusiasm,  String? xAccount)?  $default,) {final _that = this;
 switch (_that) {
 case _IndividualSponsorDetail() when $default != null:
-return $default(_that.id,_that.name,_that.slug,_that.logoName,_that.enthusiasm,_that.xAccount);case _:
+return $default(_that.id,_that.name,_that.slug,_that.logoUrl,_that.enthusiasm,_that.xAccount);case _:
   return null;
 
 }
@@ -507,13 +507,13 @@ return $default(_that.id,_that.name,_that.slug,_that.logoName,_that.enthusiasm,_
 @JsonSerializable()
 
 class _IndividualSponsorDetail implements IndividualSponsorDetail {
-  const _IndividualSponsorDetail({required this.id, required this.name, required this.slug, required this.logoName, this.enthusiasm, this.xAccount});
+  const _IndividualSponsorDetail({required this.id, required this.name, required this.slug, required this.logoUrl, this.enthusiasm, this.xAccount});
   factory _IndividualSponsorDetail.fromJson(Map<String, dynamic> json) => _$IndividualSponsorDetailFromJson(json);
 
 @override final  int id;
 @override final  String name;
 @override final  String slug;
-@override final  String logoName;
+@override final  String logoUrl;
 @override final  String? enthusiasm;
 @override final  String? xAccount;
 
@@ -530,16 +530,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _IndividualSponsorDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.logoName, logoName) || other.logoName == logoName)&&(identical(other.enthusiasm, enthusiasm) || other.enthusiasm == enthusiasm)&&(identical(other.xAccount, xAccount) || other.xAccount == xAccount));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _IndividualSponsorDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.slug, slug) || other.slug == slug)&&(identical(other.logoUrl, logoUrl) || other.logoUrl == logoUrl)&&(identical(other.enthusiasm, enthusiasm) || other.enthusiasm == enthusiasm)&&(identical(other.xAccount, xAccount) || other.xAccount == xAccount));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,slug,logoName,enthusiasm,xAccount);
+int get hashCode => Object.hash(runtimeType,id,name,slug,logoUrl,enthusiasm,xAccount);
 
 @override
 String toString() {
-  return 'IndividualSponsorDetail(id: $id, name: $name, slug: $slug, logoName: $logoName, enthusiasm: $enthusiasm, xAccount: $xAccount)';
+  return 'IndividualSponsorDetail(id: $id, name: $name, slug: $slug, logoUrl: $logoUrl, enthusiasm: $enthusiasm, xAccount: $xAccount)';
 }
 
 
@@ -550,7 +550,7 @@ abstract mixin class _$IndividualSponsorDetailCopyWith<$Res> implements $Individ
   factory _$IndividualSponsorDetailCopyWith(_IndividualSponsorDetail value, $Res Function(_IndividualSponsorDetail) _then) = __$IndividualSponsorDetailCopyWithImpl;
 @override @useResult
 $Res call({
- int id, String name, String slug, String logoName, String? enthusiasm, String? xAccount
+ int id, String name, String slug, String logoUrl, String? enthusiasm, String? xAccount
 });
 
 
@@ -567,12 +567,12 @@ class __$IndividualSponsorDetailCopyWithImpl<$Res>
 
 /// Create a copy of IndividualSponsorDetail
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? slug = null,Object? logoName = null,Object? enthusiasm = freezed,Object? xAccount = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? slug = null,Object? logoUrl = null,Object? enthusiasm = freezed,Object? xAccount = freezed,}) {
   return _then(_IndividualSponsorDetail(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,slug: null == slug ? _self.slug : slug // ignore: cast_nullable_to_non_nullable
-as String,logoName: null == logoName ? _self.logoName : logoName // ignore: cast_nullable_to_non_nullable
+as String,logoUrl: null == logoUrl ? _self.logoUrl : logoUrl // ignore: cast_nullable_to_non_nullable
 as String,enthusiasm: freezed == enthusiasm ? _self.enthusiasm : enthusiasm // ignore: cast_nullable_to_non_nullable
 as String?,xAccount: freezed == xAccount ? _self.xAccount : xAccount // ignore: cast_nullable_to_non_nullable
 as String?,

--- a/packages/db_types/lib/src/models/sponsors.g.dart
+++ b/packages/db_types/lib/src/models/sponsors.g.dart
@@ -17,7 +17,7 @@ _CompanySponsorDetail _$CompanySponsorDetailFromJson(
     final val = _CompanySponsorDetail(
       id: $checkedConvert('id', (v) => (v as num).toInt()),
       name: $checkedConvert('name', (v) => v as String),
-      logoName: $checkedConvert('logo_name', (v) => v as String),
+      logoUrl: $checkedConvert('logo_url', (v) => v as String),
       slug: $checkedConvert('slug', (v) => v as String),
       prText: $checkedConvert('pr_text', (v) => v as String),
       websiteUrl: $checkedConvert('website_url', (v) => v as String),
@@ -41,7 +41,7 @@ _CompanySponsorDetail _$CompanySponsorDetailFromJson(
     return val;
   },
   fieldKeyMap: const {
-    'logoName': 'logo_name',
+    'logoUrl': 'logo_url',
     'prText': 'pr_text',
     'websiteUrl': 'website_url',
     'sponsorType': 'sponsor_type',
@@ -55,7 +55,7 @@ Map<String, dynamic> _$CompanySponsorDetailToJson(
 ) => <String, dynamic>{
   'id': instance.id,
   'name': instance.name,
-  'logo_name': instance.logoName,
+  'logo_url': instance.logoUrl,
   'slug': instance.slug,
   'pr_text': instance.prText,
   'website_url': instance.websiteUrl,
@@ -98,13 +98,13 @@ _IndividualSponsorDetail _$IndividualSponsorDetailFromJson(
       id: $checkedConvert('id', (v) => (v as num).toInt()),
       name: $checkedConvert('name', (v) => v as String),
       slug: $checkedConvert('slug', (v) => v as String),
-      logoName: $checkedConvert('logo_name', (v) => v as String),
+      logoUrl: $checkedConvert('logo_url', (v) => v as String),
       enthusiasm: $checkedConvert('enthusiasm', (v) => v as String?),
       xAccount: $checkedConvert('x_account', (v) => v as String?),
     );
     return val;
   },
-  fieldKeyMap: const {'logoName': 'logo_name', 'xAccount': 'x_account'},
+  fieldKeyMap: const {'logoUrl': 'logo_url', 'xAccount': 'x_account'},
 );
 
 Map<String, dynamic> _$IndividualSponsorDetailToJson(
@@ -113,7 +113,7 @@ Map<String, dynamic> _$IndividualSponsorDetailToJson(
   'id': instance.id,
   'name': instance.name,
   'slug': instance.slug,
-  'logo_name': instance.logoName,
+  'logo_url': instance.logoUrl,
   'enthusiasm': instance.enthusiasm,
   'x_account': instance.xAccount,
 };


### PR DESCRIPTION
## 概要

スポンサー詳細情報のロゴ名をロゴURLに変更し、ロゴの表示を改善しました。

## 変更内容

### 環境変数の追加
- `LOGO_BASE_URL`環境変数を追加し、ロゴURLの設定を可能に

### モデルの更新
- `Environments`モデルに`logoBaseUrl`フィールドを追加
- スポンサーモデルのロゴ関連フィールドを更新

### データベースクライアントの更新
- `DbClient`に`logoBaseUrl`を追加
- スポンサー詳細情報の取得時にロゴURLを生成

### 影響範囲
- `bff/engine` - 環境設定とプロバイダーの更新
- `packages/db_client` - データベースクライアントの更新
- `packages/db_types` - スポンサーモデルの更新

## 技術的詳細

- 環境変数からロゴベースURLを取得し、スポンサーのロゴ名と組み合わせて完全なURLを生成
- 既存のAPIとの互換性を保ちながら、ロゴ表示の改善を実現

## テスト

- 環境変数の設定確認
- スポンサー詳細情報の取得テスト
- ロゴURLの生成テスト