### PR TITLE
feat: 管理画面のユーザー詳細からチケット詳細への遷移を追加

### DIFF
--- a/apps/app/lib/features/admin/ui/admin_user_detail_screen.dart
+++ b/apps/app/lib/features/admin/ui/admin_user_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:app/core/designsystem/components/error_screen.dart';
+import 'package:app/core/router/router.dart';
 import 'package:app/features/account/ui/component/account_circle_image.dart';
 import 'package:app/features/admin/data/notifier/admin_user_state_notifier.dart';
 import 'package:bff_client/bff_client.dart' as bff;
@@ -61,13 +62,22 @@ final class AdminUserDetailScreen extends ConsumerWidget {
                 )
               else
                 ...value.tickets.map(
-                  (ticket) => Padding(
-                    padding: const EdgeInsets.only(bottom: 12),
-                    child: _TicketCard(
-                      ticket: ticket,
-                      dateFormat: dateFormat,
-                    ),
-                  ),
+                  (ticket) {
+                    final ticketId = switch (ticket) {
+                      TicketPurchaseItem(:final purchase) => purchase.id,
+                      TicketCheckoutItem(:final checkout) => checkout.id,
+                    };
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 12),
+                      child: _TicketCard(
+                        ticket: ticket,
+                        dateFormat: dateFormat,
+                        onTap: () =>
+                            AdminTicketDetailRoute(ticketId: ticketId)
+                                .go(context),
+                      ),
+                    );
+                  },
                 ),
               const SizedBox(height: 16),
             ],
@@ -260,10 +270,12 @@ final class _TicketCard extends StatelessWidget {
   const _TicketCard({
     required this.ticket,
     required this.dateFormat,
+    required this.onTap,
   });
 
   final TicketItem ticket;
   final DateFormat dateFormat;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -272,7 +284,9 @@ final class _TicketCard extends StatelessWidget {
 
     return Card(
       clipBehavior: Clip.antiAlias,
-      child: Column(
+      child: InkWell(
+        onTap: onTap,
+        child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Container(
@@ -368,6 +382,7 @@ final class _TicketCard extends StatelessWidget {
             ),
           ),
         ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## 概要

管理画面のユーザー詳細画面に表示されているチケット一覧から、各チケットの詳細画面に遷移できるようになりました。

## 変更内容

- ユーザー詳細画面のチケットカードをタップ可能にしました
- タップ時に `AdminTicketDetailRoute` を使用してチケット詳細画面に遷移するようにしました

## 実装の詳細

- `_TicketCard` に `onTap` コールバックを追加
- `Card` 内に `InkWell` を配置してタップ可能にしました
- チケット一覧のマッピング時にタップハンドラを設定し、適切なチケットIDで詳細画面に遷移します

## 確認方法

1. 管理画面にアクセス
2. ユーザー一覧からユーザーを選択
3. ユーザー詳細画面のチケット一覧でチケットカードをタップ
4. チケット詳細画面に遷移することを確認