### PR TITLE
feat: アカウント情報画面からChips表示を削除

### DIFF
--- a/apps/app/lib/features/account/ui/info/account_info_screen.dart
+++ b/apps/app/lib/features/account/ui/info/account_info_screen.dart
@@ -154,25 +154,6 @@ class _UserInfoCard extends ConsumerWidget {
               style: Theme.of(context).textTheme.bodyLarge,
             ),
             const SizedBox(height: 16),
-            Wrap(
-              crossAxisAlignment: WrapCrossAlignment.center,
-              spacing: 8,
-              runSpacing: 8,
-              // TODO: ユースケースから取得した情報を表示する
-              children: ['Sponsor', 'Google']
-                  .map(
-                    (text) => Chip(
-                      label: Text(
-                        text,
-                        softWrap: true,
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 2,
-                      ),
-                    ),
-                  )
-                  .toList(),
-            ),
-            const SizedBox(height: 16),
             SizedBox(
               width: double.infinity,
               child: ElevatedButton.icon(


### PR DESCRIPTION
## 概要

Issue 203で実装されたアカウント情報画面のUIから、「Sponsor」「Google」などのChips表示を削除しました。

## 背景

- Issue 203でアカウント情報画面のUIが実装された
- 現在、一時的に不要な表示要素としてChips表示が含まれている
- シンプルなUIにするため、Chips表示を削除

## 変更内容

### 削除された要素
- **Chips表示**: 「Sponsor」「Google」のラベルを表示するChipウィジェット
- **関連するスペーシング**: Chips表示の前後の適切なスペーシング

### 修正されたファイル
- `apps/app/lib/features/account/ui/info/account_info_screen.dart`
  - `_UserInfoCard`クラス内のChips表示部分を削除
  - スペーシングを適切に調整

### 変更前の実装
```dart
Wrap(
  crossAxisAlignment: WrapCrossAlignment.center,
  spacing: 8,
  runSpacing: 8,
  // TODO: ユースケースから取得した情報を表示する
  children: ['Sponsor', 'Google']
      .map(
        (text) => Chip(
          label: Text(
            text,
            softWrap: true,
            overflow: TextOverflow.ellipsis,
            maxLines: 2,
          ),
        ),
      )
      .toList(),
),
```

## 確認済み
- ✅ 静的解析エラーなし（`dart analyze`）
- ✅ Chips表示の完全削除
- ✅ スペーシングの適切な調整
- ✅ UIの一貫性維持

<img width="320" height="2622" alt="simulator_screenshot_7839C52C-71DB-4D0B-B01E-EB558755F88E" src="https://github.com/user-attachments/assets/0d23673e-c0df-4454-8028-8e3393bb8bab" />

## 関連Issue
References #203

## テスト
- [x] 静的解析エラーなし
- [x] Chips表示の削除確認
- [x] UIレイアウトの確認