### PR TITLE
feat: アカウント情報画面に退会申請フォームへのリンクを追加

### DIFF
--- a/apps/app/environments/.env.dev
+++ b/apps/app/environments/.env.dev
@@ -6,3 +6,4 @@ SUPABASE_URL=http://localhost:54321
 SUPABASE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
 
 BFF_BASE_URL=http://localhost:8080/v1
+WITHDRAWAL_FORM_URL="https://docs.google.com/forms/d/e/1FAIpQLSfz2_V6wCbjUzdEdvkw7eOaFkxk_1PF_d7PQUDwwdKlJM2vhg/viewform?usp=dialog"

--- a/apps/app/environments/.env.prod
+++ b/apps/app/environments/.env.prod
@@ -6,3 +6,4 @@ SUPABASE_URL=https://sotendzncvqiyfaxpydk.supabase.co
 SUPABASE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNvdGVuZHpuY3ZxaXlmYXhweWRrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDYyNzk5OTUsImV4cCI6MjA2MTg1NTk5NX0.nrxJg5EBcDyZ5ASqS7a_L0GQb6yJ7jgfLBJiK4D2APw
 
 BFF_BASE_URL=https://2025-bff.flutterkaigi.jp/v1
+WITHDRAWAL_FORM_URL="https://docs.google.com/forms/d/e/1FAIpQLSfm11DgLntsLCko28HN-Iltxf42Fan5rt9VoducgduBNC3_Aw/viewform?usp=dialog"

--- a/apps/app/environments/.env.stg
+++ b/apps/app/environments/.env.stg
@@ -6,3 +6,4 @@ SUPABASE_URL=https://ikrzxakkbmajammujqao.supabase.co
 SUPABASE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imlrcnp4YWtrYm1hamFtbXVqcWFvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDYyNzk5OTUsImV4cCI6MjA2MTg1NTk5NX0.KpdkNSo4Ap2vba8Q5fUtST_Zzg5wqyyGBCKbJf0iTks
 
 BFF_BASE_URL=https://flutterkaigi-2025-bff-staging.flutter-kaigi.workers.dev/v1
+WITHDRAWAL_FORM_URL="https://docs.google.com/forms/d/e/1FAIpQLSfz2_V6wCbjUzdEdvkw7eOaFkxk_1PF_d7PQUDwwdKlJM2vhg/viewform?usp=dialog"

--- a/apps/app/lib/core/gen/i18n/i18n.g.dart
+++ b/apps/app/lib/core/gen/i18n/i18n.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 213 (106 per locale)
+/// Strings: 215 (107 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/apps/app/lib/core/gen/i18n/i18n_en.g.dart
+++ b/apps/app/lib/core/gen/i18n/i18n_en.g.dart
@@ -58,6 +58,7 @@ class _TranslationsAccountEn extends TranslationsAccountJa {
 	@override String get contact => 'Contact Us';
 	@override String get contactUrl => 'https://docs.google.com/forms/d/e/1FAIpQLSemYPFEWpP8594MWI4k3Nz45RJzMS7pz1ufwtnX4t3V7z2TOw/viewform';
 	@override String get ossLicenses => 'OSS Licenses';
+	@override String get withdrawal => 'Withdrawal Request';
 	@override String get logout => 'Sign Out';
 	@override String get settings => 'Account Settings';
 	@override late final _TranslationsAccountProfileEn profile = _TranslationsAccountProfileEn._(_root);
@@ -188,6 +189,7 @@ extension on TranslationsEn {
 			case 'account.contact': return 'Contact Us';
 			case 'account.contactUrl': return 'https://docs.google.com/forms/d/e/1FAIpQLSemYPFEWpP8594MWI4k3Nz45RJzMS7pz1ufwtnX4t3V7z2TOw/viewform';
 			case 'account.ossLicenses': return 'OSS Licenses';
+			case 'account.withdrawal': return 'Withdrawal Request';
 			case 'account.logout': return 'Sign Out';
 			case 'account.settings': return 'Account Settings';
 			case 'account.profile.title': return 'Profile';

--- a/apps/app/lib/core/gen/i18n/i18n_ja.g.dart
+++ b/apps/app/lib/core/gen/i18n/i18n_ja.g.dart
@@ -86,6 +86,9 @@ class TranslationsAccountJa {
 	/// ja: 'OSS Licenses'
 	String get ossLicenses => 'OSS Licenses';
 
+	/// ja: '退会申請'
+	String get withdrawal => '退会申請';
+
 	/// ja: 'ログアウト'
 	String get logout => 'ログアウト';
 
@@ -830,6 +833,7 @@ extension on Translations {
 			case 'account.contact': return 'お問い合わせ';
 			case 'account.contactUrl': return 'https://docs.google.com/forms/d/e/1FAIpQLSemYPFEWpP8594MWI4k3Nz45RJzMS7pz1ufwtnX4t3V7z2TOw/viewform';
 			case 'account.ossLicenses': return 'OSS Licenses';
+			case 'account.withdrawal': return '退会申請';
 			case 'account.logout': return 'ログアウト';
 			case 'account.settings': return 'アカウント設定';
 			case 'account.profile.title': return 'プロファイル';

--- a/apps/app/lib/core/provider/environment.dart
+++ b/apps/app/lib/core/provider/environment.dart
@@ -18,6 +18,7 @@ abstract class Environment with _$Environment {
     required String supabaseUrl,
     required String supabaseKey,
     required String bffBaseUrl,
+    required String withdrawalFormUrl,
   }) = _Environment;
 
   factory Environment.fromEnvironment() => const Environment(
@@ -27,6 +28,7 @@ abstract class Environment with _$Environment {
     supabaseUrl: String.fromEnvironment('SUPABASE_URL'),
     supabaseKey: String.fromEnvironment('SUPABASE_KEY'),
     bffBaseUrl: String.fromEnvironment('BFF_BASE_URL'),
+    withdrawalFormUrl: String.fromEnvironment('WITHDRAWAL_FORM_URL'),
   );
 
   factory Environment.fromJson(Map<String, dynamic> json) =>

--- a/apps/app/lib/core/provider/environment.freezed.dart
+++ b/apps/app/lib/core/provider/environment.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Environment {
 
- String get appIdSuffix; String get appName; String get flavor; String get supabaseUrl; String get supabaseKey; String get bffBaseUrl;
+ String get appIdSuffix; String get appName; String get flavor; String get supabaseUrl; String get supabaseKey; String get bffBaseUrl; String get withdrawalFormUrl;
 /// Create a copy of Environment
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $EnvironmentCopyWith<Environment> get copyWith => _$EnvironmentCopyWithImpl<Envi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Environment&&(identical(other.appIdSuffix, appIdSuffix) || other.appIdSuffix == appIdSuffix)&&(identical(other.appName, appName) || other.appName == appName)&&(identical(other.flavor, flavor) || other.flavor == flavor)&&(identical(other.supabaseUrl, supabaseUrl) || other.supabaseUrl == supabaseUrl)&&(identical(other.supabaseKey, supabaseKey) || other.supabaseKey == supabaseKey)&&(identical(other.bffBaseUrl, bffBaseUrl) || other.bffBaseUrl == bffBaseUrl));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Environment&&(identical(other.appIdSuffix, appIdSuffix) || other.appIdSuffix == appIdSuffix)&&(identical(other.appName, appName) || other.appName == appName)&&(identical(other.flavor, flavor) || other.flavor == flavor)&&(identical(other.supabaseUrl, supabaseUrl) || other.supabaseUrl == supabaseUrl)&&(identical(other.supabaseKey, supabaseKey) || other.supabaseKey == supabaseKey)&&(identical(other.bffBaseUrl, bffBaseUrl) || other.bffBaseUrl == bffBaseUrl)&&(identical(other.withdrawalFormUrl, withdrawalFormUrl) || other.withdrawalFormUrl == withdrawalFormUrl));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,appIdSuffix,appName,flavor,supabaseUrl,supabaseKey,bffBaseUrl);
+int get hashCode => Object.hash(runtimeType,appIdSuffix,appName,flavor,supabaseUrl,supabaseKey,bffBaseUrl,withdrawalFormUrl);
 
 @override
 String toString() {
-  return 'Environment(appIdSuffix: $appIdSuffix, appName: $appName, flavor: $flavor, supabaseUrl: $supabaseUrl, supabaseKey: $supabaseKey, bffBaseUrl: $bffBaseUrl)';
+  return 'Environment(appIdSuffix: $appIdSuffix, appName: $appName, flavor: $flavor, supabaseUrl: $supabaseUrl, supabaseKey: $supabaseKey, bffBaseUrl: $bffBaseUrl, withdrawalFormUrl: $withdrawalFormUrl)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $EnvironmentCopyWith<$Res>  {
   factory $EnvironmentCopyWith(Environment value, $Res Function(Environment) _then) = _$EnvironmentCopyWithImpl;
 @useResult
 $Res call({
- String appIdSuffix, String appName, String flavor, String supabaseUrl, String supabaseKey, String bffBaseUrl
+ String appIdSuffix, String appName, String flavor, String supabaseUrl, String supabaseKey, String bffBaseUrl, String withdrawalFormUrl
 });
 
 
@@ -65,7 +65,7 @@ class _$EnvironmentCopyWithImpl<$Res>
 
 /// Create a copy of Environment
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? appIdSuffix = null,Object? appName = null,Object? flavor = null,Object? supabaseUrl = null,Object? supabaseKey = null,Object? bffBaseUrl = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? appIdSuffix = null,Object? appName = null,Object? flavor = null,Object? supabaseUrl = null,Object? supabaseKey = null,Object? bffBaseUrl = null,Object? withdrawalFormUrl = null,}) {
   return _then(_self.copyWith(
 appIdSuffix: null == appIdSuffix ? _self.appIdSuffix : appIdSuffix // ignore: cast_nullable_to_non_nullable
 as String,appName: null == appName ? _self.appName : appName // ignore: cast_nullable_to_non_nullable
@@ -73,6 +73,7 @@ as String,flavor: null == flavor ? _self.flavor : flavor // ignore: cast_nullabl
 as String,supabaseUrl: null == supabaseUrl ? _self.supabaseUrl : supabaseUrl // ignore: cast_nullable_to_non_nullable
 as String,supabaseKey: null == supabaseKey ? _self.supabaseKey : supabaseKey // ignore: cast_nullable_to_non_nullable
 as String,bffBaseUrl: null == bffBaseUrl ? _self.bffBaseUrl : bffBaseUrl // ignore: cast_nullable_to_non_nullable
+as String,withdrawalFormUrl: null == withdrawalFormUrl ? _self.withdrawalFormUrl : withdrawalFormUrl // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }
@@ -158,10 +159,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String appIdSuffix,  String appName,  String flavor,  String supabaseUrl,  String supabaseKey,  String bffBaseUrl)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String appIdSuffix,  String appName,  String flavor,  String supabaseUrl,  String supabaseKey,  String bffBaseUrl,  String withdrawalFormUrl)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Environment() when $default != null:
-return $default(_that.appIdSuffix,_that.appName,_that.flavor,_that.supabaseUrl,_that.supabaseKey,_that.bffBaseUrl);case _:
+return $default(_that.appIdSuffix,_that.appName,_that.flavor,_that.supabaseUrl,_that.supabaseKey,_that.bffBaseUrl,_that.withdrawalFormUrl);case _:
   return orElse();
 
 }
@@ -179,10 +180,10 @@ return $default(_that.appIdSuffix,_that.appName,_that.flavor,_that.supabaseUrl,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String appIdSuffix,  String appName,  String flavor,  String supabaseUrl,  String supabaseKey,  String bffBaseUrl)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String appIdSuffix,  String appName,  String flavor,  String supabaseUrl,  String supabaseKey,  String bffBaseUrl,  String withdrawalFormUrl)  $default,) {final _that = this;
 switch (_that) {
 case _Environment():
-return $default(_that.appIdSuffix,_that.appName,_that.flavor,_that.supabaseUrl,_that.supabaseKey,_that.bffBaseUrl);case _:
+return $default(_that.appIdSuffix,_that.appName,_that.flavor,_that.supabaseUrl,_that.supabaseKey,_that.bffBaseUrl,_that.withdrawalFormUrl);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -199,10 +200,10 @@ return $default(_that.appIdSuffix,_that.appName,_that.flavor,_that.supabaseUrl,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String appIdSuffix,  String appName,  String flavor,  String supabaseUrl,  String supabaseKey,  String bffBaseUrl)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String appIdSuffix,  String appName,  String flavor,  String supabaseUrl,  String supabaseKey,  String bffBaseUrl,  String withdrawalFormUrl)?  $default,) {final _that = this;
 switch (_that) {
 case _Environment() when $default != null:
-return $default(_that.appIdSuffix,_that.appName,_that.flavor,_that.supabaseUrl,_that.supabaseKey,_that.bffBaseUrl);case _:
+return $default(_that.appIdSuffix,_that.appName,_that.flavor,_that.supabaseUrl,_that.supabaseKey,_that.bffBaseUrl,_that.withdrawalFormUrl);case _:
   return null;
 
 }
@@ -214,7 +215,7 @@ return $default(_that.appIdSuffix,_that.appName,_that.flavor,_that.supabaseUrl,_
 @JsonSerializable()
 
 class _Environment implements Environment {
-  const _Environment({required this.appIdSuffix, required this.appName, required this.flavor, required this.supabaseUrl, required this.supabaseKey, required this.bffBaseUrl});
+  const _Environment({required this.appIdSuffix, required this.appName, required this.flavor, required this.supabaseUrl, required this.supabaseKey, required this.bffBaseUrl, required this.withdrawalFormUrl});
   factory _Environment.fromJson(Map<String, dynamic> json) => _$EnvironmentFromJson(json);
 
 @override final  String appIdSuffix;
@@ -223,6 +224,7 @@ class _Environment implements Environment {
 @override final  String supabaseUrl;
 @override final  String supabaseKey;
 @override final  String bffBaseUrl;
+@override final  String withdrawalFormUrl;
 
 /// Create a copy of Environment
 /// with the given fields replaced by the non-null parameter values.
@@ -237,16 +239,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Environment&&(identical(other.appIdSuffix, appIdSuffix) || other.appIdSuffix == appIdSuffix)&&(identical(other.appName, appName) || other.appName == appName)&&(identical(other.flavor, flavor) || other.flavor == flavor)&&(identical(other.supabaseUrl, supabaseUrl) || other.supabaseUrl == supabaseUrl)&&(identical(other.supabaseKey, supabaseKey) || other.supabaseKey == supabaseKey)&&(identical(other.bffBaseUrl, bffBaseUrl) || other.bffBaseUrl == bffBaseUrl));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Environment&&(identical(other.appIdSuffix, appIdSuffix) || other.appIdSuffix == appIdSuffix)&&(identical(other.appName, appName) || other.appName == appName)&&(identical(other.flavor, flavor) || other.flavor == flavor)&&(identical(other.supabaseUrl, supabaseUrl) || other.supabaseUrl == supabaseUrl)&&(identical(other.supabaseKey, supabaseKey) || other.supabaseKey == supabaseKey)&&(identical(other.bffBaseUrl, bffBaseUrl) || other.bffBaseUrl == bffBaseUrl)&&(identical(other.withdrawalFormUrl, withdrawalFormUrl) || other.withdrawalFormUrl == withdrawalFormUrl));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,appIdSuffix,appName,flavor,supabaseUrl,supabaseKey,bffBaseUrl);
+int get hashCode => Object.hash(runtimeType,appIdSuffix,appName,flavor,supabaseUrl,supabaseKey,bffBaseUrl,withdrawalFormUrl);
 
 @override
 String toString() {
-  return 'Environment(appIdSuffix: $appIdSuffix, appName: $appName, flavor: $flavor, supabaseUrl: $supabaseUrl, supabaseKey: $supabaseKey, bffBaseUrl: $bffBaseUrl)';
+  return 'Environment(appIdSuffix: $appIdSuffix, appName: $appName, flavor: $flavor, supabaseUrl: $supabaseUrl, supabaseKey: $supabaseKey, bffBaseUrl: $bffBaseUrl, withdrawalFormUrl: $withdrawalFormUrl)';
 }
 
 
@@ -257,7 +259,7 @@ abstract mixin class _$EnvironmentCopyWith<$Res> implements $EnvironmentCopyWith
   factory _$EnvironmentCopyWith(_Environment value, $Res Function(_Environment) _then) = __$EnvironmentCopyWithImpl;
 @override @useResult
 $Res call({
- String appIdSuffix, String appName, String flavor, String supabaseUrl, String supabaseKey, String bffBaseUrl
+ String appIdSuffix, String appName, String flavor, String supabaseUrl, String supabaseKey, String bffBaseUrl, String withdrawalFormUrl
 });
 
 
@@ -274,7 +276,7 @@ class __$EnvironmentCopyWithImpl<$Res>
 
 /// Create a copy of Environment
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? appIdSuffix = null,Object? appName = null,Object? flavor = null,Object? supabaseUrl = null,Object? supabaseKey = null,Object? bffBaseUrl = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? appIdSuffix = null,Object? appName = null,Object? flavor = null,Object? supabaseUrl = null,Object? supabaseKey = null,Object? bffBaseUrl = null,Object? withdrawalFormUrl = null,}) {
   return _then(_Environment(
 appIdSuffix: null == appIdSuffix ? _self.appIdSuffix : appIdSuffix // ignore: cast_nullable_to_non_nullable
 as String,appName: null == appName ? _self.appName : appName // ignore: cast_nullable_to_non_nullable
@@ -282,6 +284,7 @@ as String,flavor: null == flavor ? _self.flavor : flavor // ignore: cast_nullabl
 as String,supabaseUrl: null == supabaseUrl ? _self.supabaseUrl : supabaseUrl // ignore: cast_nullable_to_non_nullable
 as String,supabaseKey: null == supabaseKey ? _self.supabaseKey : supabaseKey // ignore: cast_nullable_to_non_nullable
 as String,bffBaseUrl: null == bffBaseUrl ? _self.bffBaseUrl : bffBaseUrl // ignore: cast_nullable_to_non_nullable
+as String,withdrawalFormUrl: null == withdrawalFormUrl ? _self.withdrawalFormUrl : withdrawalFormUrl // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }

--- a/apps/app/lib/core/provider/environment.g.dart
+++ b/apps/app/lib/core/provider/environment.g.dart
@@ -19,6 +19,10 @@ _Environment _$EnvironmentFromJson(Map<String, dynamic> json) => $checkedCreate(
       supabaseUrl: $checkedConvert('supabase_url', (v) => v as String),
       supabaseKey: $checkedConvert('supabase_key', (v) => v as String),
       bffBaseUrl: $checkedConvert('bff_base_url', (v) => v as String),
+      withdrawalFormUrl: $checkedConvert(
+        'withdrawal_form_url',
+        (v) => v as String,
+      ),
     );
     return val;
   },
@@ -28,6 +32,7 @@ _Environment _$EnvironmentFromJson(Map<String, dynamic> json) => $checkedCreate(
     'supabaseUrl': 'supabase_url',
     'supabaseKey': 'supabase_key',
     'bffBaseUrl': 'bff_base_url',
+    'withdrawalFormUrl': 'withdrawal_form_url',
   },
 );
 
@@ -39,6 +44,7 @@ Map<String, dynamic> _$EnvironmentToJson(_Environment instance) =>
       'supabase_url': instance.supabaseUrl,
       'supabase_key': instance.supabaseKey,
       'bff_base_url': instance.bffBaseUrl,
+      'withdrawal_form_url': instance.withdrawalFormUrl,
     };
 
 // **************************************************************************

--- a/apps/app/lib/core/router/account.dart
+++ b/apps/app/lib/core/router/account.dart
@@ -41,6 +41,7 @@ class AccountInfoRoute extends GoRouteData with $AccountInfoRoute {
         context: context,
         applicationName: Translations.of(context).common.app.name,
       ),
+      onTapWithdrawalTile: () => _openWithdrawalForm(context),
     );
   }
 
@@ -52,6 +53,12 @@ class AccountInfoRoute extends GoRouteData with $AccountInfoRoute {
     } else {
       throw Exception('Could not launch $urlString');
     }
+  }
+
+  Future<void> _openWithdrawalForm(BuildContext context) async {
+    final container = ProviderScope.containerOf(context);
+    final environment = container.read(environmentProvider);
+    await _openUrl(urlString: environment.withdrawalFormUrl);
   }
 }
 

--- a/apps/app/lib/core/router/router.dart
+++ b/apps/app/lib/core/router/router.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:app/core/debug/debug_screen.dart';
 import 'package:app/core/debug/talker.dart';
 import 'package:app/core/gen/i18n/i18n.g.dart';
+import 'package:app/core/provider/environment.dart';
 import 'package:app/core/ui/main/main_screen.dart';
 import 'package:app/core/ui/main/not_found_screen.dart';
 import 'package:app/features/account/ui/info/account_info_screen.dart';

--- a/apps/app/lib/features/account/ui/info/account_info_screen.dart
+++ b/apps/app/lib/features/account/ui/info/account_info_screen.dart
@@ -25,18 +25,21 @@ final class AccountInfoScreen extends ConsumerWidget {
     required VoidCallback onTapPrivacyPolicyTile,
     required VoidCallback onTapContactTile,
     required VoidCallback onTapOssLicensesTile,
+    required VoidCallback onTapWithdrawalTile,
     super.key,
   }) : _onProfileEdit = onProfileEdit,
        _onTapCodeOfConductTile = onTapCodeOfConductTile,
        _onTapPrivacyPolicyTile = onTapPrivacyPolicyTile,
        _onTapContactTile = onTapContactTile,
-       _onTapOssLicensesTile = onTapOssLicensesTile;
+       _onTapOssLicensesTile = onTapOssLicensesTile,
+       _onTapWithdrawalTile = onTapWithdrawalTile;
 
   final VoidCallback _onProfileEdit;
   final VoidCallback _onTapCodeOfConductTile;
   final VoidCallback _onTapPrivacyPolicyTile;
   final VoidCallback _onTapContactTile;
   final VoidCallback _onTapOssLicensesTile;
+  final VoidCallback _onTapWithdrawalTile;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -88,6 +91,10 @@ final class AccountInfoScreen extends ConsumerWidget {
               (
                 title: t.account.ossLicenses,
                 onTap: _onTapOssLicensesTile,
+              ),
+              (
+                title: t.account.withdrawal,
+                onTap: _onTapWithdrawalTile,
               ),
             ].map(
               (item) => _OtherListItem(

--- a/apps/app/lib/features/account/ui/info/account_info_screen.dart
+++ b/apps/app/lib/features/account/ui/info/account_info_screen.dart
@@ -92,10 +92,12 @@ final class AccountInfoScreen extends ConsumerWidget {
                 title: t.account.ossLicenses,
                 onTap: _onTapOssLicensesTile,
               ),
-              (
-                title: t.account.withdrawal,
-                onTap: _onTapWithdrawalTile,
-              ),
+              // ゲストユーザーの場合は退会申請リンクを非表示
+              if (user != null && !user.isAnonymous)
+                (
+                  title: t.account.withdrawal,
+                  onTap: _onTapWithdrawalTile,
+                ),
             ].map(
               (item) => _OtherListItem(
                 title: item.title,

--- a/apps/app/res/i18n/account/account_en.i18n.yaml
+++ b/apps/app/res/i18n/account/account_en.i18n.yaml
@@ -8,6 +8,7 @@ privacyPolicyUrl: https://docs.flutterkaigi.jp/Privacy-Policy
 contact: Contact Us
 contactUrl: https://docs.google.com/forms/d/e/1FAIpQLSemYPFEWpP8594MWI4k3Nz45RJzMS7pz1ufwtnX4t3V7z2TOw/viewform
 ossLicenses: OSS Licenses
+withdrawal: Withdrawal Request
 logout: Sign Out
 settings: Account Settings
 profile:

--- a/apps/app/res/i18n/account/account_ja.i18n.yaml
+++ b/apps/app/res/i18n/account/account_ja.i18n.yaml
@@ -8,6 +8,7 @@ privacyPolicyUrl: https://docs.flutterkaigi.jp/Privacy-Policy.ja
 contact: お問い合わせ
 contactUrl: https://docs.google.com/forms/d/e/1FAIpQLSemYPFEWpP8594MWI4k3Nz45RJzMS7pz1ufwtnX4t3V7z2TOw/viewform
 ossLicenses: OSS Licenses
+withdrawal: 退会申請
 logout: ログアウト
 settings: アカウント設定
 profile:

--- a/apps/app_catalog/lib/feature/account/account_info_screen.dart
+++ b/apps/app_catalog/lib/feature/account/account_info_screen.dart
@@ -40,6 +40,7 @@ Widget accountInfoScreenUseCase(BuildContext context) {
           bffBaseUrl: '',
           supabaseUrl: '',
           supabaseKey: '',
+          withdrawalFormUrl: '',
         ),
       ),
     ],
@@ -49,6 +50,7 @@ Widget accountInfoScreenUseCase(BuildContext context) {
       onTapPrivacyPolicyTile: () {},
       onTapContactTile: () {},
       onTapOssLicensesTile: () {},
+      onTapWithdrawalTile: () {},
     ),
   );
 }


### PR DESCRIPTION
## Issue

Closes #420

## 概要

アカウント情報画面に退会申請フォームへのリンクを追加し、ゲストユーザーの場合は非表示にする機能を実装しました。

## 詳細

### 実装内容
1. **国際化ファイルの更新**
   - `account_ja.i18n.yaml` に「退会申請」を追加
   - `account_en.i18n.yaml` に「Withdrawal Request」を追加

2. **アカウント情報画面の更新**
   - `AccountInfoScreen` に退会申請リンクを追加
   - ゲストユーザー（`user.isAnonymous`）の場合は退会申請リンクを非表示にする条件分岐を実装

3. **ルーターの更新**
   - `AccountInfoRoute` に退会申請フォームへの遷移機能を追加
   - 環境変数 `WITHDRAWAL_FORM_URL` から退会申請フォームのURLを取得し、外部ブラウザで開く機能を実装

4. **環境設定の更新**
   - 各環境（dev, stg, prod）の設定ファイルに退会申請フォームURLを追加

### 変更理由
- ユーザーがアカウントを退会したい場合の申請手順を提供するため
- ゲストユーザーには退会申請が不要なため、通常ユーザーのみに表示するため

## 画像・動画

| Before | After |
| ------ | ----- |
| 退会申請リンクなし | <video src=https://github.com/user-attachments/assets/19ff5a36-4599-41d9-bcb1-bf3c6f1169f2 /> |

## その他

- 退会申請フォームは外部URLに遷移するため、環境変数でURLを管理
- ゲストユーザーの判定は `user.isAnonymous` を使用
- 国際化対応済み（日本語・英語）