### PR TITLE
fix: イベント情報画面の曜日を正しい木曜日に修正

### DIFF
--- a/apps/app/lib/core/gen/l10n/l10n.dart
+++ b/apps/app/lib/core/gen/l10n/l10n.dart
@@ -132,7 +132,7 @@ abstract class L10n {
   /// No description provided for @eventDate.
   ///
   /// In ja, this message translates to:
-  /// **'2025年11月13日(金)'**
+  /// **'2025年11月13日(木)'**
   String get eventDate;
 
   /// No description provided for @eventTime.

--- a/apps/app/lib/core/gen/l10n/l10n_ja.dart
+++ b/apps/app/lib/core/gen/l10n/l10n_ja.dart
@@ -28,7 +28,7 @@ class L10nJa extends L10n {
       '2025年、日本国内で Flutter をメインに扱う技術カンファレンス。Flutter や Dart の深い知見を持つ開発者によるセッションを多数企画します。';
 
   @override
-  String get eventDate => '2025年11月13日(金)';
+  String get eventDate => '2025年11月13日(木)';
 
   @override
   String get eventTime => '10:00 ~ 18:00';

--- a/apps/app/res/l10n/app_ja.arb
+++ b/apps/app/res/l10n/app_ja.arb
@@ -12,7 +12,7 @@
   "@newsEmptyMessage": {},
   "eventDescription": "2025年、日本国内で Flutter をメインに扱う技術カンファレンス。Flutter や Dart の深い知見を持つ開発者によるセッションを多数企画します。",
   "@eventDescription": {},
-  "eventDate": "2025年11月13日(金)",
+  "eventDate": "2025年11月13日(木)",
   "@eventDate": {},
   "eventTime": "10:00 ~ 18:00",
   "@eventTime": {},


### PR DESCRIPTION
## 概要
イベント情報画面で表示されている曜日が間違っていた問題を修正しました。

## 問題
- 2025年11月13日は木曜日だが、アプリでは「2025年11月13日(金)」と金曜日で表示されていた

## 修正内容
- `apps/app/res/l10n/app_ja.arb`の`eventDate`を「2025年11月13日(金)」から「2025年11月13日(木)」に変更
- ローカライゼーションファイルを再生成して自動生成ファイルも更新

## 確認方法
1. アプリを起動
2. イベント情報画面を表示
3. 日付が「2025年11月13日(木)」と正しく表示されることを確認

## 関連Issue
Fixes #406

## 画像

<img width="779" height="1231" alt="スクリーンショット 2025-09-09 19 42 52" src="https://github.com/user-attachments/assets/63d01056-0eb7-40d2-98fd-07195676602c" />
