### PR TITLE
fix: チケット決済ボタンタップ時のリロード処理を修正

### DIFF
--- a/apps/app/lib/core/router/router.g.dart
+++ b/apps/app/lib/core/router/router.g.dart
@@ -441,7 +441,7 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'ed356bcd3c88ae0a73948479fcbe24efe9c7b3e8';
+String _$routerHash() => r'e2ba3a85081f260a7e3d011122865214a995a427';
 
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/app/lib/features/ticket/data/notifier/ticket_checkout_notifier.dart
+++ b/apps/app/lib/features/ticket/data/notifier/ticket_checkout_notifier.dart
@@ -10,7 +10,6 @@ class TicketCheckoutNotifier extends _$TicketCheckoutNotifier {
   @override
   Future<List<TicketCheckoutItem>> build() async {
     final ticketItems = await ref.watch(ticketItemsProvider.future);
-    ref.onDispose(() => ref.invalidate(ticketItemsProvider));
     return ticketItems.whereType<TicketCheckoutItem>().toList();
   }
 
@@ -19,7 +18,7 @@ class TicketCheckoutNotifier extends _$TicketCheckoutNotifier {
   ) async {
     final repository = ref.read(ticketRepositoryProvider);
     final response = await repository.createCheckout(request);
-    ref.invalidateSelf(asReload: true);
+    ref.invalidate(ticketItemsProvider, asReload: true);
 
     return response;
   }
@@ -27,6 +26,6 @@ class TicketCheckoutNotifier extends _$TicketCheckoutNotifier {
   Future<void> cancelCheckout(String checkoutId) async {
     final repository = ref.read(ticketRepositoryProvider);
     await repository.cancelCheckout(checkoutId);
-    ref.invalidateSelf(asReload: true);
+    ref.invalidate(ticketItemsProvider, asReload: true);
   }
 }

--- a/apps/app/lib/features/ticket/data/notifier/ticket_checkout_notifier.g.dart
+++ b/apps/app/lib/features/ticket/data/notifier/ticket_checkout_notifier.g.dart
@@ -37,7 +37,7 @@ final class TicketCheckoutNotifierProvider
 }
 
 String _$ticketCheckoutNotifierHash() =>
-    r'7fa9f1e801057293ef027439f9c9a1797fb1b4d1';
+    r'7ba36c969df7e49ce3a26645da64f1000ca03f0c';
 
 abstract class _$TicketCheckoutNotifier
     extends $AsyncNotifier<List<TicketCheckoutItem>> {


### PR DESCRIPTION
## Issue

<!-- Issueがないため空欄 -->

## 概要

チケット決済ボタンをタップした際のリロード処理を修正し、適切なプロバイダーを無効化するように変更しました。

## 詳細

### 変更内容
- `TicketCheckoutNotifier`の`createCheckout`と`cancelCheckout`メソッドで、`ref.invalidateSelf(asReload: true)`から`ref.invalidate(ticketItemsProvider, asReload: true)`に変更
- `onDispose`での`ticketItemsProvider`の無効化処理を削除

### 変更理由
- 決済処理後に`ticketItemsProvider`を直接無効化することで、チケット情報が適切に更新されるように修正
- 不要な`onDispose`処理を削除してコードを簡潔化

### 影響範囲
- チケット決済フローのみ
- 他の機能への影響なし

## 画像・動画

https://github.com/user-attachments/assets/41c435ad-f1be-4e7c-93be-a7946805820c

## その他

<!-- 特になし -->