### PR TITLE
fix: resolve port conflict between Flutter app and BFF engine

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
         "environments/.env.dev",
         "--web-experimental-hot-reload",
         "--web-port",
-        "8080"
+        "3000"
       ]
     },
     {
@@ -33,7 +33,7 @@
         "environments/.env.stg",
         "--web-experimental-hot-reload",
         "--web-port",
-        "8080"
+        "3000"
       ]
     },
     {
@@ -47,7 +47,7 @@
         "environments/.env.prod",
         "--web-experimental-hot-reload",
         "--web-port",
-        "8080"
+        "3000"
       ]
     }
   ]

--- a/bff/bridge/src/index.ts
+++ b/bff/bridge/src/index.ts
@@ -33,12 +33,12 @@ const app = new Hono()
 					case "staging": {
 						return origin.endsWith("flutter-kaigi.workers.dev")
 							? origin
-							: "http://localhost:8080";
+							: "http://localhost:3000";
 					}
 					case "production": {
 						return origin === "https://2025-app.flutterkaigi.jp"
 							? origin
-							: "http://localhost:8080";
+							: "http://localhost:3000";
 					}
 				}
 			},

--- a/bff/engine/lib/main.dart
+++ b/bff/engine/lib/main.dart
@@ -1,9 +1,11 @@
 import 'dart:io';
 
+import 'package:engine/provider/environments_provider.dart';
 import 'package:engine/routes/api_service.dart';
-import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:riverpod/riverpod.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:shelf_cors_headers/shelf_cors_headers.dart';
 
 // ignore: unreachable_from_main
 final ProviderContainer container = ProviderContainer();
@@ -12,10 +14,23 @@ Future<void> main() async {
   print('Starting server...');
 
   final apiService = ApiService();
+  final pipeline = const Pipeline().addMiddleware(logRequests());
 
-  final handler = const Pipeline()
-      .addMiddleware(logRequests())
-      .addHandler(apiService.handler);
+  final Handler handler;
+  if (container.read(
+    environmentsProvider.select((e) => e.isLocal),
+  )) {
+    // ローカル環境の場合は `http://localhost:3000` からのリクエストを許可
+    handler = pipeline
+        .addMiddleware(
+          corsHeaders(
+            originChecker: (origin) => origin == 'http://localhost:3000',
+          ),
+        )
+        .addHandler(apiService.handler);
+  } else {
+    handler = pipeline.addHandler(apiService.handler);
+  }
 
   final server = await shelf_io.serve(
     handler,

--- a/bff/engine/pubspec.yaml
+++ b/bff/engine/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   riverpod: ^3.0.0-dev.17
   riverpod_annotation: ^3.0.0-dev.17
   shelf: ^1.4.0
+  shelf_cors_headers: ^0.1.5
   shelf_router: ^1.1.4
   supabase: ^2.7.0
   uuid: ^4.5.1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1406,6 +1406,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
+  shelf_cors_headers:
+    dependency: transitive
+    description:
+      name: shelf_cors_headers
+      sha256: a127c80f99bbef3474293db67a7608e3a0f1f0fcdb171dad77fa9bd2cd123ae4
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.5"
   shelf_gzip:
     dependency: transitive
     description:

--- a/terraform/supabase/production.tf
+++ b/terraform/supabase/production.tf
@@ -47,6 +47,6 @@ resource "supabase_settings" "production" {
     external_google_secret                = var.SUPABASE_GOOGLE_AUTH_CLIENT_SECRET
     external_google_skip_nonce_check      = true
     security_manual_linking_enabled       = true
-    uri_allow_list                        = "http://localhost:8080,https://2025-app.flutterkaigi.jp,https://*.2025-app.flutterkaigi.jp,jp.flutterkaigi.conf2025://login-callback"
+    uri_allow_list                        = "http://localhost:3000,https://2025-app.flutterkaigi.jp,https://*.2025-app.flutterkaigi.jp,jp.flutterkaigi.conf2025://login-callback"
   })
 }

--- a/terraform/supabase/staging.tf
+++ b/terraform/supabase/staging.tf
@@ -47,6 +47,6 @@ resource "supabase_settings" "staging" {
     external_google_secret                = var.SUPABASE_GOOGLE_AUTH_CLIENT_SECRET
     external_google_skip_nonce_check      = true
     security_manual_linking_enabled       = true
-    uri_allow_list                        = "http://localhost:8080,https://*.flutter-kaigi.workers.dev,jp.flutterkaigi.conf2025.stg://login-callback"
+    uri_allow_list                        = "http://localhost:3000,https://*.flutter-kaigi.workers.dev,jp.flutterkaigi.conf2025.stg://login-callback"
   })
 }


### PR DESCRIPTION
## 概要
FlutterアプリとBFFエンジンが同じポート8080を使用していたため、開発環境でポート競合が発生していました。この問題を解決するため、ポート番号を適切に分離しました。

## 変更内容
- **Flutterアプリ**: ポート8080 → 3000（フロントエンド開発の標準）
- **BFFエンジン**: ポート8080のまま（APIサーバー）
- **CORS設定**: `localhost:3000`を許可するよう更新
- **Terraform設定**: Supabaseの`uri_allow_list`を`localhost:3000`に更新

## 影響範囲
- 開発環境でのポート競合が解消される
- ステージング・本番環境での認証フローが正常に動作する
- CORS設定が適切に更新される

## テスト
- [ ] 開発環境でFlutterアプリとBFFエンジンが同時に動作することを確認
- [ ] 認証フローが正常に動作することを確認

## 関連Issue
ポート競合による開発環境の動作不良