### PR TITLE
fix: WebプラットフォームでのshowLicensePageエラーを修正

### DIFF
--- a/apps/app/lib/core/router/account.dart
+++ b/apps/app/lib/core/router/account.dart
@@ -37,7 +37,10 @@ class AccountInfoRoute extends GoRouteData with $AccountInfoRoute {
       onTapContactTile: () => _openUrl(
         urlString: L10n.of(context).accountContactUrl,
       ),
-      onTapOssLicensesTile: () => showLicensePage(context: context),
+      onTapOssLicensesTile: () => showLicensePage(
+        context: context,
+        applicationName: L10n.of(context).appName,
+      ),
     );
   }
 


### PR DESCRIPTION
## Issue

<!-- Issue番号がないため、空白とします -->

## 概要

Webプラットフォームでライセンスページを表示する際に発生する`Platform._resolvedExecutable`エラーを修正しました。

## 詳細

### 問題
- `showLicensePage`をWebプラットフォームで実行すると`UnsupportedError: Platform._resolvedExecutable`エラーが発生
- Webでは`Platform`クラスの一部の機能がサポートされていないため

### 解決方法
- `showLicensePage`に`applicationName`パラメータを追加
- `L10n.of(context).appName`を指定することで、プラットフォーム固有の処理を回避

### 変更内容
```dart
// 修正前
onTapOssLicensesTile: () => showLicensePage(context: context),

// 修正後
onTapOssLicensesTile: () => showLicensePage(
  context: context,
  applicationName: L10n.of(context).appName,
),
```

## 画像・動画

<img width="851" height="597" alt="image" src="https://github.com/user-attachments/assets/0b9398c5-b0ca-4d51-97e1-ec68241349f0" />

## その他

- この修正により、Webプラットフォームでもライセンスページが正常に表示されるようになります
- 他のプラットフォーム（iOS、Android）での動作に影響はありません