### PR TITLE
feat: プロフィール編集時に既存のアバターキーを保持するように修正

### DIFF
--- a/apps/app/lib/features/account/ui/profile_edit_screen.dart
+++ b/apps/app/lib/features/account/ui/profile_edit_screen.dart
@@ -65,11 +65,16 @@ class ProfileEditScreen extends HookConsumerWidget {
           )
           .toList();
 
+      final avatarKey = ref
+          .read(profileNotifierProvider)
+          .requireValue!
+          .avatarKey;
       final request = ProfileUpdateRequest(
         name: nameController.text.trim(),
         comment: commentController.text.trim(),
         isAdult: isAdult,
         snsLinks: validSnsLinks,
+        avatarKey: avatarKey,
       );
 
       final notifier = ref.read(profileNotifierProvider.notifier);
@@ -356,5 +361,15 @@ class ProfileEditScreen extends HookConsumerWidget {
         skipLoadingOnReload: true,
       ),
     );
+  }
+}
+
+extension on ProfileResponse {
+  String? get avatarKey {
+    final avatarUrl = profile.avatarUrl;
+    if (avatarUrl == null) {
+      return null;
+    }
+    return avatarUrl.path.replaceFirst('/', '');
   }
 }


### PR DESCRIPTION
## 概要

プロフィール編集時に既存のアバターキーを保持するように修正しました。アバターを変更しない場合でも既存のアバターが保持されるようになります。

## 詳細

### 変更内容
- `ProfileResponse`に`avatarKey`のextensionを追加
- プロフィール更新時に既存のアバターキーを取得してリクエストに含める
- アバターURLからパス部分を抽出してアバターキーとして使用

### 変更理由
現在のプロフィール編集機能では、アバターを変更しない場合でも既存のアバターが失われてしまう問題がありました。この修正により、アバターを変更しない場合でも既存のアバターが適切に保持されるようになります。

### 技術的詳細
- `ProfileResponse`にextensionを追加してアバターURLからアバターキーを抽出
- `ProfileUpdateRequest`に`avatarKey`パラメータを追加して既存のアバターキーを渡す
- アバターURLのパス部分（先頭の`/`を除く）をアバターキーとして使用

## その他

この修正により、ユーザーがプロフィールの他の情報（名前、コメント、SNSリンクなど）のみを変更する場合でも、既存のアバターが保持されるようになります。