### PR TITLE
feat: アカウント情報画面でプロフィール画像を優先表示

### DIFF
--- a/apps/app/pubspec.yaml
+++ b/apps/app/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
+  font_awesome_flutter: ^10.10.0
   freezed_annotation: ^3.0.0
   go_router: ^16.2.1
   hooks_riverpod: ^3.0.0-dev.17

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -565,6 +565,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  font_awesome_flutter:
+    dependency: transitive
+    description:
+      name: font_awesome_flutter
+      sha256: "27af5982e6c510dec1ba038eff634fa284676ee84e3fd807225c80c4ad869177"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.10.0"
   freezed:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue

<!-- Issue番号がないため空欄 -->

## 概要

アカウント情報画面でプロフィール画像を優先表示し、Google認証画像をフォールバック表示する機能を実装しました。

## 詳細

### 変更内容
- アカウント情報画面のプロフィール画像表示ロジックを改良
- プロフィール画像が設定されている場合はそれを優先表示
- プロフィール画像がない場合はGoogle認証画像をフォールバック表示
- Google認証画像にはGoogleアイコンをオーバーレイで表示
- どちらの画像もない場合はデフォルトの人物アイコンを表示
- ローディング・エラー状態の適切な表示

### 実装詳細
- `_ProfileImage`ウィジェットとして独立したコンポーネントに分離
- `ConsumerWidget`として実装し、内部で`profileNotifierProvider`をwatch
- 段階的なフォールバック機能（プロフィール画像 → Google認証画像 → デフォルトアイコン）
- `font_awesome_flutter`依存関係を追加してGoogleアイコン表示を実現

### 技術的改善
- 責任の分離によりコードの可読性と保守性を向上
- 再利用可能なウィジェットとして設計
- 適切な状態管理（ローディング中やエラー時の表示）

## 画像・動画

https://github.com/user-attachments/assets/0075229c-3b5b-49d6-a12a-aac5af8a314e

## その他

- ユーザビリティの向上：どの画像が表示されているかが分かりやすいUI
- 既存のプロフィール編集機能との整合性を保持
- エラーハンドリングとローディング状態の適切な処理
