### PR TITLE
feat: お知らせの初期データを更新

### DIFF
--- a/supabase/seeds/005_news.sql
+++ b/supabase/seeds/005_news.sql
@@ -2,14 +2,27 @@ INSERT INTO
     public.news (title, url, starts_at, ends_at)
 VALUES
     (
-        'FlutterKaigi mini #4 @Kyoto を開催',
+        'FlutterKaigi mini #4 @Kyoto を開催します',
         'https://medium.com/flutterkaigi/flutterkaigi-mini-4-kyoto-%E3%82%92%E9%96%8B%E5%82%AC%E3%81%97%E3%81%BE%E3%81%99-85facf0ec6b2',
         '2025-04-16 09:00:00+00'::timestamp,
         '2025-06-30 09:00:00+00'::timestamp
     ),
     (
-        'FlutterKaigi 2025 スポンサー募集を開始',
+        'FlutterKaigi 2025 スポンサー募集について',
         'https://medium.com/flutterkaigi/flutterkaigi-2025-%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B5%E3%83%BC%E5%8B%9F%E9%9B%86%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6-034330881a94',
         '2025-04-23 09:00:00+00'::timestamp,
+        '2025-08-01 09:00:00+00'::timestamp
+    ),
+    (
+        'FlutterKaigi mini #4 ふりかえり',
+        'https://medium.com/flutterkaigi/flutterkaigi-mini-4-%E3%81%B5%E3%82%8A%E3%81%8B%E3%81%88%E3%82%8A-beca6b44f937',
+        '2025-05-16 09:00:00+00'::timestamp,
+        NULL
+    ),
+    ('FlutterKaigi 2025 プロポーザル募集を開始', NULL, '2025-06-23 09:00:00+00'::timestamp, '2025-07-22 09:00:00+00'::timestamp),
+    (
+        'FlutterKaigi 2025 当日ボランティアスタッフ募集',
+        'https://medium.com/flutterkaigi/flutterkaigi-2025-%E5%BD%93%E6%97%A5%E3%83%9C%E3%83%A9%E3%83%B3%E3%83%86%E3%82%A3%E3%82%A2%E3%82%B9%E3%82%BF%E3%83%83%E3%83%95%E5%8B%9F%E9%9B%86-02f97b5996a3',
+        '2025-08-07 09:00:00+00'::timestamp,
         NULL
     );


### PR DESCRIPTION
## 概要

お知らせの初期データ（seed data）を更新し、最新の情報を反映しました。

## 変更内容

### 既存のお知らせの更新
- **`FlutterKaigi mini #4 @Kyoto を開催`** → **`FlutterKaigi mini #4 @Kyoto を開催します`**
- **`FlutterKaigi 2025 スポンサー募集を開始`** → **`FlutterKaigi 2025 スポンサー募集について`**
  - 終了期間を `2025-06-30` から `2025-08-01` に延長

### 新しいお知らせの追加
1. **`FlutterKaigi mini #4 ふりかえり`**
   - 開始: 2025-05-16 09:00:00+00
   - 終了: なし（継続中）
   - URL: https://medium.com/flutterkaigi/flutterkaigi-mini-4-ふりかえり-beca6b44f937

2. **`FlutterKaigi 2025 プロポーザル募集を開始`**
   - 開始: 2025-06-23 09:00:00+00
   - 終了: 2025-07-22 09:00:00+00
   - URL: なし

3. **`FlutterKaigi 2025 当日ボランティアスタッフ募集`**
   - 開始: 2025-08-07 09:00:00+00
   - 終了: なし（継続中）
   - URL: https://medium.com/flutterkaigi/flutterkaigi-2025-当日ボランティアスタッフ募集-02f97b5996a3

## 技術的な変更
- `supabase/seeds/005_news.sql` ファイルを更新
- データの整合性と最新性を向上
- アプリ内のお知らせ表示により豊富な情報を提供

## 確認済み
- ✅ 既存データの適切な更新
- ✅ 新規データの追加
- ✅ SQL構文の正確性
- ✅ 日付形式の一貫性

<img width="320" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-31 at 17 17 13" src="https://github.com/user-attachments/assets/ace6e9aa-6362-4b73-bf48-6c5a6a4a4125" />

## 影響範囲
- アプリ内のお知らせ画面で表示される情報が更新される
- データベースの初期化時に最新のお知らせ情報が反映される