### PR TITLE
chore(slang): アカウント関連の英語翻訳を追加

### DIFF
--- a/apps/app/lib/core/gen/i18n/i18n.g.dart
+++ b/apps/app/lib/core/gen/i18n/i18n.g.dart
@@ -3,8 +3,8 @@
 /// Source: res/i18n
 /// To regenerate, run: `dart run slang`
 ///
-/// Locales: 1
-/// Strings: 150
+/// Locales: 2
+/// Strings: 213 (106 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
@@ -15,6 +15,7 @@ import 'package:slang/generated.dart';
 import 'package:slang_flutter/slang_flutter.dart';
 export 'package:slang_flutter/slang_flutter.dart';
 
+import 'i18n_en.g.dart' deferred as l_en;
 part 'i18n_ja.g.dart';
 
 /// Supported locales.
@@ -24,7 +25,8 @@ part 'i18n_ja.g.dart';
 /// - Locale locale = AppLocale.ja.flutterLocale // get flutter locale from enum
 /// - if (LocaleSettings.currentLocale == AppLocale.ja) // locale check
 enum AppLocale with BaseAppLocale<AppLocale, Translations> {
-	ja(languageCode: 'ja');
+	ja(languageCode: 'ja'),
+	en(languageCode: 'en');
 
 	const AppLocale({
 		required this.languageCode,
@@ -49,6 +51,13 @@ enum AppLocale with BaseAppLocale<AppLocale, Translations> {
 					cardinalResolver: cardinalResolver,
 					ordinalResolver: ordinalResolver,
 				);
+			case AppLocale.en:
+				await l_en.loadLibrary();
+				return l_en.TranslationsEn(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
 		}
 	}
 
@@ -61,6 +70,12 @@ enum AppLocale with BaseAppLocale<AppLocale, Translations> {
 		switch (this) {
 			case AppLocale.ja:
 				return TranslationsJa(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.en:
+				return l_en.TranslationsEn(
 					overrides: overrides,
 					cardinalResolver: cardinalResolver,
 					ordinalResolver: ordinalResolver,

--- a/apps/app/lib/core/gen/i18n/i18n_en.g.dart
+++ b/apps/app/lib/core/gen/i18n/i18n_en.g.dart
@@ -1,0 +1,248 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+
+import 'i18n.g.dart';
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+
+// Path: <root>
+class TranslationsEn extends Translations {
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	TranslationsEn({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.en,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ),
+		  super(cardinalResolver: cardinalResolver, ordinalResolver: ordinalResolver) {
+		super.$meta.setFlatMapFunction($meta.getTranslation); // copy base translations to super.$meta
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <en>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	@override dynamic operator[](String key) => $meta.getTranslation(key) ?? super.$meta.getTranslation(key);
+
+	late final TranslationsEn _root = this; // ignore: unused_field
+
+	@override 
+	TranslationsEn $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => TranslationsEn(meta: meta ?? this.$meta);
+
+	// Translations
+	@override late final _TranslationsAccountEn account = _TranslationsAccountEn._(_root);
+}
+
+// Path: account
+class _TranslationsAccountEn extends TranslationsAccountJa {
+	_TranslationsAccountEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get profileEdit => 'Edit Profile';
+	@override String get guestUserLabel => 'Guest Mode';
+	@override String get others => 'Others';
+	@override String get codeOfConduct => 'Code of Conduct';
+	@override String get codeOfConductUrl => 'https://docs.flutterkaigi.jp/Code-of-Conduct';
+	@override String get privacyPolicy => 'Privacy Policy';
+	@override String get privacyPolicyUrl => 'https://docs.flutterkaigi.jp/Privacy-Policy';
+	@override String get contact => 'Contact Us';
+	@override String get contactUrl => 'https://docs.google.com/forms/d/e/1FAIpQLSemYPFEWpP8594MWI4k3Nz45RJzMS7pz1ufwtnX4t3V7z2TOw/viewform';
+	@override String get ossLicenses => 'OSS Licenses';
+	@override String get logout => 'Sign Out';
+	@override String get settings => 'Account Settings';
+	@override late final _TranslationsAccountProfileEn profile = _TranslationsAccountProfileEn._(_root);
+}
+
+// Path: account.profile
+class _TranslationsAccountProfileEn extends TranslationsAccountProfileJa {
+	_TranslationsAccountProfileEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Profile';
+	@override String get editTitle => 'Edit Profile';
+	@override String get createInfo => 'Please create profile information';
+	@override String get edit => 'Edit Profile';
+	@override String get notFound => 'Profile not found';
+	@override String get saving => 'Saving...';
+	@override String get save => 'Save';
+	@override String get saveSuccess => 'Profile saved';
+	@override String get saveFailed => 'Failed to save';
+	@override String get errorOccurred => 'An error occurred';
+	@override String get ageOver20 => '20 or older';
+	@override String get ageUnder20 => 'Under 20';
+	@override String get nameLabel => 'Name *';
+	@override String get nameRequired => 'Please enter your name';
+	@override String get upload => 'Upload';
+	@override String get delete => 'Delete';
+	@override String get snsLinks => 'Social Links';
+	@override String get add => 'Add';
+	@override late final _TranslationsAccountProfileAvatarEn avatar = _TranslationsAccountProfileAvatarEn._(_root);
+	@override late final _TranslationsAccountProfileSnsEn sns = _TranslationsAccountProfileSnsEn._(_root);
+	@override late final _TranslationsAccountProfileImageEn image = _TranslationsAccountProfileImageEn._(_root);
+}
+
+// Path: account.profile.avatar
+class _TranslationsAccountProfileAvatarEn extends TranslationsAccountProfileAvatarJa {
+	_TranslationsAccountProfileAvatarEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get deleteSuccess => 'Avatar removed successfully';
+	@override String get changeFailed => 'Could not update avatar';
+	@override String get changeSuccess => 'Avatar updated successfully';
+}
+
+// Path: account.profile.sns
+class _TranslationsAccountProfileSnsEn extends TranslationsAccountProfileSnsJa {
+	_TranslationsAccountProfileSnsEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get notLinked => 'No social links registered';
+	@override String get type => 'Platform';
+	@override String get urlOrUserId => 'URL/User ID';
+	@override String get urlOrUserIdRequired => 'Please enter URL/User ID';
+	@override String get other => 'Other';
+	@override String get fullUrlRequired => 'Please enter full URL';
+	@override String get userIdOnly => 'User ID only';
+	@override String get alphanumericOnly => 'Only letters, numbers, underscore and hyphen allowed';
+	@override late final _TranslationsAccountProfileSnsExamplesEn examples = _TranslationsAccountProfileSnsExamplesEn._(_root);
+	@override late final _TranslationsAccountProfileSnsDisplayNamesEn displayNames = _TranslationsAccountProfileSnsDisplayNamesEn._(_root);
+}
+
+// Path: account.profile.image
+class _TranslationsAccountProfileImageEn extends TranslationsAccountProfileImageJa {
+	_TranslationsAccountProfileImageEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get selectTitle => 'Select Image';
+	@override String get selectMessage => 'Please select an image';
+	@override String get selectButton => 'Select Image';
+	@override String get useGooglePhoto => 'Use Google Account Photo';
+	@override String get cropTitle => 'Crop Image';
+	@override String get complete => 'Complete';
+	@override String get crop => 'Crop';
+	@override String get reset => 'Reset';
+}
+
+// Path: account.profile.sns.examples
+class _TranslationsAccountProfileSnsExamplesEn extends TranslationsAccountProfileSnsExamplesJa {
+	_TranslationsAccountProfileSnsExamplesEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get github => 'e.g. octocat';
+	@override String get x => 'e.g. twitter';
+	@override String get discord => 'e.g. 123456789012345678 (User ID)';
+	@override String get medium => 'e.g. username';
+	@override String get qiita => 'e.g. username';
+	@override String get zenn => 'e.g. username';
+	@override String get note => 'e.g. username';
+}
+
+// Path: account.profile.sns.displayNames
+class _TranslationsAccountProfileSnsDisplayNamesEn extends TranslationsAccountProfileSnsDisplayNamesJa {
+	_TranslationsAccountProfileSnsDisplayNamesEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get github => 'GitHub';
+	@override String get x => 'X (Twitter)';
+	@override String get discord => 'Discord';
+	@override String get medium => 'Medium';
+	@override String get qiita => 'Qiita';
+	@override String get zenn => 'Zenn';
+	@override String get note => 'note';
+}
+
+/// Flat map(s) containing all translations.
+/// Only for edge cases! For simple maps, use the map function of this library.
+extension on TranslationsEn {
+	dynamic _flatMapFunction(String path) {
+		switch (path) {
+			case 'account.profileEdit': return 'Edit Profile';
+			case 'account.guestUserLabel': return 'Guest Mode';
+			case 'account.others': return 'Others';
+			case 'account.codeOfConduct': return 'Code of Conduct';
+			case 'account.codeOfConductUrl': return 'https://docs.flutterkaigi.jp/Code-of-Conduct';
+			case 'account.privacyPolicy': return 'Privacy Policy';
+			case 'account.privacyPolicyUrl': return 'https://docs.flutterkaigi.jp/Privacy-Policy';
+			case 'account.contact': return 'Contact Us';
+			case 'account.contactUrl': return 'https://docs.google.com/forms/d/e/1FAIpQLSemYPFEWpP8594MWI4k3Nz45RJzMS7pz1ufwtnX4t3V7z2TOw/viewform';
+			case 'account.ossLicenses': return 'OSS Licenses';
+			case 'account.logout': return 'Sign Out';
+			case 'account.settings': return 'Account Settings';
+			case 'account.profile.title': return 'Profile';
+			case 'account.profile.editTitle': return 'Edit Profile';
+			case 'account.profile.createInfo': return 'Please create profile information';
+			case 'account.profile.edit': return 'Edit Profile';
+			case 'account.profile.notFound': return 'Profile not found';
+			case 'account.profile.saving': return 'Saving...';
+			case 'account.profile.save': return 'Save';
+			case 'account.profile.saveSuccess': return 'Profile saved';
+			case 'account.profile.saveFailed': return 'Failed to save';
+			case 'account.profile.errorOccurred': return 'An error occurred';
+			case 'account.profile.ageOver20': return '20 or older';
+			case 'account.profile.ageUnder20': return 'Under 20';
+			case 'account.profile.nameLabel': return 'Name *';
+			case 'account.profile.nameRequired': return 'Please enter your name';
+			case 'account.profile.upload': return 'Upload';
+			case 'account.profile.delete': return 'Delete';
+			case 'account.profile.snsLinks': return 'Social Links';
+			case 'account.profile.add': return 'Add';
+			case 'account.profile.avatar.deleteSuccess': return 'Avatar removed successfully';
+			case 'account.profile.avatar.changeFailed': return 'Could not update avatar';
+			case 'account.profile.avatar.changeSuccess': return 'Avatar updated successfully';
+			case 'account.profile.sns.notLinked': return 'No social links registered';
+			case 'account.profile.sns.type': return 'Platform';
+			case 'account.profile.sns.urlOrUserId': return 'URL/User ID';
+			case 'account.profile.sns.urlOrUserIdRequired': return 'Please enter URL/User ID';
+			case 'account.profile.sns.other': return 'Other';
+			case 'account.profile.sns.fullUrlRequired': return 'Please enter full URL';
+			case 'account.profile.sns.userIdOnly': return 'User ID only';
+			case 'account.profile.sns.alphanumericOnly': return 'Only letters, numbers, underscore and hyphen allowed';
+			case 'account.profile.sns.examples.github': return 'e.g. octocat';
+			case 'account.profile.sns.examples.x': return 'e.g. twitter';
+			case 'account.profile.sns.examples.discord': return 'e.g. 123456789012345678 (User ID)';
+			case 'account.profile.sns.examples.medium': return 'e.g. username';
+			case 'account.profile.sns.examples.qiita': return 'e.g. username';
+			case 'account.profile.sns.examples.zenn': return 'e.g. username';
+			case 'account.profile.sns.examples.note': return 'e.g. username';
+			case 'account.profile.sns.displayNames.github': return 'GitHub';
+			case 'account.profile.sns.displayNames.x': return 'X (Twitter)';
+			case 'account.profile.sns.displayNames.discord': return 'Discord';
+			case 'account.profile.sns.displayNames.medium': return 'Medium';
+			case 'account.profile.sns.displayNames.qiita': return 'Qiita';
+			case 'account.profile.sns.displayNames.zenn': return 'Zenn';
+			case 'account.profile.sns.displayNames.note': return 'note';
+			case 'account.profile.image.selectTitle': return 'Select Image';
+			case 'account.profile.image.selectMessage': return 'Please select an image';
+			case 'account.profile.image.selectButton': return 'Select Image';
+			case 'account.profile.image.useGooglePhoto': return 'Use Google Account Photo';
+			case 'account.profile.image.cropTitle': return 'Crop Image';
+			case 'account.profile.image.complete': return 'Complete';
+			case 'account.profile.image.crop': return 'Crop';
+			case 'account.profile.image.reset': return 'Reset';
+			default: return null;
+		}
+	}
+}
+

--- a/apps/app/lib/core/gen/i18n/i18n_ja.g.dart
+++ b/apps/app/lib/core/gen/i18n/i18n_ja.g.dart
@@ -39,18 +39,18 @@ class Translations implements BaseTranslations<AppLocale, Translations> {
 	Translations $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => Translations(meta: meta ?? this.$meta);
 
 	// Translations
-	late final TranslationsAccountJa account = TranslationsAccountJa._(_root);
-	late final TranslationsAuthJa auth = TranslationsAuthJa._(_root);
-	late final TranslationsCommonJa common = TranslationsCommonJa._(_root);
-	late final TranslationsEventJa event = TranslationsEventJa._(_root);
-	late final TranslationsNewsJa news = TranslationsNewsJa._(_root);
-	late final TranslationsSponsorJa sponsor = TranslationsSponsorJa._(_root);
-	late final TranslationsTicketJa ticket = TranslationsTicketJa._(_root);
+	late final TranslationsAccountJa account = TranslationsAccountJa.internal(_root);
+	late final TranslationsAuthJa auth = TranslationsAuthJa.internal(_root);
+	late final TranslationsCommonJa common = TranslationsCommonJa.internal(_root);
+	late final TranslationsEventJa event = TranslationsEventJa.internal(_root);
+	late final TranslationsNewsJa news = TranslationsNewsJa.internal(_root);
+	late final TranslationsSponsorJa sponsor = TranslationsSponsorJa.internal(_root);
+	late final TranslationsTicketJa ticket = TranslationsTicketJa.internal(_root);
 }
 
 // Path: account
 class TranslationsAccountJa {
-	TranslationsAccountJa._(this._root);
+	TranslationsAccountJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -92,37 +92,37 @@ class TranslationsAccountJa {
 	/// ja: 'アカウント設定'
 	String get settings => 'アカウント設定';
 
-	late final TranslationsAccountProfileJa profile = TranslationsAccountProfileJa._(_root);
+	late final TranslationsAccountProfileJa profile = TranslationsAccountProfileJa.internal(_root);
 }
 
 // Path: auth
 class TranslationsAuthJa {
-	TranslationsAuthJa._(this._root);
+	TranslationsAuthJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	late final TranslationsAuthGuestJa guest = TranslationsAuthGuestJa._(_root);
-	late final TranslationsAuthErrorJa error = TranslationsAuthErrorJa._(_root);
+	late final TranslationsAuthGuestJa guest = TranslationsAuthGuestJa.internal(_root);
+	late final TranslationsAuthErrorJa error = TranslationsAuthErrorJa.internal(_root);
 }
 
 // Path: common
 class TranslationsCommonJa {
-	TranslationsCommonJa._(this._root);
+	TranslationsCommonJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	late final TranslationsCommonAppJa app = TranslationsCommonAppJa._(_root);
-	late final TranslationsCommonForceUpdateJa forceUpdate = TranslationsCommonForceUpdateJa._(_root);
-	late final TranslationsCommonErrorJa error = TranslationsCommonErrorJa._(_root);
-	late final TranslationsCommonNavigationJa navigation = TranslationsCommonNavigationJa._(_root);
-	late final TranslationsCommonDebugJa debug = TranslationsCommonDebugJa._(_root);
+	late final TranslationsCommonAppJa app = TranslationsCommonAppJa.internal(_root);
+	late final TranslationsCommonForceUpdateJa forceUpdate = TranslationsCommonForceUpdateJa.internal(_root);
+	late final TranslationsCommonErrorJa error = TranslationsCommonErrorJa.internal(_root);
+	late final TranslationsCommonNavigationJa navigation = TranslationsCommonNavigationJa.internal(_root);
+	late final TranslationsCommonDebugJa debug = TranslationsCommonDebugJa.internal(_root);
 }
 
 // Path: event
 class TranslationsEventJa {
-	TranslationsEventJa._(this._root);
+	TranslationsEventJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -146,19 +146,19 @@ class TranslationsEventJa {
 
 // Path: news
 class TranslationsNewsJa {
-	TranslationsNewsJa._(this._root);
+	TranslationsNewsJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	late final TranslationsNewsTileJa tile = TranslationsNewsTileJa._(_root);
-	late final TranslationsNewsScreenJa screen = TranslationsNewsScreenJa._(_root);
-	late final TranslationsNewsEmptyJa empty = TranslationsNewsEmptyJa._(_root);
+	late final TranslationsNewsTileJa tile = TranslationsNewsTileJa.internal(_root);
+	late final TranslationsNewsScreenJa screen = TranslationsNewsScreenJa.internal(_root);
+	late final TranslationsNewsEmptyJa empty = TranslationsNewsEmptyJa.internal(_root);
 }
 
 // Path: sponsor
 class TranslationsSponsorJa {
-	TranslationsSponsorJa._(this._root);
+	TranslationsSponsorJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -194,12 +194,12 @@ class TranslationsSponsorJa {
 
 // Path: ticket
 class TranslationsTicketJa {
-	TranslationsTicketJa._(this._root);
+	TranslationsTicketJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	late final TranslationsTicketStatusJa status = TranslationsTicketStatusJa._(_root);
+	late final TranslationsTicketStatusJa status = TranslationsTicketStatusJa.internal(_root);
 
 	/// ja: 'オプション:'
 	String get options => 'オプション:';
@@ -216,15 +216,15 @@ class TranslationsTicketJa {
 	/// ja: 'チケット一覧'
 	String get list => 'チケット一覧';
 
-	late final TranslationsTicketLoginRequiredJa loginRequired = TranslationsTicketLoginRequiredJa._(_root);
-	late final TranslationsTicketNoticeJa notice = TranslationsTicketNoticeJa._(_root);
-	late final TranslationsTicketStudentRefundJa studentRefund = TranslationsTicketStudentRefundJa._(_root);
-	late final TranslationsTicketPurchaseJa purchase = TranslationsTicketPurchaseJa._(_root);
+	late final TranslationsTicketLoginRequiredJa loginRequired = TranslationsTicketLoginRequiredJa.internal(_root);
+	late final TranslationsTicketNoticeJa notice = TranslationsTicketNoticeJa.internal(_root);
+	late final TranslationsTicketStudentRefundJa studentRefund = TranslationsTicketStudentRefundJa.internal(_root);
+	late final TranslationsTicketPurchaseJa purchase = TranslationsTicketPurchaseJa.internal(_root);
 }
 
 // Path: account.profile
 class TranslationsAccountProfileJa {
-	TranslationsAccountProfileJa._(this._root);
+	TranslationsAccountProfileJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -284,14 +284,14 @@ class TranslationsAccountProfileJa {
 	/// ja: '追加'
 	String get add => '追加';
 
-	late final TranslationsAccountProfileAvatarJa avatar = TranslationsAccountProfileAvatarJa._(_root);
-	late final TranslationsAccountProfileSnsJa sns = TranslationsAccountProfileSnsJa._(_root);
-	late final TranslationsAccountProfileImageJa image = TranslationsAccountProfileImageJa._(_root);
+	late final TranslationsAccountProfileAvatarJa avatar = TranslationsAccountProfileAvatarJa.internal(_root);
+	late final TranslationsAccountProfileSnsJa sns = TranslationsAccountProfileSnsJa.internal(_root);
+	late final TranslationsAccountProfileImageJa image = TranslationsAccountProfileImageJa.internal(_root);
 }
 
 // Path: auth.guest
 class TranslationsAuthGuestJa {
-	TranslationsAuthGuestJa._(this._root);
+	TranslationsAuthGuestJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -306,7 +306,7 @@ class TranslationsAuthGuestJa {
 
 // Path: auth.error
 class TranslationsAuthErrorJa {
-	TranslationsAuthErrorJa._(this._root);
+	TranslationsAuthErrorJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -318,7 +318,7 @@ class TranslationsAuthErrorJa {
 
 // Path: common.app
 class TranslationsCommonAppJa {
-	TranslationsCommonAppJa._(this._root);
+	TranslationsCommonAppJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -330,7 +330,7 @@ class TranslationsCommonAppJa {
 
 // Path: common.forceUpdate
 class TranslationsCommonForceUpdateJa {
-	TranslationsCommonForceUpdateJa._(this._root);
+	TranslationsCommonForceUpdateJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -348,20 +348,20 @@ class TranslationsCommonForceUpdateJa {
 
 // Path: common.error
 class TranslationsCommonErrorJa {
-	TranslationsCommonErrorJa._(this._root);
+	TranslationsCommonErrorJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	late final TranslationsCommonErrorNotFoundJa notFound = TranslationsCommonErrorNotFoundJa._(_root);
-	late final TranslationsCommonErrorServerJa server = TranslationsCommonErrorServerJa._(_root);
-	late final TranslationsCommonErrorWidgetJa widget = TranslationsCommonErrorWidgetJa._(_root);
-	late final TranslationsCommonErrorGeneralJa general = TranslationsCommonErrorGeneralJa._(_root);
+	late final TranslationsCommonErrorNotFoundJa notFound = TranslationsCommonErrorNotFoundJa.internal(_root);
+	late final TranslationsCommonErrorServerJa server = TranslationsCommonErrorServerJa.internal(_root);
+	late final TranslationsCommonErrorWidgetJa widget = TranslationsCommonErrorWidgetJa.internal(_root);
+	late final TranslationsCommonErrorGeneralJa general = TranslationsCommonErrorGeneralJa.internal(_root);
 }
 
 // Path: common.navigation
 class TranslationsCommonNavigationJa {
-	TranslationsCommonNavigationJa._(this._root);
+	TranslationsCommonNavigationJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -382,7 +382,7 @@ class TranslationsCommonNavigationJa {
 
 // Path: common.debug
 class TranslationsCommonDebugJa {
-	TranslationsCommonDebugJa._(this._root);
+	TranslationsCommonDebugJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -412,7 +412,7 @@ class TranslationsCommonDebugJa {
 
 // Path: news.tile
 class TranslationsNewsTileJa {
-	TranslationsNewsTileJa._(this._root);
+	TranslationsNewsTileJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -427,7 +427,7 @@ class TranslationsNewsTileJa {
 
 // Path: news.screen
 class TranslationsNewsScreenJa {
-	TranslationsNewsScreenJa._(this._root);
+	TranslationsNewsScreenJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -439,7 +439,7 @@ class TranslationsNewsScreenJa {
 
 // Path: news.empty
 class TranslationsNewsEmptyJa {
-	TranslationsNewsEmptyJa._(this._root);
+	TranslationsNewsEmptyJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -451,7 +451,7 @@ class TranslationsNewsEmptyJa {
 
 // Path: ticket.status
 class TranslationsTicketStatusJa {
-	TranslationsTicketStatusJa._(this._root);
+	TranslationsTicketStatusJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -466,7 +466,7 @@ class TranslationsTicketStatusJa {
 
 // Path: ticket.loginRequired
 class TranslationsTicketLoginRequiredJa {
-	TranslationsTicketLoginRequiredJa._(this._root);
+	TranslationsTicketLoginRequiredJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -484,7 +484,7 @@ class TranslationsTicketLoginRequiredJa {
 
 // Path: ticket.notice
 class TranslationsTicketNoticeJa {
-	TranslationsTicketNoticeJa._(this._root);
+	TranslationsTicketNoticeJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -499,7 +499,7 @@ class TranslationsTicketNoticeJa {
 
 // Path: ticket.studentRefund
 class TranslationsTicketStudentRefundJa {
-	TranslationsTicketStudentRefundJa._(this._root);
+	TranslationsTicketStudentRefundJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -520,7 +520,7 @@ class TranslationsTicketStudentRefundJa {
 
 // Path: ticket.purchase
 class TranslationsTicketPurchaseJa {
-	TranslationsTicketPurchaseJa._(this._root);
+	TranslationsTicketPurchaseJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -604,7 +604,7 @@ class TranslationsTicketPurchaseJa {
 
 // Path: account.profile.avatar
 class TranslationsAccountProfileAvatarJa {
-	TranslationsAccountProfileAvatarJa._(this._root);
+	TranslationsAccountProfileAvatarJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -622,7 +622,7 @@ class TranslationsAccountProfileAvatarJa {
 
 // Path: account.profile.sns
 class TranslationsAccountProfileSnsJa {
-	TranslationsAccountProfileSnsJa._(this._root);
+	TranslationsAccountProfileSnsJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -652,13 +652,13 @@ class TranslationsAccountProfileSnsJa {
 	/// ja: '英数字、アンダースコア、ハイフンのみ使用可能です'
 	String get alphanumericOnly => '英数字、アンダースコア、ハイフンのみ使用可能です';
 
-	late final TranslationsAccountProfileSnsExamplesJa examples = TranslationsAccountProfileSnsExamplesJa._(_root);
-	late final TranslationsAccountProfileSnsDisplayNamesJa displayNames = TranslationsAccountProfileSnsDisplayNamesJa._(_root);
+	late final TranslationsAccountProfileSnsExamplesJa examples = TranslationsAccountProfileSnsExamplesJa.internal(_root);
+	late final TranslationsAccountProfileSnsDisplayNamesJa displayNames = TranslationsAccountProfileSnsDisplayNamesJa.internal(_root);
 }
 
 // Path: account.profile.image
 class TranslationsAccountProfileImageJa {
-	TranslationsAccountProfileImageJa._(this._root);
+	TranslationsAccountProfileImageJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -691,7 +691,7 @@ class TranslationsAccountProfileImageJa {
 
 // Path: common.error.notFound
 class TranslationsCommonErrorNotFoundJa {
-	TranslationsCommonErrorNotFoundJa._(this._root);
+	TranslationsCommonErrorNotFoundJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -709,7 +709,7 @@ class TranslationsCommonErrorNotFoundJa {
 
 // Path: common.error.server
 class TranslationsCommonErrorServerJa {
-	TranslationsCommonErrorServerJa._(this._root);
+	TranslationsCommonErrorServerJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -727,7 +727,7 @@ class TranslationsCommonErrorServerJa {
 
 // Path: common.error.widget
 class TranslationsCommonErrorWidgetJa {
-	TranslationsCommonErrorWidgetJa._(this._root);
+	TranslationsCommonErrorWidgetJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -745,7 +745,7 @@ class TranslationsCommonErrorWidgetJa {
 
 // Path: common.error.general
 class TranslationsCommonErrorGeneralJa {
-	TranslationsCommonErrorGeneralJa._(this._root);
+	TranslationsCommonErrorGeneralJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -757,7 +757,7 @@ class TranslationsCommonErrorGeneralJa {
 
 // Path: account.profile.sns.examples
 class TranslationsAccountProfileSnsExamplesJa {
-	TranslationsAccountProfileSnsExamplesJa._(this._root);
+	TranslationsAccountProfileSnsExamplesJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 
@@ -787,7 +787,7 @@ class TranslationsAccountProfileSnsExamplesJa {
 
 // Path: account.profile.sns.displayNames
 class TranslationsAccountProfileSnsDisplayNamesJa {
-	TranslationsAccountProfileSnsDisplayNamesJa._(this._root);
+	TranslationsAccountProfileSnsDisplayNamesJa.internal(this._root);
 
 	final Translations _root; // ignore: unused_field
 

--- a/apps/app/res/i18n/account/account_en.i18n.yaml
+++ b/apps/app/res/i18n/account/account_en.i18n.yaml
@@ -1,0 +1,69 @@
+profileEdit: Edit Profile
+guestUserLabel: Guest Mode
+others: Others
+codeOfConduct: Code of Conduct
+codeOfConductUrl: https://docs.flutterkaigi.jp/Code-of-Conduct
+privacyPolicy: Privacy Policy
+privacyPolicyUrl: https://docs.flutterkaigi.jp/Privacy-Policy
+contact: Contact Us
+contactUrl: https://docs.google.com/forms/d/e/1FAIpQLSemYPFEWpP8594MWI4k3Nz45RJzMS7pz1ufwtnX4t3V7z2TOw/viewform
+ossLicenses: OSS Licenses
+logout: Sign Out
+settings: Account Settings
+profile:
+  title: Profile
+  editTitle: Edit Profile
+  createInfo: Please create profile information
+  edit: Edit Profile
+  notFound: Profile not found
+  saving: Saving...
+  save: Save
+  saveSuccess: Profile saved
+  saveFailed: Failed to save
+  errorOccurred: An error occurred
+  ageOver20: 20 or older
+  ageUnder20: Under 20
+  nameLabel: Name *
+  nameRequired: Please enter your name
+  upload: Upload
+  delete: Delete
+  snsLinks: Social Links
+  add: Add
+  avatar:
+    deleteSuccess: Avatar removed successfully
+    changeFailed: Could not update avatar
+    changeSuccess: Avatar updated successfully
+  sns:
+    notLinked: No social links registered
+    type: Platform
+    urlOrUserId: URL/User ID
+    urlOrUserIdRequired: Please enter URL/User ID
+    other: Other
+    fullUrlRequired: Please enter full URL
+    userIdOnly: User ID only
+    alphanumericOnly: Only letters, numbers, underscore and hyphen allowed
+    examples:
+      github: "e.g. octocat"
+      x: "e.g. twitter"
+      discord: "e.g. 123456789012345678 (User ID)"
+      medium: "e.g. username"
+      qiita: "e.g. username"
+      zenn: "e.g. username"
+      note: "e.g. username"
+    displayNames:
+      github: GitHub
+      x: X (Twitter)
+      discord: Discord
+      medium: Medium
+      qiita: Qiita
+      zenn: Zenn
+      note: note
+  image:
+    selectTitle: Select Image
+    selectMessage: Please select an image
+    selectButton: Select Image
+    useGooglePhoto: Use Google Account Photo
+    cropTitle: Crop Image
+    complete: Complete
+    crop: Crop
+    reset: Reset

--- a/apps/app/slang.yaml
+++ b/apps/app/slang.yaml
@@ -1,4 +1,5 @@
 base_locale: ja
+fallback_strategy: base_locale
 input_directory: res/i18n
 input_file_pattern: .i18n.yaml
 output_directory: lib/core/gen/i18n


### PR DESCRIPTION
## 関連Issue
- Closes #280

## 概要
アカウント設定画面の英語翻訳ファイルを追加し、言語フォールバック設定を実装しました。

## 変更内容
- `account_en.i18n.yaml` - アカウント設定の英語翻訳を追加
- `slang.yaml` - 英語ファイルが存在しない場合の日本語へのフォールバック設定を追加
- slang による自動生成ファイルを更新

## 翻訳内容
- プロフィール関連のテキスト
- ソーシャルリンク設定
- アバター画像のアップロード/削除メッセージ
- ゲストサインイン関連のテキスト

## スナップショット

|           ゲスト           |           通常            |           編集            |
| :------------------------: | :------------------------: | :------------------------: |
| <img src="https://github.com/user-attachments/assets/d7d09832-8a11-4011-ad84-18bc90f6f7bb" width="300" /> | <img src="https://github.com/user-attachments/assets/431ca1c5-329a-416e-b6e2-a73658572305" width="300" /> |<img src="https://github.com/user-attachments/assets/8daaf926-c41b-412a-a051-4f18e500b0cc" width="300" /> |

## スナップショット（遷移先）

|           利用規約           |           プライバシーポリシー            |
| :------------------------: | :------------------------: |
| <img src="https://github.com/user-attachments/assets/a26c05ca-9a89-42d1-b6b4-75a6ae6ab0a9" width="300" /> | <img src="https://github.com/user-attachments/assets/a5455a51-66dc-4bf0-8eec-a7fdc517eede" width="300" /> |
