### PR TITLE
Replace add_2_calendar with Google Calendar URL for iOS compatibility

### DIFF
--- a/apps/app/lib/features/session/ui/session_screen.dart
+++ b/apps/app/lib/features/session/ui/session_screen.dart
@@ -1,4 +1,3 @@
-import 'package:add_2_calendar/add_2_calendar.dart';
 import 'package:app/core/designsystem/components/error_view.dart';
 import 'package:app/core/gen/i18n/i18n.g.dart';
 import 'package:app/core/util/share_util.dart';
@@ -7,7 +6,6 @@ import 'package:app/features/session/data/provider/session_provider.dart';
 import 'package:app/features/session/ui/components/session_speaker_icon.dart';
 import 'package:app/features/session/ui/components/session_type_chip.dart';
 import 'package:app/features/session/ui/components/session_venue_chip.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -241,30 +239,9 @@ class _SessionDetailView extends ConsumerWidget with SessionScreenMixin {
 
   /// カレンダーにセッションを追加する
   Future<void> _addToCalendar(Session session) async {
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
-      // iOS の場合は add_2_calendar パッケージを使用
-      final event = _createIosEvent(session);
-      await Add2Calendar.addEvent2Cal(event);
-    } else {
-      // その他のプラットフォーム（Android、Web等）ではGoogle Calendar URLを使用
-      final url = _createGoogleCalendarUrl(session);
-      await launchUrl(url, mode: LaunchMode.externalApplication);
-    }
-  }
-
-  /// iOS用のイベントオブジェクトを作成
-  Event _createIosEvent(Session session) {
-    return Event(
-      title: session.title,
-      description: session.description,
-      location: session.venue.name,
-      startDate: session.startsAt,
-      endDate: session.endsAt,
-      timeZone: 'Asia/Tokyo',
-      iosParams: const IOSParams(
-        reminder: Duration(minutes: 10),
-      ),
-    );
+    // すべてのプラットフォームでGoogle Calendar URLを使用
+    final url = _createGoogleCalendarUrl(session);
+    await launchUrl(url, mode: LaunchMode.externalApplication);
   }
 
   /// Google Calendar用のURLを作成

--- a/apps/app/pubspec.yaml
+++ b/apps/app/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 resolution: workspace
 
 dependencies:
-  add_2_calendar: ^3.0.1
   auth_client:
     path: ../../packages/auth_client
   bff_client:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,14 +17,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.1"
-  add_2_calendar:
-    dependency: transitive
-    description:
-      name: add_2_calendar
-      sha256: "8d7a82aba607d35f2a5bc913419e12f865a96a350a8ad2509a59322bc161f200"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.1"
   altive_lints:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue

Closes #474

## 概要

add_2_calendarパッケージの更新が停止しており、Swift Package Managerや最新のXcode、iOSのサポートが不足しているため、iOSでもGoogle Calendar URLを使用するように統一しました。

## 詳細

### 変更内容
- iOSでもGoogle Calendar URLを使用するように修正
- add_2_calendarパッケージの依存関係を削除
- 不要なimportとメソッドを削除

### 変更理由
- add_2_calendarパッケージの更新が停止している
- Swift Package Managerへの対応が不足している
- 最新のXcode、iOSバージョンへのサポートが不足している
- Podfileが作成されてしまう問題を解決

### 効果
- Swift Package Managerの問題を回避
- すべてのプラットフォームで統一された動作
- アプリの軽量化
- iOSビルドの問題を解決

## 画像・動画

<!-- 見た目の変更はありません -->

| Before | After |
| ------ | ----- |
| iOSでadd_2_calendarパッケージを使用 | <video src=https://github.com/user-attachments/assets/01c3c871-94b8-48ec-a62b-09eef4af0b15 /> |

## その他

### 参考
- [device_calendar GitHub issue #592](https://github.com/builttoroam/device_calendar/issues/592) - Swift Package Managerサポートのリクエスト
- [ja2375/add_2_calendar#164](https://github.com/ja2375/add_2_calendar/issues/164) - Swift Package Manager対応の問題
- FlutterのSwift Package Manager対応状況の調査結果

### 注意事項
- すべてのプラットフォームでGoogle Calendar URLを使用するため、ユーザーはGoogleカレンダーアプリまたはブラウザでGoogleカレンダーを開く必要があります
- iOSのネイティブカレンダーアプリへの直接追加はできなくなりますが、Googleカレンダー経由で同期されます