### PR TITLE
fix: アカウント情報画面のUIを改善

### DIFF
--- a/apps/app/lib/features/account/ui/info/account_info_screen.dart
+++ b/apps/app/lib/features/account/ui/info/account_info_screen.dart
@@ -53,17 +53,23 @@ final class AccountInfoScreen extends ConsumerWidget {
           child: CircularProgressIndicator(),
         ),
         data: (user) => ListView(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.symmetric(vertical: 16),
           children: [
             if (user != null)
-              _UserInfoCard(
-                user: user,
-                onProfileEdit: _onProfileEdit,
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: _UserInfoCard(
+                  user: user,
+                  onProfileEdit: _onProfileEdit,
+                ),
               ),
             const SizedBox(height: 16),
-            Text(
-              l10n.accountOthers,
-              style: textTheme.titleLarge,
+            Padding(
+              padding: const EdgeInsetsDirectional.only(start: 16),
+              child: Text(
+                l10n.accountOthers,
+                style: textTheme.titleLarge,
+              ),
             ),
             const SizedBox(height: 8),
             ...([


### PR DESCRIPTION
- ユーザー情報カードの周囲にパディングを追加
- アカウントの他の情報のテキストにパディングを追加し、レイアウトを整えた
