### PR TITLE
feat: セッション詳細画面にルーム名を表示

### DIFF
--- a/apps/app/lib/features/session/ui/session_screen.dart
+++ b/apps/app/lib/features/session/ui/session_screen.dart
@@ -213,6 +213,13 @@ class _SessionDetailView extends ConsumerWidget with SessionScreenMixin {
                 leading: const Icon(Icons.event_outlined),
                 onTap: () => _addToCalendar(session),
               ),
+              ListTile(
+                title: Text(
+                  session.venue,
+                  style: theme.textTheme.bodyLarge,
+                ),
+                leading: const Icon(Icons.room_outlined),
+              ),
               const SizedBox(height: 64),
             ],
           ),


### PR DESCRIPTION
セッション詳細画面にルーム名を表示するようにしました。

## 変更内容
- 時間情報の下にルーム名を表示するListTileを追加
- ルームアイコン（Icons.room_outlined）を使用
- session.venueの値を表示