### PR TITLE
Dioの例外の場合、レスポンスの中身を見てエラーメッセージを表示する

### DIFF
--- a/apps/app/lib/core/designsystem/components/error_view.dart
+++ b/apps/app/lib/core/designsystem/components/error_view.dart
@@ -16,32 +16,31 @@ class ErrorView extends StatelessWidget {
   final VoidCallback? onRetry;
   final bool? isRetrying;
 
-  String _getErrorMessage() {
-    if (error is DioException) {
-      final dioError = error as DioException;
-      final response = dioError.response;
-
-      if (response?.data != null) {
-        final data = response!.data;
-
-        // dataがMapで、messageキーが含まれている場合
-        if (data is Map && data.containsKey('message')) {
-          return data['message'].toString();
-        }
-
-        // それ以外の場合はJSONとして表示を試みる
-        try {
-          if (data is Map || data is List) {
-            return const JsonEncoder.withIndent('  ').convert(data);
-          }
-          return data.toString();
-        } on Exception catch (_) {
-          return data.toString();
-        }
-      }
+  String _getErrorMessage(Object error) {
+    if (error is! DioException) {
+      return error.toString();
     }
 
-    return error.toString();
+    final data = error.response?.data;
+
+    if (data == null) {
+      return error.toString();
+    }
+    if (data is! Map && data is! List) {
+      return data.toString();
+    }
+
+    // dataがMapで、messageキーが含まれている場合
+    if (data is Map && data.containsKey('message')) {
+      return data['message'].toString();
+    }
+
+    // それ以外の場合はJSONとして表示を試みる
+    try {
+      return const JsonEncoder.withIndent('  ').convert(data);
+    } on Exception catch (_) {
+      return data.toString();
+    }
   }
 
   @override
@@ -82,7 +81,7 @@ class ErrorView extends StatelessWidget {
                   ],
                 ),
                 Text(
-                  _getErrorMessage(),
+                  _getErrorMessage(error),
                   textAlign: TextAlign.center,
                   style: theme.textTheme.bodyMedium,
                 ),


### PR DESCRIPTION
## Issue

Closes #432

## 概要

- エラー画面上で、Dioのエラーの場合にエラーレスポンスを表示する処理を追加しました。

<!--
必ず書いてください。
やったことをわかりやすく短く書いてください。
-->

## 詳細

- APIを叩いた際の例外で、Dioの例外メッセージがそのまま出ている事象に対する対応を実施しました。
- エラーメッセージ取得用のメソッドを追加して、エラーオブジェクトがDioExceptionの場合は、中身を見て表示するようにしました。


<!--
可能であれば、変更した内容と変更した理由や背景を書いてください。
-->

## 画像・動画

### 画面

<img width="300" alt="image" src="https://github.com/user-attachments/assets/69bd7fe9-126d-4575-ba6b-e74690b35e21" />

### 確認用のコード

<img width="527" height="240" alt="image" src="https://github.com/user-attachments/assets/9a423083-da71-490b-b088-059e522eb41e" />

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
