### PR TITLE
Process project data

### DIFF
--- a/bff/internal-api-proxy/src/index.ts
+++ b/bff/internal-api-proxy/src/index.ts
@@ -37,6 +37,7 @@ const app = new Hono<{
         service: v.union([
           v.literal("payment-workflow-internal-api"),
           v.literal("stripe-internal-api"),
+          v.literal("r2-internal-api"),
         ]),
       })
     ),
@@ -57,6 +58,10 @@ const app = new Hono<{
         }
         case "stripe-internal-api": {
           fetcher = c.env.STRIPE_INTERNAL_API;
+          break;
+        }
+        case "r2-internal-api": {
+          fetcher = c.env.R2_INTERNAL_API;
           break;
         }
         default: {

--- a/bff/internal-api-proxy/wrangler.jsonc
+++ b/bff/internal-api-proxy/wrangler.jsonc
@@ -22,6 +22,10 @@
           "binding": "STRIPE_INTERNAL_API",
           "service": "stripe-internal-api-staging",
         },
+        {
+          "binding": "R2_INTERNAL_API",
+          "service": "r2-internal-api-staging",
+        },
       ],
     },
     "production": {
@@ -36,6 +40,10 @@
         {
           "binding": "STRIPE_INTERNAL_API",
           "service": "stripe-internal-api-production",
+        },
+        {
+          "binding": "R2_INTERNAL_API",
+          "service": "r2-internal-api-production",
         },
       ],
     },

--- a/bff/r2-internal-api/.dev.vars.example
+++ b/bff/r2-internal-api/.dev.vars.example
@@ -1,0 +1,3 @@
+CLOUDFLARE_R2_ACCESS_KEY_ID=your_access_key_id
+CLOUDFLARE_R2_SECRET_ACCESS_KEY=your_secret_access_key
+CLOUDFLARE_R2_BUCKET_NAME=flutterkaigi-2025

--- a/bff/r2-internal-api/.gitignore
+++ b/bff/r2-internal-api/.gitignore
@@ -1,0 +1,70 @@
+# Cloudflare Workers
+.dev.vars
+.wrangler/
+wrangler.toml
+
+# Dependencies
+node_modules/
+.yarn/
+.pnp
+.pnp.js
+
+# Build artifacts
+dist/
+build/
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Coverage directory used by tools like istanbul
+coverage/
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+jspm_packages/
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# Stores VSCode versions used for testing VSCode extensions
+.vscode-test

--- a/bff/r2-internal-api/README.md
+++ b/bff/r2-internal-api/README.md
@@ -1,0 +1,71 @@
+# R2 Internal API
+
+Cloudflare R2を操作するHonoベースの内部API
+
+## 概要
+
+このAPIは、Cloudflare R2ストレージを操作するための内部APIです。ファイルのアップロード用署名付きURLの生成とオブジェクトの削除機能を提供します。
+
+## エンドポイント
+
+### PUT /internal/r2/signed-url
+
+ファイルアップロード用の署名付きURLを生成します。
+
+**リクエスト:**
+```json
+{
+  "key": "avatar/user123.jpg",
+  "size": 1024000,
+  "mimeType": "image/jpeg",
+  "variant": "avatar",
+  "expiresIn": 3600
+}
+```
+
+**レスポンス:**
+```json
+{
+  "key": "avatar/user123.jpg",
+  "signed_url": "https://..."
+}
+```
+
+### DELETE /internal/r2/object
+
+R2バケットからオブジェクトを削除します。
+
+**リクエスト:**
+```json
+{
+  "key": "avatar/user123.jpg"
+}
+```
+
+**レスポンス:**
+```json
+{
+  "success": true,
+  "key": "avatar/user123.jpg"
+}
+```
+
+## 環境変数
+
+`.dev.vars`ファイルに以下の環境変数を設定してください：
+
+```
+CLOUDFLARE_R2_ACCESS_KEY_ID=your_access_key_id
+CLOUDFLARE_R2_SECRET_ACCESS_KEY=your_secret_access_key
+CLOUDFLARE_R2_BUCKET_NAME=flutterkaigi-2025
+```
+
+## 開発
+
+```bash
+# 開発サーバーの起動
+npm run dev
+
+# デプロイ
+npm run deploy
+```

--- a/bff/r2-internal-api/biome.json
+++ b/bff/r2-internal-api/biome.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
+  "root": false,
+  "extends": "//"
+}

--- a/bff/r2-internal-api/src/api/internal.ts
+++ b/bff/r2-internal-api/src/api/internal.ts
@@ -1,0 +1,5 @@
+import { Hono } from "hono";
+
+import { r2Api } from "./internal/r2/r2";
+
+export const internalApi = new Hono().route("/r2", r2Api);

--- a/bff/r2-internal-api/src/api/internal/r2/model/DeleteObjectRequest.ts
+++ b/bff/r2-internal-api/src/api/internal/r2/model/DeleteObjectRequest.ts
@@ -1,0 +1,7 @@
+import * as v from "valibot";
+
+export const DeleteObjectRequest = v.object({
+  key: v.string(),
+});
+
+export type DeleteObjectRequest = v.InferInput<typeof DeleteObjectRequest>;

--- a/bff/r2-internal-api/src/api/internal/r2/model/DeleteObjectResponse.ts
+++ b/bff/r2-internal-api/src/api/internal/r2/model/DeleteObjectResponse.ts
@@ -1,0 +1,8 @@
+import * as v from "valibot";
+
+export const DeleteObjectResponse = v.object({
+  success: v.boolean(),
+  key: v.string(),
+});
+
+export type DeleteObjectResponse = v.InferInput<typeof DeleteObjectResponse>;

--- a/bff/r2-internal-api/src/api/internal/r2/model/PutSignedUrlRequest.ts
+++ b/bff/r2-internal-api/src/api/internal/r2/model/PutSignedUrlRequest.ts
@@ -1,0 +1,11 @@
+import * as v from "valibot";
+
+export const PutSignedUrlRequest = v.object({
+  key: v.string(),
+  size: v.number(),
+  mimeType: v.string(),
+  variant: v.literal("avatar"),
+  expiresIn: v.optional(v.number(), 3600), // デフォルト1時間
+});
+
+export type PutSignedUrlRequest = v.InferInput<typeof PutSignedUrlRequest>;

--- a/bff/r2-internal-api/src/api/internal/r2/model/PutSignedUrlResponse.ts
+++ b/bff/r2-internal-api/src/api/internal/r2/model/PutSignedUrlResponse.ts
@@ -1,0 +1,8 @@
+import * as v from "valibot";
+
+export const PutSignedUrlResponse = v.object({
+  key: v.string(),
+  signed_url: v.string(),
+});
+
+export type PutSignedUrlResponse = v.InferInput<typeof PutSignedUrlResponse>;

--- a/bff/r2-internal-api/src/api/internal/r2/r2.ts
+++ b/bff/r2-internal-api/src/api/internal/r2/r2.ts
@@ -1,0 +1,164 @@
+import { AwsClient } from "aws4fetch";
+import { Hono } from "hono";
+import { describeRoute } from "hono-openapi";
+import { resolver, validator as vValidator } from "hono-openapi/valibot";
+import * as v from "valibot";
+import { DeleteObjectRequest } from "./model/DeleteObjectRequest";
+import { DeleteObjectResponse } from "./model/DeleteObjectResponse";
+import { PutSignedUrlRequest } from "./model/PutSignedUrlRequest";
+import { PutSignedUrlResponse } from "./model/PutSignedUrlResponse";
+
+export const r2Api = new Hono<{
+	Bindings: Cloudflare.Env;
+}>()
+	// PUT /signed-url - 署名付きURL生成エンドポイント
+	.put(
+		"/signed-url",
+		describeRoute({
+			summary: "Generate Signed URL for R2 Upload",
+			description: "Generate a signed URL for uploading files to Cloudflare R2",
+			responses: {
+				200: {
+					description: "Successful",
+					content: {
+						"application/json": {
+							schema: resolver(PutSignedUrlResponse),
+						},
+					},
+				},
+				400: {
+					description: "Bad Request",
+					content: {
+						"application/json": {
+							schema: resolver(v.object({ error: v.string() })),
+						},
+					},
+				},
+				500: {
+					description: "Internal Server Error",
+					content: {
+						"application/json": {
+							schema: resolver(v.object({ error: v.string() })),
+						},
+					},
+				},
+			},
+		}),
+		vValidator(
+			"header",
+			v.object({
+				"x-api-key": v.string(),
+			}),
+		),
+		vValidator("json", PutSignedUrlRequest),
+		async (c) => {
+			try {
+				const request = c.req.valid("json");
+				const { key, size, mimeType, variant, expiresIn } = request;
+
+				// AWS4Fetch クライアントの初期化
+				const client = new AwsClient({
+					accessKeyId: c.env.CLOUDFLARE_R2_ACCESS_KEY_ID,
+					secretAccessKey: c.env.CLOUDFLARE_R2_SECRET_ACCESS_KEY,
+					region: "auto",
+					service: "s3",
+				});
+
+				// R2エンドポイントURLの構築
+				const bucketName = c.env.CLOUDFLARE_R2_BUCKET_NAME || c.env.BUCKET_NAME;
+				
+				// Cloudflare R2の場合、アカウントIDを使用したエンドポイント
+				// 実際のR2エンドポイントは https://<account-id>.r2.cloudflarestorage.com/<bucket>/<key> の形式
+				const r2Endpoint = `https://cdd8f59359fe226645e7b541cdc53b57.r2.cloudflarestorage.com`;
+				const objectUrl = `${r2Endpoint}/${bucketName}/${key}`;
+
+				// 署名付きURLの生成
+				const signedRequest = await client.sign(
+					new Request(objectUrl, {
+						method: "PUT",
+						headers: {
+							"Content-Type": mimeType,
+							"Content-Length": size.toString(),
+						},
+					}),
+					{
+						aws: {
+							signQuery: true,
+							datetime: new Date().toISOString().replace(/[:-]|\.\d{3}/g, ""),
+						},
+						expiresIn: expiresIn || 3600, // デフォルト1時間
+					}
+				);
+
+				const response: PutSignedUrlResponse = {
+					key,
+					signed_url: signedRequest.url,
+				};
+
+				return c.json(response);
+			} catch (error) {
+				console.error("Error generating signed URL:", error);
+				return c.json({ error: "Failed to generate signed URL" }, 500);
+			}
+		}
+	)
+	// DELETE /object - オブジェクト削除エンドポイント
+	.delete(
+		"/object",
+		describeRoute({
+			summary: "Delete Object from R2",
+			description: "Delete an object from Cloudflare R2 bucket",
+			responses: {
+				200: {
+					description: "Successful",
+					content: {
+						"application/json": {
+							schema: resolver(DeleteObjectResponse),
+						},
+					},
+				},
+				400: {
+					description: "Bad Request",
+					content: {
+						"application/json": {
+							schema: resolver(v.object({ error: v.string() })),
+						},
+					},
+				},
+				500: {
+					description: "Internal Server Error",
+					content: {
+						"application/json": {
+							schema: resolver(v.object({ error: v.string() })),
+						},
+					},
+				},
+			},
+		}),
+		vValidator(
+			"header",
+			v.object({
+				"x-api-key": v.string(),
+			}),
+		),
+		vValidator("json", DeleteObjectRequest),
+		async (c) => {
+			try {
+				const request = c.req.valid("json");
+				const { key } = request;
+
+				// Service Bindingを使用してR2バケットからオブジェクトを削除
+				await c.env.BUCKET.delete(key);
+
+				const response: DeleteObjectResponse = {
+					success: true,
+					key,
+				};
+
+				return c.json(response);
+			} catch (error) {
+				console.error("Error deleting object:", error);
+				return c.json({ error: "Failed to delete object" }, 500);
+			}
+		}
+	);

--- a/bff/r2-internal-api/src/index.ts
+++ b/bff/r2-internal-api/src/index.ts
@@ -1,0 +1,47 @@
+import { Scalar } from "@scalar/hono-api-reference";
+import { Hono } from "hono";
+import { logger } from "hono/logger";
+import { secureHeaders } from "hono/secure-headers";
+import { openAPISpecs } from "hono-openapi";
+import { internalApi } from "./api/internal";
+
+const app = new Hono<{
+	Bindings: Cloudflare.Env;
+}>()
+	.use("*", secureHeaders())
+	.use("*", logger())
+	.route("/internal", internalApi)
+	.get("/scalar", Scalar({ url: "/openapi", title: "R2 Internal API" }))
+	.onError((err, c) => {
+		console.error(err);
+		return c.json({ message: "Internal Server Error", error: err }, 500);
+	});
+
+app.get(
+	"/openapi",
+	openAPISpecs(app, {
+		documentation: {
+			info: {
+				title: "R2 Internal API",
+				version: "1.0.0",
+				contact: {
+					name: "Ryotaro Onoue",
+					url: "https://github.com/YumNumm",
+				},
+				license: {
+					name: "MIT",
+				},
+			},
+
+			servers: [
+				{
+					url: "https://localhost:8787",
+					description: "Local Development",
+				},
+			],
+		},
+	}),
+);
+
+export type R2InternalApiAppType = typeof app;
+export default app;

--- a/bff/r2-internal-api/tsconfig.json
+++ b/bff/r2-internal-api/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "lib": ["es2021"],
+    "module": "es2022",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["test"],
+  "include": ["worker-configuration.d.ts", "src/**/*.ts"]
+}

--- a/bff/r2-internal-api/worker-configuration.d.ts
+++ b/bff/r2-internal-api/worker-configuration.d.ts
@@ -1,0 +1,12 @@
+interface Cloudflare {
+  env: {
+    CLOUDFLARE_R2_ACCESS_KEY_ID: string;
+    CLOUDFLARE_R2_SECRET_ACCESS_KEY: string;
+    CLOUDFLARE_R2_BUCKET_NAME: string;
+    ENVIRONMENT: string;
+    BUCKET_NAME: string;
+    BUCKET: R2Bucket;
+  };
+}
+
+export default Cloudflare;

--- a/bff/r2-internal-api/wrangler.jsonc
+++ b/bff/r2-internal-api/wrangler.jsonc
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://unpkg.com/wrangler@latest/config-schema.json",
+  "name": "r2-internal-api",
+  "account_id": "cdd8f59359fe226645e7b541cdc53b57",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-07-15",
+  "observability": {
+    "enabled": true,
+  },
+  "compatibility_flags": ["nodejs_compat"],
+  "r2_buckets": [
+    {
+      "binding": "BUCKET",
+      "bucket_name": "flutterkaigi-2025"
+    }
+  ],
+  "env": {
+    "staging": {
+      "workers_dev": false,
+      "vars": {
+        "ENVIRONMENT": "staging",
+        "BUCKET_NAME": "flutterkaigi-2025-staging"
+      }
+    },
+    "production": {
+      "workers_dev": false,
+      "vars": {
+        "ENVIRONMENT": "production",
+        "BUCKET_NAME": "flutterkaigi-2025-production"
+      }
+    }
+  }
+}

--- a/packages/internal_api_client/lib/src/api/r2_internal_api/model/delete_object_request.dart
+++ b/packages/internal_api_client/lib/src/api/r2_internal_api/model/delete_object_request.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'delete_object_request.freezed.dart';
+part 'delete_object_request.g.dart';
+
+@freezed
+abstract class DeleteObjectRequest with _$DeleteObjectRequest {
+  const factory DeleteObjectRequest({
+    required String key,
+  }) = _DeleteObjectRequest;
+
+  factory DeleteObjectRequest.fromJson(Map<String, dynamic> json) =>
+      _$DeleteObjectRequestFromJson(json);
+}

--- a/packages/internal_api_client/lib/src/api/r2_internal_api/model/delete_object_response.dart
+++ b/packages/internal_api_client/lib/src/api/r2_internal_api/model/delete_object_response.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'delete_object_response.freezed.dart';
+part 'delete_object_response.g.dart';
+
+@freezed
+abstract class DeleteObjectResponse with _$DeleteObjectResponse {
+  const factory DeleteObjectResponse({
+    required bool success,
+    required String key,
+  }) = _DeleteObjectResponse;
+
+  factory DeleteObjectResponse.fromJson(Map<String, dynamic> json) =>
+      _$DeleteObjectResponseFromJson(json);
+}

--- a/packages/internal_api_client/lib/src/api/r2_internal_api/model/put_signed_url_request.dart
+++ b/packages/internal_api_client/lib/src/api/r2_internal_api/model/put_signed_url_request.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'put_signed_url_request.freezed.dart';
+part 'put_signed_url_request.g.dart';
+
+@freezed
+abstract class PutSignedUrlRequest with _$PutSignedUrlRequest {
+  const factory PutSignedUrlRequest({
+    required String key,
+    required int size,
+    required String mimeType,
+    required String variant,
+    int? expiresIn,
+  }) = _PutSignedUrlRequest;
+
+  factory PutSignedUrlRequest.fromJson(Map<String, dynamic> json) =>
+      _$PutSignedUrlRequestFromJson(json);
+}

--- a/packages/internal_api_client/lib/src/api/r2_internal_api/model/put_signed_url_response.dart
+++ b/packages/internal_api_client/lib/src/api/r2_internal_api/model/put_signed_url_response.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'put_signed_url_response.freezed.dart';
+part 'put_signed_url_response.g.dart';
+
+@freezed
+abstract class PutSignedUrlResponse with _$PutSignedUrlResponse {
+  const factory PutSignedUrlResponse({
+    required String key,
+    @JsonKey(name: 'signed_url') required String signedUrl,
+  }) = _PutSignedUrlResponse;
+
+  factory PutSignedUrlResponse.fromJson(Map<String, dynamic> json) =>
+      _$PutSignedUrlResponseFromJson(json);
+}

--- a/packages/internal_api_client/lib/src/api/r2_internal_api/r2_internal_api.dart
+++ b/packages/internal_api_client/lib/src/api/r2_internal_api/r2_internal_api.dart
@@ -1,0 +1,12 @@
+import 'package:dio/dio.dart';
+import 'package:internal_api_client/src/api/r2_internal_api/r2_internal_api_client.dart';
+
+class R2InternalApi {
+  R2InternalApi({
+    required Dio dio,
+  }) : _dio = dio;
+
+  final Dio _dio;
+
+  R2InternalApiClient get r2 => R2InternalApiClient(_dio);
+}

--- a/packages/internal_api_client/lib/src/api/r2_internal_api/r2_internal_api_client.dart
+++ b/packages/internal_api_client/lib/src/api/r2_internal_api/r2_internal_api_client.dart
@@ -1,0 +1,26 @@
+import 'package:dio/dio.dart';
+import 'package:internal_api_client/src/api/r2_internal_api/model/delete_object_request.dart';
+import 'package:internal_api_client/src/api/r2_internal_api/model/delete_object_response.dart';
+import 'package:internal_api_client/src/api/r2_internal_api/model/put_signed_url_request.dart';
+import 'package:internal_api_client/src/api/r2_internal_api/model/put_signed_url_response.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'r2_internal_api_client.g.dart';
+
+@RestApi()
+abstract class R2InternalApiClient {
+  factory R2InternalApiClient(Dio dio, {String baseUrl}) =
+      _R2InternalApiClient;
+
+  /// 署名付きURLを生成する
+  @PUT('/proxy/r2-internal-api/internal/r2/signed-url')
+  Future<HttpResponse<PutSignedUrlResponse>> generateSignedUrl({
+    @Body() required PutSignedUrlRequest request,
+  });
+
+  /// オブジェクトを削除する
+  @DELETE('/proxy/r2-internal-api/internal/r2/object')
+  Future<HttpResponse<DeleteObjectResponse>> deleteObject({
+    @Body() required DeleteObjectRequest request,
+  });
+}

--- a/packages/internal_api_client/lib/src/internal_api_client.dart
+++ b/packages/internal_api_client/lib/src/internal_api_client.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:internal_api_client/src/api/payment_workflow_internal_api/payment_workflow_internal_api.dart';
+import 'package:internal_api_client/src/api/r2_internal_api/r2_internal_api.dart';
 import 'package:internal_api_client/src/api/stripe_internal_api/stripe_internal_api.dart';
 
 /// Payment Workflow Internal APIクライアント
@@ -12,4 +13,6 @@ class InternalApiClient {
       PaymentWorkflowInternalApi(dio: _dio);
 
   StripeInternalApi get stripeInternalApi => StripeInternalApi(dio: _dio);
+
+  R2InternalApi get r2InternalApi => R2InternalApi(dio: _dio);
 }

--- a/packages/internal_api_client/lib/src/src.dart
+++ b/packages/internal_api_client/lib/src/src.dart
@@ -1,6 +1,12 @@
 export 'api/payment_workflow_internal_api/payment_completion_api_client.dart';
 export 'api/payment_workflow_internal_api/payment_workflow_internal_api.dart';
 export 'api/payment_workflow_internal_api/ticket_checkout_api_client.dart';
+export 'api/r2_internal_api/model/delete_object_request.dart';
+export 'api/r2_internal_api/model/delete_object_response.dart';
+export 'api/r2_internal_api/model/put_signed_url_request.dart';
+export 'api/r2_internal_api/model/put_signed_url_response.dart';
+export 'api/r2_internal_api/r2_internal_api.dart';
+export 'api/r2_internal_api/r2_internal_api_client.dart';
 export 'api/stripe_internal_api/internal_payment_api_client.dart';
 export 'api/stripe_internal_api/model/put_checkout_session_request.dart';
 export 'api/stripe_internal_api/model/put_checkout_session_response.dart';


### PR DESCRIPTION
## Issue

Closes #{issue_number}

## 概要

Cloudflare R2を操作するためのHonoベースの内部APIと、それに対応するプロキシ設定、およびDartクライアントを実装しました。

## 詳細

-   **bff/r2-internal-api**:
    -   Cloudflare R2へのファイルアップロード用署名付きURLを生成する `PUT /internal/r2/signed-url` エンドポイントを実装しました。`aws4fetch` を使用して署名付きURLを生成します。
    -   R2バケットからオブジェクトを削除する `DELETE /internal/r2/object` エンドポイントを実装しました。R2 Service Bindingを利用してオブジェクトを削除します。
    -   OpenAPI定義も合わせて提供します。
-   **bff/internal-api-proxy**:
    -   新しく作成した `r2-internal-api` へのプロキシ設定を追加しました。
    -   `wrangler.jsonc` にR2 Internal APIのサービスバインディングを追加しました。
-   **packages/internal_api_client**:
    -   R2 Internal APIと連携するためのDartクライアント（Freezed, Retrofit）を実装しました。
    -   `InternalApiClient` に `r2InternalApi` を追加し、R2操作を可能にしました。

## 画像・動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

| Before | After | Design |
| ------ | ----- | ------ |
|        |       |        |

## その他

-   Cloudflare R2の認証情報 (`CLOUDFLARE_R2_ACCESS_KEY_ID`, `CLOUDFLARE_R2_SECRET_ACCESS_KEY`, `CLOUDFLARE_R2_BUCKET_NAME`) を `.dev.vars` に設定する必要があります。
-   R2エンドポイントのURLは、CloudflareアカウントID (`cdd8f59359fe226645e7b541cdc53b57`) を使用してハードコードされています。環境に応じて調整が必要な場合があります。

---
<a href="https://cursor.com/background-agent?bcId=bc-ba1bf41c-1968-471f-b0dd-59540001caf9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba1bf41c-1968-471f-b0dd-59540001caf9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

