### PR TITLE
feat: スポンサー機能を一時的に無効化

### DIFF
--- a/apps/app/lib/core/router/router.dart
+++ b/apps/app/lib/core/router/router.dart
@@ -18,6 +18,7 @@ import 'package:app/features/sponsor/ui/sponsor_list_screen.dart';
 import 'package:app/features/ticket/ui/components/available_ticket_list_screen.dart';
 import 'package:app/features/ticket/ui/components/ticket_list_screen.dart';
 import 'package:app/features/ticket/ui/ticket_screen.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -56,7 +57,14 @@ GoRouter router(Ref ref) {
     observers: _rootObservers,
     routes: [
       $loginRoute,
-      $mainRoute,
+      StatefulShellRouteData.$route(
+        factory: $MainRouteExtension._fromState,
+        branches: ($mainRoute as StatefulShellRoute).branches
+            .whereNot(
+              (branch) => branch.defaultRoute?.path == '/sponsors',
+            )
+            .toList(),
+      ),
       if (kDebugMode) $debugRoute,
     ],
     errorBuilder: (context, state) => const NotFoundScreen(),

--- a/apps/app/lib/core/ui/main/main_screen.dart
+++ b/apps/app/lib/core/ui/main/main_screen.dart
@@ -26,7 +26,8 @@ class MainScreen extends StatelessWidget {
       currentIndex: navigationShell.currentIndex,
       destinations: const [
         ResponsiveScaffoldDestination(icon: Icons.event, title: 'イベント'),
-        ResponsiveScaffoldDestination(icon: Icons.business, title: 'スポンサー'),
+        // TODO: スポンサーの表示修正完了後に復活予定
+        // ResponsiveScaffoldDestination(icon: Icons.business, title: 'スポンサー'),
         ResponsiveScaffoldDestination(
           icon: Icons.confirmation_number,
           title: 'チケット',


### PR DESCRIPTION
## 概要

スポンサー機能を一時的に無効化し、後で簡単に再有効化できる状態を維持

## 詳細

- ルーターからSponsorBranchを動的に除外する方法を採用
- `$mainRoute`の`branches`から`/sponsors`パスを持つブランチを`whereNot`メソッドで動的に除外
- `MainScreen`のスポンサータブをコメントアウトしてUIレベルでも無効化
- `SponsorBranch`の定義や`$SponsorDetailRoute`などの生成されたコードは保持
- 後で再有効化する際は、コメントアウトされた部分を元に戻すだけで済む設計

https://github.com/user-attachments/assets/6dbfb1fe-de00-4e02-8e18-60f2582323d4

## その他

- `collection`パッケージの`whereNot`メソッドを使用してブランチを動的に除外
- コード生成に必要な定義は全て維持されているため、将来的な再有効化が容易