### PR TITLE
Display nameplate id on ticket sheet

### DIFF
--- a/apps/app/lib/features/admin/ui/components/admin_ticket_scan_sheet.dart
+++ b/apps/app/lib/features/admin/ui/components/admin_ticket_scan_sheet.dart
@@ -37,6 +37,9 @@ class AdminTicketScanSheet extends ConsumerWidget {
     final colorScheme = theme.colorScheme;
 
     final hasEntryLog = ticket.purchase.entryLog != null;
+    final nameplateId = ticket.purchase.nameplateId?.trim();
+    final displayNameplateId =
+        nameplateId == null || nameplateId.isEmpty ? 'N/A' : nameplateId;
 
     return Container(
       padding: const EdgeInsets.all(12),
@@ -102,6 +105,37 @@ class AdminTicketScanSheet extends ConsumerWidget {
                   ),
                 ),
               ],
+            ),
+
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: colorScheme.outline.withValues(alpha: 0.3),
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 4,
+                children: [
+                  Text(
+                    'ネームプレートID',
+                    style: textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: colorScheme.primary,
+                    ),
+                  ),
+                  Text(
+                    displayNameplateId,
+                    style: textTheme.bodyLarge?.copyWith(
+                      fontFamily: 'monospace',
+                      letterSpacing: 1.2,
+                    ),
+                  ),
+                ],
+              ),
             ),
 
             // チケットオプション情報


### PR DESCRIPTION
## Issue

Closes #{issue_number}

## 概要

管理者用チケット読み取り後のシートにネームプレートIDを表示する機能を追加しました。値がない場合は「N/A」と表示されます。

## 詳細

-   `AdminTicketScanSheet` にネームプレートID表示ブロックを追加しました。
-   `ticket.purchase.nameplateId` が `null` または空文字列（トリム後）の場合、「N/A」と表示されます。

## 画像・動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

| Before | After | Design |
| ------ | ----- | ------ |
|        |       |        |

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->

---
<a href="https://cursor.com/background-agent?bcId=bc-3bd56985-150d-492c-bc6a-3fd181a8c087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3bd56985-150d-492c-bc6a-3fd181a8c087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

