### PR TITLE
feat: Add id to section element for anchor link

### DIFF
--- a/apps/website/lib/src/components/section_layout.dart
+++ b/apps/website/lib/src/components/section_layout.dart
@@ -2,14 +2,21 @@ import 'package:flutterkaigi_2025_website/src/constants/styles.dart';
 import 'package:jaspr/jaspr.dart';
 
 class SectionLayout extends StatelessComponent {
-  const SectionLayout({required this.title, required this.children, super.key});
+  const SectionLayout({
+    required this.id,
+    required this.title,
+    required this.children,
+    super.key,
+  });
 
+  final String id;
   final String title;
   final Iterable<Component> children;
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
     yield section(
+      id: id,
       styles: Styles(
         display: Display.flex,
         width: const Unit.expression('calc(100% - 64px)'),

--- a/apps/website/lib/src/pages/home.dart
+++ b/apps/website/lib/src/pages/home.dart
@@ -34,7 +34,11 @@ class Home extends StatelessComponent {
       ),
       [
         const _MainArticle(),
-        const SectionLayout(title: 'News', children: [News()]),
+        const SectionLayout(
+          id: 'news',
+          title: 'News',
+          children: [News()],
+        ),
         // const SectionLayout(
         //   title: 'Call for Proposal',
         //   children: [CallForProposal()],
@@ -47,14 +51,17 @@ class Home extends StatelessComponent {
         ),
         const Tagline(),
         const SectionLayout(
+          id: 'timeline',
           title: 'Timeline',
           children: [Timeline()],
         ),
         const SectionLayout(
+          id: 'sponsor',
           title: 'Sponsor',
           children: [Sponsors()],
         ),
         const SectionLayout(
+          id: 'staff',
           title: 'Staff',
           children: [Staff()],
         ),


### PR DESCRIPTION
## Issue

Closes #{issue_number}

## 概要

* `<section>`に`id`を付与しました
* 任意の`id`を付与できるよう`SectionLayout`に`id`を追加しました

## 詳細

タイムテーブルが公開されたため `https://2025.flutterkaigi.jp#timeline` のようなアンカー付きのリンクがあると便利だと思います。このため、`<section>`に任意の`id`が付与されるよう、修正しました。現時点では` `や`'s`がないた`String#toLowerCase`でも対応可能ですが、追加された場合にアンカーリンクが不自然になるため、任意の`id`を追加できるよう修正しました。

## 画像・動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

| Before | After | Design |
| ------ | ----- | ------ |
|        |       |        |

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
