### PR TITLE
プロフィールのひとことコメント機能を削除

### DIFF
--- a/apps/app/lib/features/account/ui/profile_edit_screen.dart
+++ b/apps/app/lib/features/account/ui/profile_edit_screen.dart
@@ -25,7 +25,6 @@ class ProfileEditScreen extends HookConsumerWidget {
     WidgetRef ref,
     GlobalKey<FormState> formKey,
     TextEditingController nameController,
-    TextEditingController commentController,
     bool isAdult,
     List<SnsLinkFormData> snsLinks,
   ) async {
@@ -65,13 +64,11 @@ class ProfileEditScreen extends HookConsumerWidget {
           )
           .toList();
 
-      final avatarKey = ref
-          .read(profileNotifierProvider)
-          .value?.avatarKey;
+      final avatarKey = ref.read(profileNotifierProvider).value?.avatarKey;
       final request = ProfileUpdateRequest(
         name: nameController.text.trim(),
-        comment: commentController.text.trim(),
         isAdult: isAdult,
+        comment: '',
         snsLinks: validSnsLinks,
         avatarKey: avatarKey,
       );
@@ -123,7 +120,6 @@ class ProfileEditScreen extends HookConsumerWidget {
 
     final formKey = useMemoized(GlobalKey<FormState>.new);
     final nameController = useTextEditingController();
-    final commentController = useTextEditingController();
     final snsLinksState = useState<List<SnsLinkFormData>>([]);
     final isAdultState = useState(false);
 
@@ -139,7 +135,6 @@ class ProfileEditScreen extends HookConsumerWidget {
               ref,
               formKey,
               nameController,
-              commentController,
               isAdultState.value,
               snsLinksState.value,
             ),
@@ -166,7 +161,6 @@ class ProfileEditScreen extends HookConsumerWidget {
           useEffect(() {
             if (profile != null && nameController.text.isEmpty) {
               nameController.text = profile.profile.name;
-              commentController.text = profile.profile.comment;
               isAdultState.value = profile.profile.isAdult;
               // 既存のSNSリンクがある場合は初期化
               if (profile.snsLinks.isNotEmpty) {
@@ -266,28 +260,6 @@ class ProfileEditScreen extends HookConsumerWidget {
                       validator: (value) {
                         if (value == null || value.trim().isEmpty) {
                           return '名前を入力してください';
-                        }
-                        return null;
-                      },
-                      onChanged: (value) {},
-                    ),
-                    const SizedBox(height: 16),
-
-                    // ひとことコメント
-                    TextFormField(
-                      controller: commentController,
-                      decoration: const InputDecoration(
-                        labelText: 'ひとことコメント *',
-                        border: OutlineInputBorder(),
-                        helperText: '100文字以内',
-                      ),
-                      maxLength: 100,
-                      validator: (value) {
-                        if (value == null || value.trim().isEmpty) {
-                          return 'ひとことコメントを入力してください';
-                        }
-                        if (value.length > 100) {
-                          return 'ひとことコメントは100文字以内で入力してください';
                         }
                         return null;
                       },

--- a/apps/app/lib/features/account/ui/profile_view_screen.dart
+++ b/apps/app/lib/features/account/ui/profile_view_screen.dart
@@ -144,14 +144,6 @@ class ProfileViewScreen extends HookConsumerWidget {
                         ),
                         const SizedBox(height: 8),
 
-                        // ひとことコメント
-                        Text(
-                          profile.profile.comment,
-                          style: Theme.of(context).textTheme.bodyLarge,
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 16),
-
                         // 成人フラグ
                         Row(
                           mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
## Issue

Issue番号なし

## 概要

プロフィールの「ひとことコメント」機能を削除しました。

## 詳細

以下の変更を行いました：

- `ProfileEditScreen`からコメント入力フィールドとその関連ロジックを削除
- `ProfileViewScreen`からコメント表示部分を削除
- `ProfileUpdateRequest`でコメントを空文字列で固定送信するように変更
- コメント関連のバリデーションロジックを削除

これにより、プロフィール機能がシンプルになり、ユーザーは名前、成人確認、SNSリンクのみを管理できるようになります。

## 画像・動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

| Before | After | Design |
| ------ | ----- | ------ |
| コメント入力フィールドあり | コメント入力フィールドなし |        |

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->