### PR TITLE
プロフィールのSNS欄でピリオドなどの記号も使用可能にする

### DIFF
--- a/apps/app/lib/features/account/ui/component/sns_link_form.dart
+++ b/apps/app/lib/features/account/ui/component/sns_link_form.dart
@@ -147,7 +147,7 @@ extension _SnsTypeExtension on SnsType {
       SnsType.other when uriOrNull != null => null,
       _ when uriOrNull != null && isValid => t.account.profile.sns.userIdOnly,
       _ =>
-        RegExp(r'^[a-zA-Z0-9_-]+$').hasMatch(value)
+        RegExp(r'^[a-zA-Z0-9_.-]+$').hasMatch(value)
             ? null
             : t.account.profile.sns.alphanumericOnly,
     };


### PR DESCRIPTION
プロフィールのSNS欄のバリデーションを修正し、ピリオド（.）などの記号も使用できるようにしました。

## 変更内容
- SNS欄のユーザーIDバリデーションの正規表現を修正
-  →  に変更し、ピリオドを許可

## 背景
一部のSNSアカウントでピリオドを含むユーザーIDが使用されているため、それらも入力可能にする必要がありました。