### PR TITLE
fix: production環境のCORS設定にlocalhostを追加

### DIFF
--- a/bff/bridge/src/index.ts
+++ b/bff/bridge/src/index.ts
@@ -7,62 +7,62 @@ import { secureHeaders } from "hono/secure-headers";
 import { timing } from "hono/timing";
 
 const env = workersEnv as Cloudflare.Env & {
-  ENVIRONMENT: "development" | "staging" | "production";
+	ENVIRONMENT: "development" | "staging" | "production";
 };
 
 const app = new Hono()
-  .onError((err, c) => {
-    console.error(err);
-    return c.json({ message: "Internal Server Error", error: err }, 500);
-  })
-  .use(
-    timing({
-      autoEnd: true,
-    })
-  )
-  // CORS
-  .use("*", async (c, next) => {
-    const corsMiddlewareHandler = cors({
-      origin: (origin) => {
-        if (!origin) return null;
+	.onError((err, c) => {
+		console.error(err);
+		return c.json({ message: "Internal Server Error", error: err }, 500);
+	})
+	.use(
+		timing({
+			autoEnd: true,
+		}),
+	)
+	// CORS
+	.use("*", async (c, next) => {
+		const corsMiddlewareHandler = cors({
+			origin: (origin) => {
+				if (!origin) return null;
 
-        switch (env.ENVIRONMENT) {
-          case "development": {
-            return "*";
-          }
-          case "staging": {
-            return origin.endsWith("flutter-kaigi.workers.dev")
-              ? origin
-              : "http://localhost:8080";
-          }
-          case "production": {
-            return "https://2025-app.flutterkaigi.jp";
-          }
-        }
-      },
-    });
-    return corsMiddlewareHandler(c, next);
-  })
-  // CSRF
-  .use("*", csrf())
-  // Secure Headers
-  .use("*", secureHeaders())
-  .all("*", async (c) => {
-    const originalUrl = new URL(c.req.url);
-    const host = env.BFF_API_HOST;
-    const targetUrl = new URL(originalUrl.toString());
-    targetUrl.host = host;
-    targetUrl.search = originalUrl.search;
-    console.log("targetUrl", targetUrl.toString());
+				switch (env.ENVIRONMENT) {
+					case "development": {
+						return "*";
+					}
+					case "staging": {
+						return origin.endsWith("flutter-kaigi.workers.dev")
+							? origin
+							: "http://localhost:8080";
+					}
+					case "production": {
+						return "https://2025-app.flutterkaigi.jp";
+					}
+				}
+			},
+		});
+		return corsMiddlewareHandler(c, next);
+	})
+	// CSRF
+	.use("*", csrf())
+	// Secure Headers
+	.use("*", secureHeaders())
+	.all("*", async (c) => {
+		const originalUrl = new URL(c.req.url);
+		const host = env.BFF_API_HOST;
+		const targetUrl = new URL(originalUrl.toString());
+		targetUrl.host = host;
+		targetUrl.search = originalUrl.search;
+		console.log("targetUrl", targetUrl.toString());
 
-    const response = await proxy(targetUrl.toString(), {
-      ...c.req,
-      headers: {
-        ...c.req.header(),
-        "X-Forwarded-Host": c.req.header("host"),
-      },
-    });
-    return response;
-  });
+		const response = await proxy(targetUrl.toString(), {
+			...c.req,
+			headers: {
+				...c.req.header(),
+				"X-Forwarded-Host": c.req.header("host"),
+			},
+		});
+		return response;
+	});
 
 export default app;

--- a/bff/bridge/src/index.ts
+++ b/bff/bridge/src/index.ts
@@ -36,7 +36,9 @@ const app = new Hono()
 							: "http://localhost:8080";
 					}
 					case "production": {
-						return "https://2025-app.flutterkaigi.jp";
+						return origin === "https://2025-app.flutterkaigi.jp"
+							? origin
+							: "http://localhost:8080";
 					}
 				}
 			},


### PR DESCRIPTION
## 概要
本番環境のCORS設定でlocalhostの設定が抜けていたため、修正しました。

## 変更内容
- `bff/bridge/src/index.ts`のproduction環境のCORS設定を修正
- `https://2025-app.flutterkaigi.jp`と`http://localhost:8080`の両方を許可するように変更

## 変更前
```typescript
case "production": {
  return "https://2025-app.flutterkaigi.jp";
}
```

## 変更後
```typescript
case "production": {
  return origin === "https://2025-app.flutterkaigi.jp"
    ? origin
    : "http://localhost:8080";
}
```

## 影響範囲
- 本番環境でのlocalhostアクセスが可能になります
- セキュリティ制限は適切に維持されます

## テスト
- [ ] 本番環境でlocalhostからのアクセスが正常に動作することを確認
- [ ] 不正なoriginからのアクセスが適切に拒否されることを確認