### PR TITLE
feat: newsテーブルのstarts_atカラムをNOT NULLに変更し、型安全性を向上

### DIFF
--- a/apps/app/lib/features/news/data/news_provider.dart
+++ b/apps/app/lib/features/news/data/news_provider.dart
@@ -18,7 +18,7 @@ Future<List<News>> news(Ref ref) async {
           id: news.id,
           title: news.title,
           url: news.url != null ? Uri.parse(news.url!) : null,
-          startedAt: news.createdAt,
+          startedAt: news.startsAt,
         ),
       )
       .toList();

--- a/bff/database/drizzle/relations.ts
+++ b/bff/database/drizzle/relations.ts
@@ -11,10 +11,12 @@ import {
 	individualDraftApprovals,
 	individualDrafts,
 	individuals,
+	jobBoards,
 	mfaAmrClaimsInAuth,
 	mfaChallengesInAuth,
 	mfaFactorsInAuth,
 	oneTimeTokensInAuth,
+	profiles,
 	refreshTokensInAuth,
 	samlProvidersInAuth,
 	samlRelayStatesInAuth,
@@ -31,6 +33,7 @@ import {
 	ticketPurchases,
 	ticketTypes,
 	userRoles,
+	userSnsLinks,
 	users,
 	usersInAuth,
 } from "./schema";
@@ -93,6 +96,8 @@ export const usersInAuthRelations = relations(usersInAuth, ({ many }) => ({
 	oneTimeTokensInAuths: many(oneTimeTokensInAuth),
 	mfaFactorsInAuths: many(mfaFactorsInAuth),
 	users: many(users),
+	profiles: many(profiles),
+	userSnsLinks: many(userSnsLinks),
 }));
 
 export const ssoDomainsInAuthRelations = relations(
@@ -261,8 +266,9 @@ export const companyInvitationRelations = relations(
 
 export const companiesRelations = relations(companies, ({ many }) => ({
 	companyInvitations: many(companyInvitation),
-	companyDrafts: many(companyDrafts),
+	jobBoards: many(jobBoards),
 	sponsorCompanies: many(sponsorCompanies),
+	companyDrafts: many(companyDrafts),
 	companyMembers: many(companyMembers),
 }));
 
@@ -356,11 +362,11 @@ export const sponsorCompaniesRelations = relations(
 	sponsorCompanies,
 	({ one, many }) => ({
 		basicSponsorCompanies: many(basicSponsorCompanies),
+		sponsorCompanyOptions: many(sponsorCompanyOptions),
 		company: one(companies, {
 			fields: [sponsorCompanies.companyId],
 			references: [companies.id],
 		}),
-		sponsorCompanyOptions: many(sponsorCompanyOptions),
 	}),
 );
 
@@ -373,6 +379,27 @@ export const sponsorCompanyOptionsRelations = relations(
 		}),
 	}),
 );
+
+export const jobBoardsRelations = relations(jobBoards, ({ one }) => ({
+	company: one(companies, {
+		fields: [jobBoards.id],
+		references: [companies.id],
+	}),
+}));
+
+export const profilesRelations = relations(profiles, ({ one }) => ({
+	usersInAuth: one(usersInAuth, {
+		fields: [profiles.id],
+		references: [usersInAuth.id],
+	}),
+}));
+
+export const userSnsLinksRelations = relations(userSnsLinks, ({ one }) => ({
+	usersInAuth: one(usersInAuth, {
+		fields: [userSnsLinks.userId],
+		references: [usersInAuth.id],
+	}),
+}));
 
 export const userRolesRelations = relations(userRoles, ({ one }) => ({
 	user: one(users, {

--- a/packages/bff_client/lib/src/model/v1/news/news_create_request.dart
+++ b/packages/bff_client/lib/src/model/v1/news/news_create_request.dart
@@ -8,7 +8,7 @@ abstract class NewsCreateRequest with _$NewsCreateRequest {
   const factory NewsCreateRequest({
     required String title,
     required String url,
-    DateTime? startsAt,
+    required DateTime startsAt,
     DateTime? endsAt,
   }) = _NewsCreateRequest;
 

--- a/packages/bff_client/lib/src/model/v1/news/news_create_request.freezed.dart
+++ b/packages/bff_client/lib/src/model/v1/news/news_create_request.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$NewsCreateRequest {
 
- String get title; String get url; DateTime? get startsAt; DateTime? get endsAt;
+ String get title; String get url; DateTime get startsAt; DateTime? get endsAt;
 /// Create a copy of NewsCreateRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $NewsCreateRequestCopyWith<$Res>  {
   factory $NewsCreateRequestCopyWith(NewsCreateRequest value, $Res Function(NewsCreateRequest) _then) = _$NewsCreateRequestCopyWithImpl;
 @useResult
 $Res call({
- String title, String url, DateTime? startsAt, DateTime? endsAt
+ String title, String url, DateTime startsAt, DateTime? endsAt
 });
 
 
@@ -65,12 +65,12 @@ class _$NewsCreateRequestCopyWithImpl<$Res>
 
 /// Create a copy of NewsCreateRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? url = null,Object? startsAt = freezed,Object? endsAt = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? url = null,Object? startsAt = null,Object? endsAt = freezed,}) {
   return _then(_self.copyWith(
 title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
-as String,startsAt: freezed == startsAt ? _self.startsAt : startsAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,endsAt: freezed == endsAt ? _self.endsAt : endsAt // ignore: cast_nullable_to_non_nullable
+as String,startsAt: null == startsAt ? _self.startsAt : startsAt // ignore: cast_nullable_to_non_nullable
+as DateTime,endsAt: freezed == endsAt ? _self.endsAt : endsAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,
   ));
 }
@@ -156,7 +156,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  String url,  DateTime? startsAt,  DateTime? endsAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  String url,  DateTime startsAt,  DateTime? endsAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _NewsCreateRequest() when $default != null:
 return $default(_that.title,_that.url,_that.startsAt,_that.endsAt);case _:
@@ -177,7 +177,7 @@ return $default(_that.title,_that.url,_that.startsAt,_that.endsAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  String url,  DateTime? startsAt,  DateTime? endsAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  String url,  DateTime startsAt,  DateTime? endsAt)  $default,) {final _that = this;
 switch (_that) {
 case _NewsCreateRequest():
 return $default(_that.title,_that.url,_that.startsAt,_that.endsAt);case _:
@@ -197,7 +197,7 @@ return $default(_that.title,_that.url,_that.startsAt,_that.endsAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  String url,  DateTime? startsAt,  DateTime? endsAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  String url,  DateTime startsAt,  DateTime? endsAt)?  $default,) {final _that = this;
 switch (_that) {
 case _NewsCreateRequest() when $default != null:
 return $default(_that.title,_that.url,_that.startsAt,_that.endsAt);case _:
@@ -212,12 +212,12 @@ return $default(_that.title,_that.url,_that.startsAt,_that.endsAt);case _:
 @JsonSerializable()
 
 class _NewsCreateRequest implements NewsCreateRequest {
-  const _NewsCreateRequest({required this.title, required this.url, this.startsAt, this.endsAt});
+  const _NewsCreateRequest({required this.title, required this.url, required this.startsAt, this.endsAt});
   factory _NewsCreateRequest.fromJson(Map<String, dynamic> json) => _$NewsCreateRequestFromJson(json);
 
 @override final  String title;
 @override final  String url;
-@override final  DateTime? startsAt;
+@override final  DateTime startsAt;
 @override final  DateTime? endsAt;
 
 /// Create a copy of NewsCreateRequest
@@ -253,7 +253,7 @@ abstract mixin class _$NewsCreateRequestCopyWith<$Res> implements $NewsCreateReq
   factory _$NewsCreateRequestCopyWith(_NewsCreateRequest value, $Res Function(_NewsCreateRequest) _then) = __$NewsCreateRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String title, String url, DateTime? startsAt, DateTime? endsAt
+ String title, String url, DateTime startsAt, DateTime? endsAt
 });
 
 
@@ -270,12 +270,12 @@ class __$NewsCreateRequestCopyWithImpl<$Res>
 
 /// Create a copy of NewsCreateRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? url = null,Object? startsAt = freezed,Object? endsAt = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? url = null,Object? startsAt = null,Object? endsAt = freezed,}) {
   return _then(_NewsCreateRequest(
 title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
-as String,startsAt: freezed == startsAt ? _self.startsAt : startsAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,endsAt: freezed == endsAt ? _self.endsAt : endsAt // ignore: cast_nullable_to_non_nullable
+as String,startsAt: null == startsAt ? _self.startsAt : startsAt // ignore: cast_nullable_to_non_nullable
+as DateTime,endsAt: freezed == endsAt ? _self.endsAt : endsAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,
   ));
 }

--- a/packages/bff_client/lib/src/model/v1/news/news_create_request.g.dart
+++ b/packages/bff_client/lib/src/model/v1/news/news_create_request.g.dart
@@ -18,7 +18,7 @@ _NewsCreateRequest _$NewsCreateRequestFromJson(Map<String, dynamic> json) =>
           url: $checkedConvert('url', (v) => v as String),
           startsAt: $checkedConvert(
             'starts_at',
-            (v) => v == null ? null : DateTime.parse(v as String),
+            (v) => DateTime.parse(v as String),
           ),
           endsAt: $checkedConvert(
             'ends_at',
@@ -34,6 +34,6 @@ Map<String, dynamic> _$NewsCreateRequestToJson(_NewsCreateRequest instance) =>
     <String, dynamic>{
       'title': instance.title,
       'url': instance.url,
-      'starts_at': instance.startsAt?.toIso8601String(),
+      'starts_at': instance.startsAt.toIso8601String(),
       'ends_at': instance.endsAt?.toIso8601String(),
     };

--- a/packages/bff_client/lib/src/model/v1/news/news_update_request.dart
+++ b/packages/bff_client/lib/src/model/v1/news/news_update_request.dart
@@ -8,7 +8,7 @@ abstract class NewsUpdateRequest with _$NewsUpdateRequest {
   const factory NewsUpdateRequest({
     required String title,
     required String url,
-    DateTime? startsAt,
+    required DateTime startsAt,
     DateTime? endsAt,
   }) = _NewsUpdateRequest;
 

--- a/packages/bff_client/lib/src/model/v1/news/news_update_request.freezed.dart
+++ b/packages/bff_client/lib/src/model/v1/news/news_update_request.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$NewsUpdateRequest {
 
- String get title; String get url; DateTime? get startsAt; DateTime? get endsAt;
+ String get title; String get url; DateTime get startsAt; DateTime? get endsAt;
 /// Create a copy of NewsUpdateRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $NewsUpdateRequestCopyWith<$Res>  {
   factory $NewsUpdateRequestCopyWith(NewsUpdateRequest value, $Res Function(NewsUpdateRequest) _then) = _$NewsUpdateRequestCopyWithImpl;
 @useResult
 $Res call({
- String title, String url, DateTime? startsAt, DateTime? endsAt
+ String title, String url, DateTime startsAt, DateTime? endsAt
 });
 
 
@@ -65,12 +65,12 @@ class _$NewsUpdateRequestCopyWithImpl<$Res>
 
 /// Create a copy of NewsUpdateRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? url = null,Object? startsAt = freezed,Object? endsAt = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? url = null,Object? startsAt = null,Object? endsAt = freezed,}) {
   return _then(_self.copyWith(
 title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
-as String,startsAt: freezed == startsAt ? _self.startsAt : startsAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,endsAt: freezed == endsAt ? _self.endsAt : endsAt // ignore: cast_nullable_to_non_nullable
+as String,startsAt: null == startsAt ? _self.startsAt : startsAt // ignore: cast_nullable_to_non_nullable
+as DateTime,endsAt: freezed == endsAt ? _self.endsAt : endsAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,
   ));
 }
@@ -156,7 +156,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  String url,  DateTime? startsAt,  DateTime? endsAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String title,  String url,  DateTime startsAt,  DateTime? endsAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _NewsUpdateRequest() when $default != null:
 return $default(_that.title,_that.url,_that.startsAt,_that.endsAt);case _:
@@ -177,7 +177,7 @@ return $default(_that.title,_that.url,_that.startsAt,_that.endsAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  String url,  DateTime? startsAt,  DateTime? endsAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String title,  String url,  DateTime startsAt,  DateTime? endsAt)  $default,) {final _that = this;
 switch (_that) {
 case _NewsUpdateRequest():
 return $default(_that.title,_that.url,_that.startsAt,_that.endsAt);case _:
@@ -197,7 +197,7 @@ return $default(_that.title,_that.url,_that.startsAt,_that.endsAt);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  String url,  DateTime? startsAt,  DateTime? endsAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String title,  String url,  DateTime startsAt,  DateTime? endsAt)?  $default,) {final _that = this;
 switch (_that) {
 case _NewsUpdateRequest() when $default != null:
 return $default(_that.title,_that.url,_that.startsAt,_that.endsAt);case _:
@@ -212,12 +212,12 @@ return $default(_that.title,_that.url,_that.startsAt,_that.endsAt);case _:
 @JsonSerializable()
 
 class _NewsUpdateRequest implements NewsUpdateRequest {
-  const _NewsUpdateRequest({required this.title, required this.url, this.startsAt, this.endsAt});
+  const _NewsUpdateRequest({required this.title, required this.url, required this.startsAt, this.endsAt});
   factory _NewsUpdateRequest.fromJson(Map<String, dynamic> json) => _$NewsUpdateRequestFromJson(json);
 
 @override final  String title;
 @override final  String url;
-@override final  DateTime? startsAt;
+@override final  DateTime startsAt;
 @override final  DateTime? endsAt;
 
 /// Create a copy of NewsUpdateRequest
@@ -253,7 +253,7 @@ abstract mixin class _$NewsUpdateRequestCopyWith<$Res> implements $NewsUpdateReq
   factory _$NewsUpdateRequestCopyWith(_NewsUpdateRequest value, $Res Function(_NewsUpdateRequest) _then) = __$NewsUpdateRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String title, String url, DateTime? startsAt, DateTime? endsAt
+ String title, String url, DateTime startsAt, DateTime? endsAt
 });
 
 
@@ -270,12 +270,12 @@ class __$NewsUpdateRequestCopyWithImpl<$Res>
 
 /// Create a copy of NewsUpdateRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? url = null,Object? startsAt = freezed,Object? endsAt = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? url = null,Object? startsAt = null,Object? endsAt = freezed,}) {
   return _then(_NewsUpdateRequest(
 title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
-as String,startsAt: freezed == startsAt ? _self.startsAt : startsAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,endsAt: freezed == endsAt ? _self.endsAt : endsAt // ignore: cast_nullable_to_non_nullable
+as String,startsAt: null == startsAt ? _self.startsAt : startsAt // ignore: cast_nullable_to_non_nullable
+as DateTime,endsAt: freezed == endsAt ? _self.endsAt : endsAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,
   ));
 }

--- a/packages/bff_client/lib/src/model/v1/news/news_update_request.g.dart
+++ b/packages/bff_client/lib/src/model/v1/news/news_update_request.g.dart
@@ -18,7 +18,7 @@ _NewsUpdateRequest _$NewsUpdateRequestFromJson(Map<String, dynamic> json) =>
           url: $checkedConvert('url', (v) => v as String),
           startsAt: $checkedConvert(
             'starts_at',
-            (v) => v == null ? null : DateTime.parse(v as String),
+            (v) => DateTime.parse(v as String),
           ),
           endsAt: $checkedConvert(
             'ends_at',
@@ -34,6 +34,6 @@ Map<String, dynamic> _$NewsUpdateRequestToJson(_NewsUpdateRequest instance) =>
     <String, dynamic>{
       'title': instance.title,
       'url': instance.url,
-      'starts_at': instance.startsAt?.toIso8601String(),
+      'starts_at': instance.startsAt.toIso8601String(),
       'ends_at': instance.endsAt?.toIso8601String(),
     };

--- a/packages/db_client/lib/src/client/news/news_db_client.dart
+++ b/packages/db_client/lib/src/client/news/news_db_client.dart
@@ -13,7 +13,7 @@ class NewsDbClient {
 SELECT *
 FROM public.news
 WHERE
-  (starts_at IS NULL OR starts_at <= NOW()) AND
+  starts_at <= NOW() AND
   (ends_at IS NULL OR ends_at > NOW())
 ORDER BY id DESC
 '''),
@@ -59,7 +59,7 @@ LIMIT 1
   Future<News> createNews({
     required String title,
     required String url,
-    DateTime? startsAt,
+    required DateTime startsAt,
     DateTime? endsAt,
   }) async {
     final result = await _connection.execute(
@@ -84,7 +84,7 @@ RETURNING *
     required int id,
     required String title,
     required String url,
-    DateTime? startsAt,
+    required DateTime startsAt,
     DateTime? endsAt,
   }) async {
     final result = await _connection.execute(

--- a/packages/db_types/lib/src/tables/news.dart
+++ b/packages/db_types/lib/src/tables/news.dart
@@ -10,7 +10,7 @@ abstract class News with _$News {
     required int id,
     required String title,
     String? url,
-    @DateTimeConverter() DateTime? startsAt,
+    @RequiredDateTimeConverter() required DateTime startsAt,
     @DateTimeConverter() DateTime? endsAt,
     @RequiredDateTimeConverter() required DateTime createdAt,
     @RequiredDateTimeConverter() required DateTime updatedAt,

--- a/packages/db_types/lib/src/tables/news.freezed.dart
+++ b/packages/db_types/lib/src/tables/news.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$News {
 
- int get id; String get title; String? get url;@DateTimeConverter() DateTime? get startsAt;@DateTimeConverter() DateTime? get endsAt;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;
+ int get id; String get title; String? get url;@RequiredDateTimeConverter() DateTime get startsAt;@DateTimeConverter() DateTime? get endsAt;@RequiredDateTimeConverter() DateTime get createdAt;@RequiredDateTimeConverter() DateTime get updatedAt;
 /// Create a copy of News
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $NewsCopyWith<$Res>  {
   factory $NewsCopyWith(News value, $Res Function(News) _then) = _$NewsCopyWithImpl;
 @useResult
 $Res call({
- int id, String title, String? url,@DateTimeConverter() DateTime? startsAt,@DateTimeConverter() DateTime? endsAt,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
+ int id, String title, String? url,@RequiredDateTimeConverter() DateTime startsAt,@DateTimeConverter() DateTime? endsAt,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -65,13 +65,13 @@ class _$NewsCopyWithImpl<$Res>
 
 /// Create a copy of News
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = null,Object? url = freezed,Object? startsAt = freezed,Object? endsAt = freezed,Object? createdAt = null,Object? updatedAt = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? title = null,Object? url = freezed,Object? startsAt = null,Object? endsAt = freezed,Object? createdAt = null,Object? updatedAt = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
-as String?,startsAt: freezed == startsAt ? _self.startsAt : startsAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,endsAt: freezed == endsAt ? _self.endsAt : endsAt // ignore: cast_nullable_to_non_nullable
+as String?,startsAt: null == startsAt ? _self.startsAt : startsAt // ignore: cast_nullable_to_non_nullable
+as DateTime,endsAt: freezed == endsAt ? _self.endsAt : endsAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as DateTime,
@@ -159,7 +159,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String title,  String? url, @DateTimeConverter()  DateTime? startsAt, @DateTimeConverter()  DateTime? endsAt, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String title,  String? url, @RequiredDateTimeConverter()  DateTime startsAt, @DateTimeConverter()  DateTime? endsAt, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _News() when $default != null:
 return $default(_that.id,_that.title,_that.url,_that.startsAt,_that.endsAt,_that.createdAt,_that.updatedAt);case _:
@@ -180,7 +180,7 @@ return $default(_that.id,_that.title,_that.url,_that.startsAt,_that.endsAt,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String title,  String? url, @DateTimeConverter()  DateTime? startsAt, @DateTimeConverter()  DateTime? endsAt, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String title,  String? url, @RequiredDateTimeConverter()  DateTime startsAt, @DateTimeConverter()  DateTime? endsAt, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)  $default,) {final _that = this;
 switch (_that) {
 case _News():
 return $default(_that.id,_that.title,_that.url,_that.startsAt,_that.endsAt,_that.createdAt,_that.updatedAt);case _:
@@ -200,7 +200,7 @@ return $default(_that.id,_that.title,_that.url,_that.startsAt,_that.endsAt,_that
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String title,  String? url, @DateTimeConverter()  DateTime? startsAt, @DateTimeConverter()  DateTime? endsAt, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String title,  String? url, @RequiredDateTimeConverter()  DateTime startsAt, @DateTimeConverter()  DateTime? endsAt, @RequiredDateTimeConverter()  DateTime createdAt, @RequiredDateTimeConverter()  DateTime updatedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _News() when $default != null:
 return $default(_that.id,_that.title,_that.url,_that.startsAt,_that.endsAt,_that.createdAt,_that.updatedAt);case _:
@@ -215,13 +215,13 @@ return $default(_that.id,_that.title,_that.url,_that.startsAt,_that.endsAt,_that
 @JsonSerializable()
 
 class _News implements News {
-  const _News({required this.id, required this.title, this.url, @DateTimeConverter() this.startsAt, @DateTimeConverter() this.endsAt, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt});
+  const _News({required this.id, required this.title, this.url, @RequiredDateTimeConverter() required this.startsAt, @DateTimeConverter() this.endsAt, @RequiredDateTimeConverter() required this.createdAt, @RequiredDateTimeConverter() required this.updatedAt});
   factory _News.fromJson(Map<String, dynamic> json) => _$NewsFromJson(json);
 
 @override final  int id;
 @override final  String title;
 @override final  String? url;
-@override@DateTimeConverter() final  DateTime? startsAt;
+@override@RequiredDateTimeConverter() final  DateTime startsAt;
 @override@DateTimeConverter() final  DateTime? endsAt;
 @override@RequiredDateTimeConverter() final  DateTime createdAt;
 @override@RequiredDateTimeConverter() final  DateTime updatedAt;
@@ -259,7 +259,7 @@ abstract mixin class _$NewsCopyWith<$Res> implements $NewsCopyWith<$Res> {
   factory _$NewsCopyWith(_News value, $Res Function(_News) _then) = __$NewsCopyWithImpl;
 @override @useResult
 $Res call({
- int id, String title, String? url,@DateTimeConverter() DateTime? startsAt,@DateTimeConverter() DateTime? endsAt,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
+ int id, String title, String? url,@RequiredDateTimeConverter() DateTime startsAt,@DateTimeConverter() DateTime? endsAt,@RequiredDateTimeConverter() DateTime createdAt,@RequiredDateTimeConverter() DateTime updatedAt
 });
 
 
@@ -276,13 +276,13 @@ class __$NewsCopyWithImpl<$Res>
 
 /// Create a copy of News
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = null,Object? url = freezed,Object? startsAt = freezed,Object? endsAt = freezed,Object? createdAt = null,Object? updatedAt = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? title = null,Object? url = freezed,Object? startsAt = null,Object? endsAt = freezed,Object? createdAt = null,Object? updatedAt = null,}) {
   return _then(_News(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
-as String?,startsAt: freezed == startsAt ? _self.startsAt : startsAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,endsAt: freezed == endsAt ? _self.endsAt : endsAt // ignore: cast_nullable_to_non_nullable
+as String?,startsAt: null == startsAt ? _self.startsAt : startsAt // ignore: cast_nullable_to_non_nullable
+as DateTime,endsAt: freezed == endsAt ? _self.endsAt : endsAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as DateTime,

--- a/packages/db_types/lib/src/tables/news.g.dart
+++ b/packages/db_types/lib/src/tables/news.g.dart
@@ -18,7 +18,7 @@ _News _$NewsFromJson(Map<String, dynamic> json) => $checkedCreate(
       url: $checkedConvert('url', (v) => v as String?),
       startsAt: $checkedConvert(
         'starts_at',
-        (v) => const DateTimeConverter().fromJson(v),
+        (v) => const RequiredDateTimeConverter().fromJson(v),
       ),
       endsAt: $checkedConvert(
         'ends_at',
@@ -47,7 +47,7 @@ Map<String, dynamic> _$NewsToJson(_News instance) => <String, dynamic>{
   'id': instance.id,
   'title': instance.title,
   'url': instance.url,
-  'starts_at': const DateTimeConverter().toJson(instance.startsAt),
+  'starts_at': const RequiredDateTimeConverter().toJson(instance.startsAt),
   'ends_at': const DateTimeConverter().toJson(instance.endsAt),
   'created_at': const RequiredDateTimeConverter().toJson(instance.createdAt),
   'updated_at': const RequiredDateTimeConverter().toJson(instance.updatedAt),

--- a/supabase/migrations/20250831082239_make-news-starts-at-not-null.sql
+++ b/supabase/migrations/20250831082239_make-news-starts-at-not-null.sql
@@ -1,0 +1,3 @@
+alter table "public"."news" alter column "starts_at" set not null;
+
+

--- a/supabase/schemas/005_news.sql
+++ b/supabase/schemas/005_news.sql
@@ -1,11 +1,11 @@
 CREATE TABLE public.news (
-  id INTEGER GENERATED ALWAYS AS IDENTITY NOT NULL PRIMARY KEY,
-  title TEXT NOT NULL,
-  url TEXT,
-  starts_at TIMESTAMP,
-  ends_at TIMESTAMP,
-  created_at TIMESTAMP NOT NULL DEFAULT now(),
-  updated_at TIMESTAMP NOT NULL DEFAULT now()
+  id integer GENERATED ALWAYS AS IDENTITY NOT NULL PRIMARY KEY,
+  title text NOT NULL,
+  url text,
+  starts_at timestamp NOT NULL,
+  ends_at timestamp,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
 );
 
-ALTER TABLE public.news ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.news enable ROW level security;


### PR DESCRIPTION
## 概要

お知らせ（news）テーブルの `starts_at` カラムを NOT NULL に変更し、データベーススキーマとDartの型定義の整合性を向上させました。

## 変更内容

### 1. データベーススキーマの更新
- `supabase/schemas/005_news.sql` で `starts_at TIMESTAMP` を `starts_at TIMESTAMP NOT NULL` に変更
- お知らせの開始日時が必須項目となり、データの整合性が向上

### 2. マイグレーションファイルの作成
- `bunx supabase db diff -f make-news-starts-at-not-null` でマイグレーションファイルを作成
- `supabase/migrations/20250831082239_make-news-starts-at-not-null.sql` が生成されました
- マイグレーションの動作確認を `bunx supabase db reset` で実施済み

### 3. Dart型定義の更新
- `packages/db_types/lib/src/tables/news.dart` で `startsAt` フィールドを `required` に変更
- `@RequiredDateTimeConverter()` アノテーションを使用して一貫性を保持
- `melos run gen:build` で生成ファイルを更新

### 4. アプリケーションコードの修正
- `apps/app/lib/features/news/data/news_provider.dart` で `createdAt` から `startsAt` を使用するように修正
- お知らせの開始日時として適切なフィールドを使用することで、ビジネスロジックの整合性が向上

## 技術的な改善点

### データベースレベル
- `starts_at` カラムが NOT NULL 制約を持つことで、お知らせの開始日時が確実に設定される
- データの整合性と品質が向上

### アプリケーションレベル
- Dartの型定義で `startsAt` が `required` となり、コンパイル時にnullチェックが可能
- 実行時エラーのリスクが軽減
- お知らせの表示で適切な日時（開始日時）を使用

## 影響範囲

- **データベース**: 既存のデータに `starts_at` が設定されていない場合は、マイグレーション時にエラーが発生する可能性があります
- **アプリケーション**: お知らせの表示で、より適切な日時（開始日時）が表示されるようになります
- **開発者体験**: 型安全性が向上し、開発時のエラー検出が改善されます

## 確認済み項目

- ✅ データベーススキーマの更新
- ✅ マイグレーションファイルの生成と動作確認
- ✅ Dart型定義の更新と生成ファイルの再生成
- ✅ アプリケーションコードの修正
- ✅ 静的解析での問題なし
- ✅ データベースリセットでの動作確認

※ 開発環境・検証環境でも動作確認済み

<img width="320" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-31 at 18 20 00" src="https://github.com/user-attachments/assets/7ae603fc-1baf-4622-8000-c2eeba0f7ec8" />


## 注意事項

この変更により、既存のデータで `starts_at` が設定されていないレコードがある場合は、マイグレーション実行前に適切な値を設定する必要があります。