### PR TITLE
feat: 管理者用ユーザー一覧画面にRole編集機能を追加

### DIFF
--- a/apps/app/lib/features/admin/data/notifier/admin_user_list_notifier.g.dart
+++ b/apps/app/lib/features/admin/data/notifier/admin_user_list_notifier.g.dart
@@ -55,7 +55,7 @@ final class AdminUserListProvider
   }
 }
 
-String _$adminUserListHash() => r'71eece5d5cd3efa37174aa09fa0f9968fc3baaac';
+String _$adminUserListHash() => r'd18efe532addc96763ba74614702bdb1e5cd243c';
 
 /// ユーザー一覧を管理するNotifier（ページネーション対応）
 

--- a/apps/app/lib/features/admin/ui/components/admin_user_item.dart
+++ b/apps/app/lib/features/admin/ui/components/admin_user_item.dart
@@ -9,11 +9,13 @@ class AdminUserItem extends StatelessWidget {
   const AdminUserItem({
     required this.user,
     required this.onTap,
+    this.onRoleEdit,
     super.key,
   });
 
   final UserAndUserRoles user;
   final VoidCallback onTap;
+  final VoidCallback? onRoleEdit;
 
   @override
   Widget build(BuildContext context) {
@@ -111,24 +113,44 @@ class AdminUserItem extends StatelessWidget {
                         ),
                       ),
                     ),
-                    if (user.roles.isNotEmpty) ...[
-                      const SizedBox(height: 8),
-                      Wrap(
-                        spacing: 4,
-                        runSpacing: 4,
-                        children: user.roles.map((role) {
-                          return Chip(
-                            label: Text(
-                              role.name,
-                              style: textTheme.labelSmall,
-                            ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: user.roles.isNotEmpty
+                              ? Wrap(
+                                  spacing: 4,
+                                  runSpacing: 4,
+                                  children: user.roles.map((role) {
+                                    return Chip(
+                                      label: Text(
+                                        role.name,
+                                        style: textTheme.labelSmall,
+                                      ),
+                                      visualDensity: VisualDensity.compact,
+                                      materialTapTargetSize:
+                                          MaterialTapTargetSize.shrinkWrap,
+                                    );
+                                  }).toList(),
+                                )
+                              : Text(
+                                  'ロールなし',
+                                  style: textTheme.bodySmall?.copyWith(
+                                    color: colorScheme.onSurfaceVariant,
+                                  ),
+                                ),
+                        ),
+                        if (onRoleEdit != null) ...[
+                          const SizedBox(width: 8),
+                          IconButton(
+                            icon: const Icon(Icons.edit),
+                            onPressed: onRoleEdit,
                             visualDensity: VisualDensity.compact,
-                            materialTapTargetSize:
-                                MaterialTapTargetSize.shrinkWrap,
-                          );
-                        }).toList(),
-                      ),
-                    ],
+                            tooltip: 'ロールを編集',
+                          ),
+                        ],
+                      ],
+                    ),
                     const SizedBox(height: 8),
                     Row(
                       children: [

--- a/apps/app/lib/features/admin/ui/components/role_selection_sheet.dart
+++ b/apps/app/lib/features/admin/ui/components/role_selection_sheet.dart
@@ -1,0 +1,113 @@
+import 'package:db_types/db_types.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+/// ロール選択用ボトムシート
+class RoleSelectionSheet extends HookWidget {
+  const RoleSelectionSheet({
+    required this.currentRoles,
+    super.key,
+  });
+
+  final List<Role> currentRoles;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final selectedRoles = useState<Set<Role>>(currentRoles.toSet());
+
+    return Container(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'ロールを選択',
+                  style: theme.textTheme.titleLarge,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Flexible(
+            child: ListView(
+              shrinkWrap: true,
+              children: Role.values.map((role) {
+                final isSelected = selectedRoles.value.contains(role);
+                return CheckboxListTile(
+                  title: Text(_getRoleDisplayName(role)),
+                  subtitle: Text(_getRoleDescription(role)),
+                  value: isSelected,
+                  onChanged: (value) {
+                    if (value == true) {
+                      selectedRoles.value = {...selectedRoles.value, role};
+                    } else {
+                      selectedRoles.value = {...selectedRoles.value}
+                        ..remove(role);
+                    }
+                  },
+                );
+              }).toList(),
+            ),
+          ),
+          const Divider(height: 1),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('キャンセル'),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: FilledButton(
+                    onPressed: () {
+                      Navigator.of(context).pop(selectedRoles.value.toList());
+                    },
+                    child: const Text('保存'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _getRoleDisplayName(Role role) {
+    return switch (role) {
+      Role.admin => '管理者',
+      Role.staff => 'スタッフ',
+      Role.sponsor => 'スポンサー',
+      Role.speaker => 'スピーカー',
+      Role.viewer => '閲覧者',
+      Role.attendee => '参加者',
+    };
+  }
+
+  String _getRoleDescription(Role role) {
+    return switch (role) {
+      Role.admin => 'システム全体の管理権限',
+      Role.staff => 'イベント運営権限',
+      Role.sponsor => 'スポンサー権限',
+      Role.speaker => '登壇者権限',
+      Role.viewer => '閲覧のみ可能',
+      Role.attendee => 'イベント参加者',
+    };
+  }
+}


### PR DESCRIPTION
## 概要
管理者用ユーザー一覧画面から、任意のユーザーのRoleを切り替えられる機能を実装しました。

## 変更内容

### 1. AdminUserListNotifier の拡張
- `updateRolesMutation` を追加（Mutationパターンを使用）
- `updateUserRoles` メソッドを追加して、ユーザーのRoleを更新
- 更新後は自動的にリストを再取得

### 2. Role選択Sheet の作成
- 全てのRoleをチェックボックスで選択可能
- 各Roleに日本語の表示名と説明を追加
- 複数のRoleを同時に選択可能
- キャンセルと保存ボタンを配置

### 3. AdminUserItem の拡張
- Role編集ボタンを追加（編集アイコン付き）
- `onRoleEdit` コールバックを追加
- Roleがない場合は「ロールなし」と表示

### 4. AdminUserListScreen の拡張
- `showRoleSelectionSheet` メソッドを追加
- Sheetを表示してRole選択
- Mutationを使用して非同期でRole更新
- 成功/失敗のSnackBarを表示

## 機能の特徴

- ✅ **管理者権限チェック**: APIレベルで管理者であることを確認（既存実装）
- ✅ **Riverpod Mutation**: 他の実装と同様にMutationパターンを使用
- ✅ **ユーザーフレンドリー**: Sheetで視覚的にRole選択が可能
- ✅ **複数Role対応**: 複数のRoleを同時に設定可能
- ✅ **自動更新**: Role更新後、ユーザーリストが自動的に再取得される
- ✅ **エラーハンドリング**: 失敗時にはエラーメッセージを表示

## 使用方法

1. 管理者としてログイン
2. 管理者用ページのユーザー一覧画面に移動
3. 各ユーザーカードの右側にある編集アイコン（✏️）をタップ
4. ボトムシートが表示され、Roleを選択
5. 「保存」ボタンで変更を適用

## API

既存のAPI `PUT /users/{userId}/roles` を使用しています（管理者権限チェック済み）

## テスト

- [ ] 管理者としてRole編集が可能
- [ ] 非管理者の場合はAPIでエラーが返される
- [ ] 複数のRoleを同時に設定可能
- [ ] Role更新後にリストが自動更新される